### PR TITLE
fix(dfra): concept ownership + property links + RDF dedup + notifications idle

### DIFF
--- a/.cursor/rules/08-testing-and-deployment.mdc
+++ b/.cursor/rules/08-testing-and-deployment.mdc
@@ -19,12 +19,11 @@ scope:
 
 - The user's primary worktree owns ports **8000/3000** — **NEVER restart those** and never bind your own servers to them.
 - When working in a *separate* worktree, start your **own** frontend + backend on **distinct ports** so you don't collide with (or accidentally proxy into) another branch's servers. Worktrees can share the same local `app_ontos` PostgreSQL DB; only the HTTP ports must differ.
-- All ports are env-var driven (no code edits):
-  - `BACKEND_PORT` (default `8000`), `BACKEND_HOST` (default `0.0.0.0`) — via the `dev-backend` hatch script.
+- Frontend port + proxy target are env-var driven; the backend port is passed straight to `uvicorn` (the `dev-backend` hatch script is hard-coded to 8000, so a second worktree runs uvicorn directly):
   - `VITE_PORT` (default `3000`) — Vite dev server.
   - `VITE_PROXY_TARGET` (default `http://localhost:8000`) — must point at *your* backend port.
 - Example second pair (backend 8100 / frontend 3100):
-  - Backend (from `src/`): `BACKEND_PORT=8100 yarn dev:backend`
+  - Backend (from `src/`): `hatch -e dev run uvicorn --app-dir backend src.app:app --reload --host=0.0.0.0 --port=8100`
   - Frontend (from `src/frontend/`): `VITE_PORT=3100 VITE_PROXY_TARGET=http://localhost:8100 yarn dev:frontend`
 - Full contributor-facing docs: `CONTRIBUTING.md` → "Running Multiple Worktrees Side-by-Side".
 

--- a/.cursor/rules/08-testing-and-deployment.mdc
+++ b/.cursor/rules/08-testing-and-deployment.mdc
@@ -15,6 +15,19 @@ scope:
 - Always run Python snippets via `hatch -e dev run ...` to pick up the project's environment.
 - Input validation: Pydantic on the backend, Zod / `react-hook-form` on the frontend.
 
+**Multiple worktrees (parallel LLM sessions)**
+
+- The user's primary worktree owns ports **8000/3000** — **NEVER restart those** and never bind your own servers to them.
+- When working in a *separate* worktree, start your **own** frontend + backend on **distinct ports** so you don't collide with (or accidentally proxy into) another branch's servers. Worktrees can share the same local `app_ontos` PostgreSQL DB; only the HTTP ports must differ.
+- All ports are env-var driven (no code edits):
+  - `BACKEND_PORT` (default `8000`), `BACKEND_HOST` (default `0.0.0.0`) — via the `dev-backend` hatch script.
+  - `VITE_PORT` (default `3000`) — Vite dev server.
+  - `VITE_PROXY_TARGET` (default `http://localhost:8000`) — must point at *your* backend port.
+- Example second pair (backend 8100 / frontend 3100):
+  - Backend (from `src/`): `BACKEND_PORT=8100 yarn dev:backend`
+  - Frontend (from `src/frontend/`): `VITE_PORT=3100 VITE_PROXY_TARGET=http://localhost:8100 yarn dev:frontend`
+- Full contributor-facing docs: `CONTRIBUTING.md` → "Running Multiple Worktrees Side-by-Side".
+
 **Testing**
 
 - Backend: `pytest` (tests under `src/backend/src/tests/` and top-level `e2e/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,6 @@ Project-specific guidance for Claude Code lives in [`.cursor/rules/`](./.cursor/
 
 - **NEVER restart the dev server processes.** Backend and frontend run with auto-reload. See `08-testing-and-deployment.mdc`.
 - Backend logs: `/tmp/backend.log`. Frontend logs: `/tmp/frontend.log`. Read them for debugging.
-- Backend port: **8000**. Frontend port: **3000**. In a *separate* worktree, run your own servers on distinct ports (`BACKEND_PORT`, `VITE_PORT`, `VITE_PROXY_TARGET`) — never rebind 8000/3000. See `08-testing-and-deployment.mdc`.
+- Backend port: **8000**. Frontend port: **3000**. In a *separate* worktree, run your own servers on distinct ports — frontend via `VITE_PORT`/`VITE_PROXY_TARGET`, backend by invoking `uvicorn ... --port=<port>` directly (the `dev-backend` script is hard-coded to 8000) — never rebind 8000/3000. See `08-testing-and-deployment.mdc`.
 - Run Python via `hatch -e dev run ...`.
 - Frontend package manager is **yarn**, not npm.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,6 @@ Project-specific guidance for Claude Code lives in [`.cursor/rules/`](./.cursor/
 
 - **NEVER restart the dev server processes.** Backend and frontend run with auto-reload. See `08-testing-and-deployment.mdc`.
 - Backend logs: `/tmp/backend.log`. Frontend logs: `/tmp/frontend.log`. Read them for debugging.
-- Backend port: **8000**. Frontend port: **3000**.
+- Backend port: **8000**. Frontend port: **3000**. In a *separate* worktree, run your own servers on distinct ports (`BACKEND_PORT`, `VITE_PORT`, `VITE_PROXY_TARGET`) — never rebind 8000/3000. See `08-testing-and-deployment.mdc`.
 - Run Python via `hatch -e dev run ...`.
 - Frontend package manager is **yarn**, not npm.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,12 +160,11 @@ either fail to start or, worse, serve one branch's frontend against the other
 branch's backend. The default `3000`/`8000` are fine for a single worktree;
 give every additional worktree its own pair.
 
-All three ports are env-var driven, so no code edits are needed:
+The frontend port and proxy target are env-var driven; the backend port is
+passed directly to `uvicorn`:
 
 | Variable | Default | Controls |
 |----------|---------|----------|
-| `BACKEND_PORT` | `8000` | uvicorn backend port (via the `dev-backend` hatch script) |
-| `BACKEND_HOST` | `0.0.0.0` | uvicorn backend host |
 | `VITE_PORT` | `3000` | Vite dev-server port |
 | `VITE_PROXY_TARGET` | `http://localhost:8000` | backend the Vite dev server proxies `/api`, `/docs`, `/redoc` to |
 
@@ -173,11 +172,11 @@ Point the frontend at its own backend with `VITE_PROXY_TARGET` so the proxy
 targets the matching port. Example — a second worktree on backend `8100` /
 frontend `3100`:
 
-**Backend** (from `src/`):
+**Backend** (from `src/`): invoke `uvicorn` directly with the port you want.
+The `yarn dev:backend` / `hatch -e dev run dev-backend` shortcut is hard-coded to
+`8000`, so a secondary worktree runs the underlying command instead:
 ```bash
-BACKEND_PORT=8100 yarn dev:backend
-# or, without the yarn wrapper:
-BACKEND_PORT=8100 hatch -e dev run dev-backend
+hatch -e dev run uvicorn --app-dir backend src.app:app --reload --host=0.0.0.0 --port=8100
 ```
 
 **Frontend** (from `src/frontend/`):
@@ -186,9 +185,7 @@ VITE_PORT=3100 VITE_PROXY_TARGET=http://localhost:8100 yarn dev:frontend
 ```
 
 Both worktrees can share the same local `app_ontos` PostgreSQL database; only
-the HTTP ports need to differ. Persist the values in each worktree's
-`.env` files (`src/backend/.env`, `src/frontend/.env`) to avoid repeating them
-on every launch.
+the HTTP ports need to differ.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,45 @@ yarn dev:backend
 - Backend API: http://localhost:8000
 - API Docs (Swagger): http://localhost:8000/docs
 
+### Running Multiple Worktrees Side-by-Side
+
+If you develop in more than one git worktree at once (e.g. one per feature
+branch), **each worktree must run its own frontend and backend on distinct
+ports** — otherwise a second worktree's servers bind to the same 3000/8000 and
+either fail to start or, worse, serve one branch's frontend against the other
+branch's backend. The default `3000`/`8000` are fine for a single worktree;
+give every additional worktree its own pair.
+
+All three ports are env-var driven, so no code edits are needed:
+
+| Variable | Default | Controls |
+|----------|---------|----------|
+| `BACKEND_PORT` | `8000` | uvicorn backend port (via the `dev-backend` hatch script) |
+| `BACKEND_HOST` | `0.0.0.0` | uvicorn backend host |
+| `VITE_PORT` | `3000` | Vite dev-server port |
+| `VITE_PROXY_TARGET` | `http://localhost:8000` | backend the Vite dev server proxies `/api`, `/docs`, `/redoc` to |
+
+Point the frontend at its own backend with `VITE_PROXY_TARGET` so the proxy
+targets the matching port. Example — a second worktree on backend `8100` /
+frontend `3100`:
+
+**Backend** (from `src/`):
+```bash
+BACKEND_PORT=8100 yarn dev:backend
+# or, without the yarn wrapper:
+BACKEND_PORT=8100 hatch -e dev run dev-backend
+```
+
+**Frontend** (from `src/frontend/`):
+```bash
+VITE_PORT=3100 VITE_PROXY_TARGET=http://localhost:8100 yarn dev:frontend
+```
+
+Both worktrees can share the same local `app_ontos` PostgreSQL database; only
+the HTTP ports need to differ. Persist the values in each worktree's
+`.env` files (`src/backend/.env`, `src/frontend/.env`) to avoid repeating them
+on every launch.
+
 ---
 
 ## Commit Guidelines

--- a/src/backend/src/controller/jobs_manager.py
+++ b/src/backend/src/controller/jobs_manager.py
@@ -36,6 +36,12 @@ class JobsManager:
         self._running_jobs: Dict[int, str] = {}  # run_id -> notification_id
         self._polling_thread: Optional[threading.Thread] = None
         self._stop_polling = threading.Event()
+        # Tracks whether any workflows are installed, so the polling thread can
+        # skip its per-cycle DB query when there are none. None = unknown (do a
+        # DB check on the next cycle); False = confirmed zero (skip the DB so a
+        # workflow-free deployment lets Lakebase idle down); True = at least one.
+        # Authoritative because JobsManager is a single app-state singleton.
+        self._has_installations: Optional[bool] = None
 
     def list_available_workflows(self) -> List[Dict[str, str]]:
         root = self._workflows_root
@@ -205,6 +211,9 @@ class JobsManager:
             workflow_installation_repo.create(self._db, obj_in=installation)
             self._db.commit()
             logger.info(f"Persisted installation record for workflow '{workflow_id}' with job_id {job_id}")
+            # Wake the polling thread: it may have parked itself after confirming
+            # zero installations. None forces a DB re-check on the next cycle.
+            self._has_installations = None
         except Exception as e:
             logger.error(f"Failed to persist installation record for workflow '{workflow_id}': {e}")
             self._db.rollback()
@@ -1007,11 +1016,25 @@ class JobsManager:
         logger.info("Job state polling thread started")
 
         while not self._stop_polling.is_set():
+            # Skip the whole cycle — including opening a DB session — when we
+            # have confirmed there are zero installed workflows. Touching the DB
+            # every interval otherwise keeps Lakebase compute permanently warm on
+            # deployments that don't use the jobs feature (the reported
+            # "compute always active" symptom). install_workflow() resets this
+            # flag to None so a freshly installed workflow is picked up next cycle.
+            if self._has_installations is False:
+                if not self._stop_polling.is_set():
+                    self._stop_polling.wait(timeout=interval_seconds)
+                continue
+
             # Create a new database session for this polling iteration
             db = next(get_db())
             try:
                 # Get all installed workflows from database
                 installations = workflow_installation_repo.get_all_installed(db)
+                # Cache the presence signal so future cycles can skip the DB
+                # entirely when there is nothing to poll.
+                self._has_installations = len(installations) > 0
                 logger.info(f"Polling {len(installations)} installed workflows...")
 
                 for installation in installations:

--- a/src/backend/src/controller/jobs_manager.py
+++ b/src/backend/src/controller/jobs_manager.py
@@ -1015,6 +1015,17 @@ class JobsManager:
 
         logger.info("Job state polling thread started")
 
+        # Adaptive backoff: when a cycle sees no active (non-terminal) runs, the
+        # only thing changing is nothing, so progressively stretch the wait up to
+        # a cap. A cycle that observes an active run (or a state change) snaps the
+        # interval back to the configured base so live jobs are tracked promptly.
+        # This lets an app with only idle/quiet workflows drift toward the cap,
+        # reducing how often Lakebase is touched, without losing timely tracking
+        # once something actually runs.
+        base_interval = interval_seconds
+        max_interval = max(base_interval * 4, base_interval)
+        current_interval = base_interval
+
         while not self._stop_polling.is_set():
             # Skip the whole cycle — including opening a DB session — when we
             # have confirmed there are zero installed workflows. Touching the DB
@@ -1023,9 +1034,16 @@ class JobsManager:
             # "compute always active" symptom). install_workflow() resets this
             # flag to None so a freshly installed workflow is picked up next cycle.
             if self._has_installations is False:
+                # No workflows installed at all: back off to the cap and skip the
+                # DB entirely (see flag docs in __init__).
+                current_interval = max_interval
                 if not self._stop_polling.is_set():
-                    self._stop_polling.wait(timeout=interval_seconds)
+                    self._stop_polling.wait(timeout=current_interval)
                 continue
+
+            # Tracks whether this cycle observed anything worth polling promptly
+            # for: an active (non-terminal) run, or a persisted state change.
+            saw_activity = False
 
             # Create a new database session for this polling iteration
             db = next(get_db())
@@ -1056,11 +1074,27 @@ class JobsManager:
                             # Skip further processing for this installation in this cycle
                             continue
 
-                        # Calculate time range for backfill (default: last 7 days)
+                        # Time window for the runs query. The backfill_days cap
+                        # bounds a cold start (or post-downtime catch-up) to the
+                        # last N days. On steady-state cycles, though, only look
+                        # back to just before the last successful poll — with a
+                        # small overlap to avoid missing a run that started right
+                        # at the boundary. This keeps each cycle fetching a
+                        # handful of recent runs instead of re-scanning the whole
+                        # N-day history (a 10-min job otherwise returns ~1000 runs
+                        # every cycle), and combined with the change-gated upserts
+                        # a quiet cycle results in zero Lakebase writes.
                         backfill_days = self._settings.JOB_POLLING_BACKFILL_DAYS if self._settings else 7
-                        start_time_from = int((datetime.utcnow() - timedelta(days=backfill_days)).timestamp() * 1000)
+                        backfill_floor_ms = int((datetime.utcnow() - timedelta(days=backfill_days)).timestamp() * 1000)
+                        start_time_from = backfill_floor_ms
+                        if installation.last_polled_at:
+                            # 2x the poll interval of overlap comfortably covers
+                            # clock skew and runs straddling the boundary.
+                            overlap = timedelta(seconds=max(interval_seconds * 2, 60))
+                            incremental_ms = int((installation.last_polled_at - overlap).timestamp() * 1000)
+                            # Never look back further than the backfill cap.
+                            start_time_from = max(backfill_floor_ms, incremental_ms)
 
-                        # Get runs from last N days (time range naturally limits results)
                         # This enables backfilling missed runs after app restart/downtime
                         runs = self._client.jobs.list_runs(
                             job_id=installation.job_id,
@@ -1083,6 +1117,12 @@ class JobsManager:
                                 'start_time': run.start_time,
                                 'end_time': run.end_time
                             }
+
+                            # A run that has not reached TERMINATED is still in
+                            # flight — keep polling at the base cadence so we
+                            # track it to completion.
+                            if run.state.life_cycle_state != RunLifeCycleState.TERMINATED:
+                                saw_activity = True
 
                             # Upsert job run record (creates or updates)
                             job_run = workflow_job_run_repo.upsert_run(
@@ -1148,7 +1188,8 @@ class JobsManager:
                             workflow_installation_repo.update_last_polled(
                                 db,
                                 workflow_id=installation.workflow_id,
-                                job_state=latest_run_data
+                                job_state=latest_run_data,
+                                only_if_changed=True,
                             )
 
                     except Exception as e:
@@ -1167,9 +1208,17 @@ class JobsManager:
                 # Always close the session
                 db.close()
 
+            # Adaptive interval: reset to base when there's live activity to
+            # track, otherwise ease off toward the cap so a quiet system stops
+            # waking every base_interval.
+            if saw_activity:
+                current_interval = base_interval
+            else:
+                current_interval = min(max_interval, current_interval * 2)
+
             # Wait for next interval or stop signal (unless stopping)
             if not self._stop_polling.is_set():
-                self._stop_polling.wait(timeout=interval_seconds)
+                self._stop_polling.wait(timeout=current_interval)
 
         logger.info("Job state polling thread stopped")
 

--- a/src/backend/src/controller/semantic_links_manager.py
+++ b/src/backend/src/controller/semantic_links_manager.py
@@ -118,9 +118,21 @@ class SemanticLinksManager:
         items = entity_semantic_links_repo.list_for_entity(self._db, entity_id, entity_type)
         return [self._to_api(it) for it in items]
 
+    def list_for_entity_prefix(self, entity_id_prefix: str, entity_type: str) -> List[EntitySemanticLink]:
+        items = entity_semantic_links_repo.list_for_entity_prefix(self._db, entity_id_prefix, entity_type)
+        return [self._to_api(it) for it in items]
+
     def list_for_iri(self, iri: str) -> List[EntitySemanticLink]:
-        """Get all entities linked to an IRI, including both explicit links and inferred type relationships."""
-        # Get explicit links from database
+        """Get all entities linked to an IRI, including both explicit links and inferred type relationships.
+
+        Explicit (stored) links and inferred (rdf:type in the graph) links can
+        describe the same (entity_type, entity_id) pair — an assignment is
+        persisted in entity_semantic_links AND surfaces again as a graph
+        relationship. Deduplicate on (entity_type, entity_id) so a single
+        assignment is never shown twice, preferring the explicit stored link
+        (it carries a real id/label) over the synthetic inferred one.
+        """
+        # Explicit links from the database come first so they win on dedup.
         items = entity_semantic_links_repo.list_for_iri(self._db, iri)
         results = [self._to_api(it) for it in items]
 
@@ -129,7 +141,16 @@ class SemanticLinksManager:
             inferred = self._get_inferred_links_from_graph(iri)
             results.extend(inferred)
 
-        return results
+        deduped: List[EntitySemanticLink] = []
+        seen: set = set()
+        for link in results:
+            key = (link.entity_type, link.entity_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            deduped.append(link)
+
+        return deduped
 
     def _get_inferred_links_from_graph(self, iri: str) -> List[EntitySemanticLink]:
         """Query RDF graph for entities that have rdf:type matching the given IRI."""

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -1236,6 +1236,39 @@ class SemanticModelsManager(SearchableAsset):
                     shutil.rmtree(temp_dir)
                 raise
 
+    def _ensure_caches_warm(self) -> bool:
+        """Repopulate both cache tiers from the current graph if they are cold.
+
+        Read paths call this on a cache miss so a single request re-warms the
+        caches for every subsequent read, instead of each request recomputing
+        SPARQL over the whole graph forever (the post-invalidation slow path).
+
+        Safe against staleness: it recomputes from ``self._graph``, which every
+        mutation path keeps fresh (full rebuild, or incremental graph edit +
+        invalidate). A warmed cache is therefore never staler than the graph.
+
+        Returns True if the in-memory caches are populated on return.
+        """
+        if (
+            self._cached_concepts is not None
+            and self._cached_taxonomies is not None
+            and self._cached_stats is not None
+        ):
+            return True
+        try:
+            # Reuse the atomic writer: it computes concepts/taxonomies/stats
+            # from the current graph, writes the JSON files under the rebuild
+            # lock, and sets self._cached_* — exactly what a warm-up needs.
+            self._build_persistent_caches_atomic()
+            return (
+                self._cached_concepts is not None
+                and self._cached_taxonomies is not None
+                and self._cached_stats is not None
+            )
+        except Exception as e:
+            logger.warning(f"Failed to warm semantic caches on read miss: {e}")
+            return False
+
     def _compute_taxonomies(self) -> List:
         """Compute taxonomies without caching - used for building persistent cache"""
         from src.models.ontology import SemanticModel as SemanticModelOntology
@@ -1389,9 +1422,14 @@ class SemanticModelsManager(SearchableAsset):
     # Call after create/update/delete/enable/disable
     def on_models_changed(self) -> None:
         try:
+            # rebuild_graph_from_enabled() already clears every cache tier and
+            # then rebuilds both the in-memory snapshots and the persistent JSON
+            # files from the fresh graph. Calling _invalidate_cache() afterwards
+            # would delete those just-built files and null the snapshots again,
+            # forcing every subsequent read to recompute SPARQL over the whole
+            # graph — the root cause of the post-mutation slowdown. So do NOT
+            # invalidate here; the rebuild is the authoritative refresh.
             self.rebuild_graph_from_enabled()
-            # Invalidate cache when models change
-            self._invalidate_cache()
         except Exception as e:
             logger.error(f"Failed to rebuild RDF graph: {e}")
 
@@ -2009,15 +2047,26 @@ class SemanticModelsManager(SearchableAsset):
         if self._cached_taxonomies is not None:
             return self._cached_taxonomies
 
-        # Cold start: fall back to persistent file cache
+        # Cold start: fall back to persistent file cache. Populate the in-memory
+        # snapshot too so we don't re-read + re-parse the file on every request.
+        # (File presence implies no mutation since the last rebuild — invalidation
+        # deletes these files — so loading it into memory is not a staleness risk.)
         cache_file = self._data_dir / "cache" / "taxonomies.json"
         if cache_file.exists():
             try:
                 with open(cache_file, "r") as f:
                     data = json.load(f)
-                    return [SemanticModelOntology(**item) for item in data]
+                    taxonomies = [SemanticModelOntology(**item) for item in data]
+                    self._cached_taxonomies = taxonomies
+                    return taxonomies
             except Exception as e:
                 logger.warning(f"Failed to load taxonomies from persistent cache: {e}")
+
+        # Cold cache: warm both tiers once so subsequent reads hit the cache
+        # instead of recomputing per request. Falls back to a direct compute if
+        # warming fails for any reason.
+        if self._ensure_caches_warm() and self._cached_taxonomies is not None:
+            return self._cached_taxonomies
 
         logger.warning("Persistent cache not found for taxonomies, computing live")
         taxonomies = self._compute_taxonomies()
@@ -2559,9 +2608,15 @@ class SemanticModelsManager(SearchableAsset):
             try:
                 with open(cache_file, "r") as f:
                     data = json.load(f)
-                    return TaxonomyStats(**data)
+                    stats = TaxonomyStats(**data)
+                    self._cached_stats = stats
+                    return stats
             except Exception as e:
                 logger.warning(f"Failed to load stats from persistent cache: {e}")
+
+        # Cold cache: warm both tiers once so subsequent reads hit the cache.
+        if self._ensure_caches_warm() and self._cached_stats is not None:
+            return self._cached_stats
 
         logger.warning("Persistent cache not found for stats, computing live")
         taxonomies = self.get_taxonomies()
@@ -2586,9 +2641,13 @@ class SemanticModelsManager(SearchableAsset):
                     with open(cache_file, "r") as f:
                         data = json.load(f)
                         concepts = [OntologyConcept(**item) for item in data]
+                        self._cached_concepts = concepts
                 except Exception as e:
                     logger.warning(f"Failed to load concepts from persistent cache: {e}")
                     concepts = self.get_concepts_by_taxonomy()
+            elif self._ensure_caches_warm() and self._cached_concepts is not None:
+                # Cold cache: warm both tiers once so subsequent reads hit it.
+                concepts = self._cached_concepts
             else:
                 logger.warning("Persistent cache not found for concepts, computing live")
                 concepts = self.get_concepts_by_taxonomy()

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -527,9 +527,17 @@ class SemanticModelsManager(SearchableAsset):
     
     def _skolemize_bnode(self, bnode: BNode, context_name: str) -> str:
         """Convert a blank node to a stable URI for persistence.
-        
+
         Blank nodes are graph-local identifiers. To persist them, we convert
         them to URIs that include the context name for global uniqueness.
+
+        IMPORTANT: ``str(bnode)`` is only stable if the bnode came from a graph
+        that has been canonicalised (see ``_import_graph_to_db``). rdflib mints
+        a fresh random id for every ``.parse()``, so without canonicalisation
+        the same blank node yields a different URI on each import — the
+        ``uq_rdf_triple`` constraint never matches and re-imports duplicate the
+        triples without bound. Canonical bnode ids are content-derived and
+        therefore reproducible across parses and process restarts.
         """
         return f"urn:ontos:bnode:{context_name}:{str(bnode)}"
 
@@ -616,8 +624,27 @@ class SemanticModelsManager(SearchableAsset):
         Returns:
             Number of triples actually inserted (excludes duplicates)
         """
+        # Canonicalise blank-node identifiers before persisting. rdflib assigns
+        # random bnode ids on each parse, so without this the skolemised URIs
+        # differ every import and the ON CONFLICT DO NOTHING dedup never fires —
+        # re-imports of any ontology with blank nodes (OWL restrictions, SHACL
+        # shapes, rdf:Lists) grow the table without bound. Canonicalisation
+        # (RGDA1) derives stable, content-based bnode ids, so identical content
+        # produces identical rows and re-imports become true no-ops.
+        # Only pay the O(n log n) cost when blank nodes are actually present.
+        if any(isinstance(t, BNode) for triple in graph for t in (triple[0], triple[2])):
+            try:
+                from rdflib.compare import to_canonical_graph
+                graph = to_canonical_graph(graph)
+            except Exception as e:
+                logger.warning(
+                    "Blank-node canonicalisation failed for %s:%s (%s); "
+                    "falling back to raw import — re-imports may duplicate.",
+                    source_type, source_identifier, e,
+                )
+
         triples_to_insert = []
-        
+
         for subj, pred, obj in graph:
             # Handle subject (can be URI or blank node)
             if isinstance(subj, BNode):
@@ -766,7 +793,14 @@ class SemanticModelsManager(SearchableAsset):
             loaded += 1
 
         logger.info(f"Loaded {loaded} triples into graph (skipped {skipped} from disabled models)")
-        
+
+        # A rebuild against a bloated table is a prime moment to snapshot where
+        # the rows come from (throttled + threshold-gated; no-op when healthy).
+        try:
+            rdf_triples_repo.maybe_log_bloat_diagnostics(self._db, trigger="rebuild")
+        except Exception as e:
+            logger.debug(f"Bloat diagnostic skipped: {e}")
+
         # Log stats by context
         contexts = rdf_triples_repo.list_contexts(self._db)
         for ctx in contexts:
@@ -856,9 +890,19 @@ class SemanticModelsManager(SearchableAsset):
         # Scan all contexts and register missing ones
         for context in self._graph.contexts():
             context_name = str(context.identifier)
-            
-            # Skip system contexts
-            if context_name in ("urn:x-rdflib:default", META_CONTEXT, ""):
+
+            # Skip system contexts. This includes the dynamic, recomputed-every-
+            # rebuild contexts (app entities, semantic links) — they are derived
+            # views, not user collections, and must not be registered as
+            # KnowledgeCollections (doing so pollutes the Collections list and
+            # writes spurious timestamped metadata each time they first appear).
+            if context_name in (
+                "urn:x-rdflib:default",
+                META_CONTEXT,
+                "urn:app-entities",
+                "urn:semantic-links",
+                "",
+            ):
                 continue
             
             # Skip if already registered

--- a/src/backend/src/repositories/rdf_triples_repository.py
+++ b/src/backend/src/repositories/rdf_triples_repository.py
@@ -3,10 +3,12 @@
 Provides CRUD operations for RDF triples with support for bulk inserts
 and context-based queries.
 """
+import os
+import time
 from typing import List, Optional, Dict, Any
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy import and_
+from sqlalchemy import and_, text
 import uuid
 
 from src.common.repository import CRUDBase
@@ -14,6 +16,20 @@ from src.db_models.rdf_triples import RdfTripleDb
 from src.common.logging import get_logger
 
 logger = get_logger(__name__)
+
+# --- Bloat diagnostics ------------------------------------------------------
+# The rdf_triples table has been observed growing to tens of thousands of rows
+# on some instances while the UI only surfaces a few hundred concepts, and we
+# have not been able to reproduce it locally. When the table crosses a
+# threshold we emit a one-shot forensic snapshot (breakdown by source/context,
+# blank-node share, constraint-bypass detection, and per-(subject,predicate)
+# churn) so we can see WHERE the rows come from and WHAT their nature is on the
+# affected instance. Tune/disable via env:
+#   RDF_TRIPLES_DIAGNOSTIC_THRESHOLD  row count that arms diagnostics (0=off, default 30000)
+#   RDF_TRIPLES_DIAGNOSTIC_INTERVAL_S minimum seconds between snapshots (default 300)
+_DIAG_THRESHOLD = int(os.getenv("RDF_TRIPLES_DIAGNOSTIC_THRESHOLD", "30000"))
+_DIAG_INTERVAL_S = int(os.getenv("RDF_TRIPLES_DIAGNOSTIC_INTERVAL_S", "300"))
+_diag_last_run_monotonic: float = 0.0
 
 
 class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
@@ -125,6 +141,12 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
                         f"inserted {result.rowcount}/{len(batch)} triples")
         
         logger.info(f"Bulk insert complete: {total_inserted}/{len(triples)} triples inserted")
+
+        # Only worth checking when this call actually added rows (a re-import
+        # that inserts 0 can't have grown the table).
+        if total_inserted > 0:
+            self.maybe_log_bloat_diagnostics(db, trigger="bulk_insert")
+
         return total_inserted
 
     def remove_triple(
@@ -251,6 +273,102 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
         return db.query(RdfTripleDb).filter(
             RdfTripleDb.context_name == context_name
         ).first() is not None
+
+    def maybe_log_bloat_diagnostics(self, db: Session, *, trigger: str) -> None:
+        """Emit a forensic snapshot of rdf_triples when the table looks bloated.
+
+        No-op unless the table exceeds RDF_TRIPLES_DIAGNOSTIC_THRESHOLD rows,
+        and then at most once per RDF_TRIPLES_DIAGNOSTIC_INTERVAL_S. The count
+        check is a cheap indexed COUNT(*); the heavier breakdown queries only
+        run once the threshold is crossed, so healthy instances pay ~nothing.
+
+        Captures the signals we need to explain the "64k triples / few hundred
+        concepts" reports without a local repro:
+          - total rows and how many are blank-node (skolemised) triples
+          - breakdown by source_type and by top contexts
+          - constraint-bypass check: rows minus distinct 6-tuples (if > 0 the
+            uq_rdf_triple unique index is not deduplicating — the classic
+            NULL-in-unique-index / missing-constraint cause)
+          - top churning (subject, predicate) groups — a single subject with
+            hundreds of rows points at a re-write path that appends instead of
+            replacing (e.g. per-save timestamps).
+
+        `trigger` labels what invoked the check (e.g. "bulk_insert", "rebuild").
+        """
+        if _DIAG_THRESHOLD <= 0:
+            return
+
+        global _diag_last_run_monotonic
+        now = time.monotonic()
+        # Throttle first so a hot insert loop past the threshold logs once, not
+        # on every batch. (First call: _diag_last_run_monotonic == 0.)
+        if _diag_last_run_monotonic and (now - _diag_last_run_monotonic) < _DIAG_INTERVAL_S:
+            return
+
+        try:
+            total = db.query(RdfTripleDb).count()
+        except Exception as e:
+            logger.debug(f"rdf_triples bloat check: count failed: {e}")
+            return
+
+        if total < _DIAG_THRESHOLD:
+            return
+
+        # Threshold crossed — mark the run now (even if a sub-query fails, we
+        # don't want to hammer these heavier queries) and collect the snapshot.
+        _diag_last_run_monotonic = now
+        logger.warning(
+            "rdf_triples BLOAT DIAGNOSTIC (trigger=%s): total=%d rows exceeds "
+            "threshold=%d — collecting forensic snapshot",
+            trigger, total, _DIAG_THRESHOLD,
+        )
+
+        def _run(label: str, sql: str, params: Optional[dict] = None):
+            try:
+                rows = db.execute(text(sql), params or {}).fetchall()
+                logger.warning("  [rdf_triples/%s] %s", label, [tuple(r) for r in rows])
+            except Exception as e:
+                logger.warning("  [rdf_triples/%s] query failed: %s", label, e)
+
+        # Blank-node share (skolemised subjects or object references).
+        _run(
+            "blank_nodes",
+            "SELECT count(*) FROM rdf_triples "
+            "WHERE subject_uri LIKE 'urn:ontos:bnode:%' "
+            "OR (object_is_uri AND object_value LIKE 'urn:ontos:bnode:%')",
+        )
+        # Rows vs distinct logical triples — a positive gap means the unique
+        # constraint is NOT collapsing exact duplicates (NULL cols / no index).
+        # Count distinct groups via a subquery (GROUP BY) rather than
+        # count(DISTINCT (row-value)), which Postgres supports but SQLite (used
+        # in tests) rejects with "row value misused".
+        _run(
+            "constraint_bypass",
+            "SELECT (SELECT count(*) FROM rdf_triples) - (SELECT count(*) FROM ("
+            "SELECT 1 FROM rdf_triples GROUP BY subject_uri, predicate_uri, object_value, "
+            "object_language, object_datatype, context_name) g) AS non_dedup_rows",
+        )
+        # Where the rows live.
+        _run(
+            "by_source_type",
+            "SELECT source_type, count(*) FROM rdf_triples GROUP BY source_type ORDER BY 2 DESC",
+        )
+        _run(
+            "top_contexts",
+            "SELECT context_name, count(*) FROM rdf_triples GROUP BY context_name ORDER BY 2 DESC LIMIT 15",
+        )
+        # Churn: subjects+predicates re-written far more than a healthy graph
+        # would (a well-behaved predicate is usually 1 row per subject).
+        _run(
+            "top_churn_subject_predicate",
+            "SELECT subject_uri, predicate_uri, count(*) AS n FROM rdf_triples "
+            "GROUP BY subject_uri, predicate_uri HAVING count(*) > 5 ORDER BY n DESC LIMIT 15",
+        )
+        # Most-repeated predicates overall (cheap orientation on nature of bloat).
+        _run(
+            "by_predicate",
+            "SELECT predicate_uri, count(*) FROM rdf_triples GROUP BY predicate_uri ORDER BY 2 DESC LIMIT 10",
+        )
 
 
 # Singleton instance

--- a/src/backend/src/repositories/semantic_links_repository.py
+++ b/src/backend/src/repositories/semantic_links_repository.py
@@ -16,6 +16,25 @@ class EntitySemanticLinksRepository(CRUDBase[EntitySemanticLinkDb, EntitySemanti
     def list_for_iri(self, db: Session, iri: str) -> List[EntitySemanticLinkDb]:
         return db.query(self.model).filter(self.model.iri == iri).all()
 
+    def list_for_entity_prefix(
+        self, db: Session, entity_id_prefix: str, entity_type: str
+    ) -> List[EntitySemanticLinkDb]:
+        """List links whose entity_id starts with the given prefix.
+
+        Used to fetch all property-level links for a contract schema in one
+        query (entity_id shape: ``{contract_id}#{schema}#{property}``), so the
+        UI can render column-level concept assignments without an API call per
+        property. The ``%``/``_`` LIKE wildcards are escaped so contract ids
+        and schema names containing them match literally.
+        """
+        escaped = (
+            entity_id_prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        return db.query(self.model).filter(
+            self.model.entity_type == entity_type,
+            self.model.entity_id.like(f"{escaped}%", escape="\\"),
+        ).all()
+
     def get_by_entity_and_iri(self, db: Session, entity_id: str, entity_type: str, iri: str) -> EntitySemanticLinkDb | None:
         return db.query(self.model).filter(
             self.model.entity_id == entity_id,

--- a/src/backend/src/repositories/workflow_installations_repository.py
+++ b/src/backend/src/repositories/workflow_installations_repository.py
@@ -60,17 +60,38 @@ class WorkflowInstallationRepository(CRUDBase[WorkflowInstallationDb, WorkflowIn
         """Retrieves all workflow installations."""
         return self.get_multi(db=db)
 
-    def update_last_polled(self, db: Session, *, workflow_id: str, job_state: Optional[Dict[str, Any]] = None) -> Optional[WorkflowInstallationDb]:
-        """Updates last_polled_at and optionally last_job_state."""
+    def update_last_polled(
+        self,
+        db: Session,
+        *,
+        workflow_id: str,
+        job_state: Optional[Dict[str, Any]] = None,
+        only_if_changed: bool = False,
+    ) -> Optional[WorkflowInstallationDb]:
+        """Updates last_polled_at and optionally last_job_state.
+
+        When ``only_if_changed`` is True, the write is skipped entirely if the
+        serialized ``job_state`` matches what is already stored. The background
+        poll uses this so a quiet cycle (no run-state transition) performs zero
+        Lakebase writes, letting the instance idle. ``last_polled_at`` is
+        intentionally NOT bumped on a no-op — its only consumers are the
+        incremental-window poll and human diagnostics, neither of which needs a
+        heartbeat when nothing changed.
+        """
         db_obj = self.get_by_workflow_id(db, workflow_id=workflow_id)
         if not db_obj:
             return None
 
+        serialized_state = json.dumps(job_state) if job_state else None
+        if only_if_changed and serialized_state is not None:
+            if db_obj.last_job_state == serialized_state:
+                return db_obj
+
         update_data = {
             'last_polled_at': datetime.utcnow()
         }
-        if job_state:
-            update_data['last_job_state'] = json.dumps(job_state)
+        if serialized_state is not None:
+            update_data['last_job_state'] = serialized_state
 
         return self.update(db, db_obj=db_obj, obj_in=update_data)
 

--- a/src/backend/src/repositories/workflow_job_runs_repository.py
+++ b/src/backend/src/repositories/workflow_job_runs_repository.py
@@ -105,14 +105,33 @@ class WorkflowJobRunRepository(CRUDBase[WorkflowJobRunDb, WorkflowJobRunCreate, 
             duration_ms = run_data['end_time'] - run_data['start_time']
 
         if existing:
+            # Skip the write entirely when nothing changed. The background poll
+            # re-fetches the last N days of runs every cycle, so the vast
+            # majority of upserts are for already-terminal runs whose state is
+            # identical to what we stored — committing those on every cycle kept
+            # Lakebase permanently busy (a job scheduled every 10 min = ~1000
+            # historical runs re-committed every 5 min). Only write on a real
+            # state transition.
+            new_values = {
+                'life_cycle_state': run_data.get('life_cycle_state'),
+                'result_state': run_data.get('result_state'),
+                'state_message': run_data.get('state_message'),
+                'start_time': run_data.get('start_time'),
+                'end_time': run_data.get('end_time'),
+                'duration_ms': duration_ms,
+                'run_name': run_data.get('run_name'),
+            }
+            unchanged = all(
+                getattr(existing, field) == value
+                for field, value in new_values.items()
+            )
+            if unchanged:
+                logger.debug(f"Job run {run_id} unchanged; skipping write")
+                return existing
+
             # Update existing record
-            existing.life_cycle_state = run_data.get('life_cycle_state')
-            existing.result_state = run_data.get('result_state')
-            existing.state_message = run_data.get('state_message')
-            existing.start_time = run_data.get('start_time')
-            existing.end_time = run_data.get('end_time')
-            existing.duration_ms = duration_ms
-            existing.run_name = run_data.get('run_name')
+            for field, value in new_values.items():
+                setattr(existing, field, value)
             db.commit()
             db.refresh(existing)
             logger.info(f"Updated job run {run_id}: {existing.life_cycle_state} / {existing.result_state}")

--- a/src/backend/src/routes/business_owners_routes.py
+++ b/src/backend/src/routes/business_owners_routes.py
@@ -104,17 +104,22 @@ def get_all_owners(
 
 
 @router.get(
-    "/by-object/{object_type}/{object_id}",
+    "/by-object/{object_type}",
     response_model=List[BusinessOwnerRead],
 )
 def get_owners_for_object(
     object_type: str,
-    object_id: str,
     db: DBSessionDep,
+    object_id: str = Query(..., min_length=1, description="Object id (may be an IRI)"),
     manager=Depends(get_business_owners_manager),
     active_only: bool = Query(True),
 ):
     """Gets all owners for a specific object.
+
+    ``object_id`` is a query parameter (not a path segment) because it may be a
+    concept IRI like ``http://…#Term``. The Databricks Apps proxy collapses
+    ``%2F%2F`` → ``/`` inside path segments, which mangles such IRIs before they
+    reach FastAPI (see PR #536); query-string values survive that intact.
 
     Authenticated-only (no feature-permission gate). Rationale: a user who
     can already view an entity (e.g. a data product in the marketplace)
@@ -134,14 +139,14 @@ def get_owners_for_object(
 
 
 @router.get(
-    "/history/{object_type}/{object_id}",
+    "/history/{object_type}",
     response_model=BusinessOwnerHistory,
     dependencies=[Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY))],
 )
 def get_owner_history(
     object_type: str,
-    object_id: str,
     db: DBSessionDep,
+    object_id: str = Query(..., min_length=1, description="Object id (may be an IRI)"),
     manager=Depends(get_business_owners_manager),
 ):
     """Gets the full ownership history (current + previous) for an object."""

--- a/src/backend/src/routes/metadata_routes.py
+++ b/src/backend/src/routes/metadata_routes.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status, UploadFile, File, Body, Request, Query
 from fastapi.responses import StreamingResponse
@@ -32,10 +32,10 @@ FEATURE_ID = "data-domains"  # Use domain feature for now; can widen later
 
 
 # --- Rich Text ---
-@router.post("/entities/{entity_type}/{entity_id}/rich-texts", response_model=RichText, status_code=status.HTTP_201_CREATED)
+@router.post("/entities/{entity_type}/rich-texts", response_model=RichText, status_code=status.HTTP_201_CREATED)
 async def create_rich_text(
     entity_type: str,
-    entity_id: str,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     request: Request,
     payload: RichTextCreate,
     db: DBSessionDep,
@@ -67,10 +67,10 @@ async def create_rich_text(
         raise HTTPException(status_code=500, detail="Failed to create rich text")
 
 
-@router.get("/entities/{entity_type}/{entity_id}/rich-texts", response_model=List[RichText])
+@router.get("/entities/{entity_type}/rich-texts", response_model=List[RichText])
 async def list_rich_texts(
     entity_type: str,
-    entity_id: str,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     db: DBSessionDep,
     manager: MetadataManager = Depends(get_metadata_manager),
     _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
@@ -134,10 +134,10 @@ async def delete_rich_text(
 
 
 # --- Links ---
-@router.post("/entities/{entity_type}/{entity_id}/links", response_model=Link, status_code=status.HTTP_201_CREATED)
+@router.post("/entities/{entity_type}/links", response_model=Link, status_code=status.HTTP_201_CREATED)
 async def create_link(
     entity_type: str,
-    entity_id: str,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     request: Request,
     payload: LinkCreate,
     db: DBSessionDep,
@@ -169,10 +169,10 @@ async def create_link(
         raise HTTPException(status_code=500, detail="Failed to create link")
 
 
-@router.get("/entities/{entity_type}/{entity_id}/links", response_model=List[Link])
+@router.get("/entities/{entity_type}/links", response_model=List[Link])
 async def list_links(
     entity_type: str,
-    entity_id: str,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     db: DBSessionDep,
     manager: MetadataManager = Depends(get_metadata_manager),
     _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
@@ -236,10 +236,10 @@ async def delete_link(
 
 
 # --- Documents ---
-@router.post("/entities/{entity_type}/{entity_id}/documents", response_model=Document, status_code=status.HTTP_201_CREATED)
+@router.post("/entities/{entity_type}/documents", response_model=Document, status_code=status.HTTP_201_CREATED)
 async def upload_document(
     entity_type: str,
-    entity_id: str,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     request: Request,
     db: DBSessionDep,
     audit_manager: AuditManagerDep,
@@ -317,10 +317,10 @@ async def upload_document(
         raise HTTPException(status_code=500, detail="Failed to upload document")
 
 
-@router.get("/entities/{entity_type}/{entity_id}/documents", response_model=List[Document])
+@router.get("/entities/{entity_type}/documents", response_model=List[Document])
 async def list_documents(
     entity_type: str,
-    entity_id: str,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     db: DBSessionDep,
     manager: MetadataManager = Depends(get_metadata_manager),
     _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
@@ -521,10 +521,10 @@ async def upload_shared_document(
 # Metadata Attachments Endpoints
 # =========================================================================
 
-@router.post("/entities/{entity_type}/{entity_id}/attachments", response_model=MetadataAttachment, status_code=status.HTTP_201_CREATED)
+@router.post("/entities/{entity_type}/attachments", response_model=MetadataAttachment, status_code=status.HTTP_201_CREATED)
 async def attach_shared_asset(
     entity_type: str,
-    entity_id: str,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     request: Request,
     payload: MetadataAttachmentCreate,
     db: DBSessionDep,
@@ -556,10 +556,10 @@ async def attach_shared_asset(
         raise HTTPException(status_code=500, detail="Failed to attach shared asset")
 
 
-@router.get("/entities/{entity_type}/{entity_id}/attachments", response_model=List[MetadataAttachment])
+@router.get("/entities/{entity_type}/attachments", response_model=List[MetadataAttachment])
 async def list_attachments(
     entity_type: str,
-    entity_id: str,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     db: DBSessionDep,
     manager: MetadataManager = Depends(get_metadata_manager),
     _: bool = Depends(PermissionChecker(FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
@@ -568,13 +568,13 @@ async def list_attachments(
     return manager.list_attachments(db, entity_type=entity_type, entity_id=entity_id)
 
 
-@router.delete("/entities/{entity_type}/{entity_id}/attachments/{asset_type}/{asset_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete("/entities/{entity_type}/attachments/{asset_type}/{asset_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def detach_shared_asset(
     entity_type: str,
-    entity_id: str,
     asset_type: str,
     asset_id: str,
     request: Request,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     db: DBSessionDep,
     audit_manager: AuditManagerDep,
     current_user: AuditCurrentUserDep,
@@ -606,10 +606,10 @@ async def detach_shared_asset(
 # Merged Metadata Endpoint (with inheritance)
 # =========================================================================
 
-@router.get("/entities/{entity_type}/{entity_id}/metadata/merged", response_model=MergedMetadataResponse)
+@router.get("/entities/{entity_type}/metadata/merged", response_model=MergedMetadataResponse)
 async def get_merged_metadata(
     entity_type: str,
-    entity_id: str,
+    entity_id: Annotated[str, Query(min_length=1, description='Entity id (may be an IRI)')],
     contract_ids: Optional[str] = Query(None, description="Comma-separated contract IDs for inheritance"),
     max_level: int = Query(99, ge=0, le=999, description="Maximum inheritance level"),
     db: DBSessionDep = None,

--- a/src/backend/src/routes/semantic_links_routes.py
+++ b/src/backend/src/routes/semantic_links_routes.py
@@ -1,5 +1,5 @@
 from typing import List
-from fastapi import APIRouter, Depends, HTTPException, Body, Request
+from fastapi import APIRouter, Depends, HTTPException, Body, Request, Query
 
 from src.common.authorization import PermissionChecker
 from src.common.dependencies import DBSessionDep, AuditCurrentUserDep, AuditManagerDep
@@ -19,7 +19,7 @@ def get_manager(request: Request, db: DBSessionDep) -> SemanticLinksManager:
     return SemanticLinksManager(db, semantic_models_manager=semantic_models_manager)
 
 
-@router.get("/semantic-links/entity/{entity_type}/{entity_id}", response_model=List[EntitySemanticLink])
+@router.get("/semantic-links/entity/{entity_type}/{entity_id:path}", response_model=List[EntitySemanticLink])
 async def list_links(entity_type: str, entity_id: str, manager: SemanticLinksManager = Depends(get_manager)):
     try:
         return manager.list_for_entity(entity_id=entity_id, entity_type=entity_type)
@@ -28,8 +28,28 @@ async def list_links(entity_type: str, entity_id: str, manager: SemanticLinksMan
         raise HTTPException(status_code=500, detail="Failed to list semantic links")
 
 
-@router.get("/semantic-links/iri/{iri:path}", response_model=List[EntitySemanticLink])
-async def list_links_by_iri(iri: str, manager: SemanticLinksManager = Depends(get_manager)):
+@router.get("/semantic-links/entity-prefix/{entity_type}/{entity_id_prefix:path}", response_model=List[EntitySemanticLink])
+async def list_links_by_entity_prefix(
+    entity_type: str, entity_id_prefix: str, manager: SemanticLinksManager = Depends(get_manager)
+):
+    """List all links whose entity_id starts with the given prefix.
+
+    Lets the contract UI fetch every column-level concept assignment for a
+    schema in one request (entity_id shape ``{contract_id}#{schema}#{prop}``),
+    instead of one request per property.
+    """
+    try:
+        return manager.list_for_entity_prefix(entity_id_prefix=entity_id_prefix, entity_type=entity_type)
+    except Exception as e:
+        logger.error("Failed listing semantic links for prefix %s/%s", entity_type, entity_id_prefix, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to list semantic links")
+
+
+@router.get("/semantic-links/by-iri", response_model=List[EntitySemanticLink])
+async def list_links_by_iri(
+    iri: str = Query(..., min_length=1, description="Concept IRI (query param survives %2F%2F proxy collapse)"),
+    manager: SemanticLinksManager = Depends(get_manager),
+):
     try:
         return manager.list_for_iri(iri=iri)
     except Exception as e:

--- a/src/backend/src/tests/unit/test_jobs_polling_idle.py
+++ b/src/backend/src/tests/unit/test_jobs_polling_idle.py
@@ -1,0 +1,127 @@
+"""Regression test: job-polling thread must not touch the DB when there are
+zero installed workflows.
+
+The background poller opened a fresh DB session every interval and queried
+``workflow_installation_repo.get_all_installed`` unconditionally — even with no
+workflows installed. On Databricks Apps that keeps Lakebase compute permanently
+warm (the reported "compute always active"), because a query every 5 minutes
+never lets the instance reach its idle window. The poller now caches a presence
+flag and skips the DB entirely once it has confirmed zero installations, so a
+workflow-free deployment lets Lakebase idle down.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from src.controller.jobs_manager import JobsManager
+
+
+def _make_manager() -> JobsManager:
+    return JobsManager(db=MagicMock(), ws_client=MagicMock())
+
+
+def test_poll_skips_db_after_confirming_zero_installations():
+    mgr = _make_manager()
+
+    # get_db yields a session; get_all_installed reports zero workflows.
+    fake_session = MagicMock()
+    get_db_calls = {"n": 0}
+
+    def fake_get_db():
+        get_db_calls["n"] += 1
+        yield fake_session
+
+    # Stop after the loop has run enough cycles to prove the skip path is taken.
+    cycle = {"n": 0}
+
+    def counting_wait(timeout=None):
+        cycle["n"] += 1
+        # Cycle 1: DB checked (zero) → flag set False.
+        # Cycles 2-3: must be skipped (no DB session opened).
+        if cycle["n"] >= 3:
+            mgr._stop_polling.set()
+        return True
+
+    with patch("src.common.database.get_db", fake_get_db), \
+         patch.object(mgr._stop_polling, "wait", side_effect=counting_wait), \
+         patch(
+             "src.controller.jobs_manager.workflow_installation_repo.get_all_installed",
+             return_value=[],
+         ) as mock_get_all:
+        mgr._poll_job_states(interval_seconds=0)
+
+    # DB session opened exactly once (cycle 1); cycles 2-3 short-circuited.
+    assert get_db_calls["n"] == 1, f"expected 1 DB session, got {get_db_calls['n']}"
+    assert mock_get_all.call_count == 1
+    assert mgr._has_installations is False
+
+
+def test_unknown_flag_triggers_db_recheck():
+    """After install resets the flag to None, the next cycle must query the DB
+    again (so a newly installed workflow is actually picked up)."""
+    mgr = _make_manager()
+    mgr._has_installations = None  # state install_workflow leaves behind
+
+    fake_session = MagicMock()
+
+    def fake_get_db():
+        yield fake_session
+
+    def stop_after_first(timeout=None):
+        mgr._stop_polling.set()
+        return True
+
+    with patch("src.common.database.get_db", fake_get_db), \
+         patch.object(mgr._stop_polling, "wait", side_effect=stop_after_first), \
+         patch(
+             "src.controller.jobs_manager.workflow_installation_repo.get_all_installed",
+             return_value=[],
+         ) as mock_get_all:
+        mgr._poll_job_states(interval_seconds=0)
+
+    # None must NOT short-circuit: the DB is re-checked.
+    assert mock_get_all.call_count == 1
+    assert mgr._has_installations is False
+
+
+def test_nonzero_installations_keeps_polling_db():
+    """When workflows exist, the poller must keep querying every cycle (no skip)."""
+    mgr = _make_manager()
+    fake_session = MagicMock()
+    get_db_calls = {"n": 0}
+
+    def fake_get_db():
+        get_db_calls["n"] += 1
+        yield fake_session
+
+    cycle = {"n": 0}
+
+    def counting_wait(timeout=None):
+        cycle["n"] += 1
+        if cycle["n"] >= 3:
+            mgr._stop_polling.set()
+        return True
+
+    # A non-empty installations list whose per-item processing is harmless: the
+    # job lookup raises, which the loop catches and cleans up (removing the
+    # stale record), so we don't need a full Databricks run fixture here.
+    fake_install = MagicMock(job_id=1, workflow_id="wf", id="row1")
+    mgr._client.jobs.get.side_effect = Exception("job gone")
+
+    with patch("src.common.database.get_db", fake_get_db), \
+         patch.object(mgr._stop_polling, "wait", side_effect=counting_wait), \
+         patch(
+             "src.controller.jobs_manager.workflow_installation_repo.get_all_installed",
+             return_value=[fake_install],
+         ) as mock_get_all, \
+         patch(
+             "src.controller.jobs_manager.workflow_installation_repo.remove",
+             return_value=None,
+         ):
+        mgr._poll_job_states(interval_seconds=0)
+
+    # Every cycle opened a DB session and queried — no skipping while non-empty.
+    assert get_db_calls["n"] == 3
+    assert mock_get_all.call_count == 3
+    assert mgr._has_installations is True

--- a/src/backend/src/tests/unit/test_rdf_bnode_dedup.py
+++ b/src/backend/src/tests/unit/test_rdf_bnode_dedup.py
@@ -1,0 +1,167 @@
+"""Regression tests for blank-node import idempotency.
+
+Blank nodes in imported ontologies (OWL restrictions, SHACL shapes, rdf:Lists)
+used to be skolemised with rdflib's RANDOM per-parse identifier, so re-importing
+the same content produced brand-new URIs that never matched the uq_rdf_triple
+constraint — every re-import duplicated the triples without bound (the reported
+40k-50k bloat). `_import_graph_to_db` now canonicalises blank nodes (RGDA1)
+before persisting, so identical content yields identical rows and re-imports
+are true no-ops.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from rdflib import Graph
+
+import src.repositories.rdf_triples_repository as rdf_repo_mod
+from src.controller.semantic_models_manager import SemanticModelsManager
+from src.repositories.rdf_triples_repository import rdf_triples_repo
+
+
+# Ontology fragment with nested blank nodes: an OWL restriction and two SHACL
+# property shapes. These are exactly the constructs that bloated in production.
+BNODE_TTL = """
+@prefix ex: <http://example.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+
+ex:Person a owl:Class ;
+    rdfs:subClassOf [ a owl:Restriction ;
+        owl:onProperty ex:hasParent ;
+        owl:someValuesFrom ex:Person ] .
+
+ex:PersonShape a sh:NodeShape ;
+    sh:property [ sh:path ex:name ; sh:minCount 1 ] ,
+                [ sh:path ex:age ; sh:datatype ex:int ] .
+"""
+
+
+@pytest.fixture
+def manager_no_rebuild(db_session, tmp_path):
+    with patch.object(SemanticModelsManager, "rebuild_graph_from_enabled", lambda self: None):
+        yield SemanticModelsManager(db_session, data_dir=tmp_path)
+
+
+def _import(manager: SemanticModelsManager, context: str) -> int:
+    g = Graph()
+    g.parse(data=BNODE_TTL, format="turtle")
+    return manager._import_graph_to_db(
+        graph=g,
+        context_name=context,
+        source_type="upload",
+        source_identifier="bnode-test.ttl",
+        created_by="tester",
+    )
+
+
+def test_reimport_of_bnode_ontology_is_idempotent(manager_no_rebuild):
+    """Re-importing identical blank-node content inserts nothing the 2nd time."""
+    context = "urn:test:bnode-idempotent"
+
+    first = _import(manager_no_rebuild, context)
+    assert first > 0, "first import should insert all triples"
+
+    total_after_first = rdf_triples_repo.count_by_context(manager_no_rebuild._db, context)
+
+    second = _import(manager_no_rebuild, context)
+    third = _import(manager_no_rebuild, context)
+
+    assert second == 0, "second import must be a no-op (canonical bnode ids)"
+    assert third == 0, "third import must be a no-op"
+
+    total_after_third = rdf_triples_repo.count_by_context(manager_no_rebuild._db, context)
+    assert total_after_third == total_after_first, "row count must not grow on re-import"
+
+
+def test_skolemized_bnode_uris_are_stable_across_parses(manager_no_rebuild):
+    """The skolem URIs persisted for identical content are identical across imports."""
+    ctx_a = "urn:test:bnode-stable-a"
+    ctx_b = "urn:test:bnode-stable-b"
+
+    _import(manager_no_rebuild, ctx_a)
+    _import(manager_no_rebuild, ctx_b)
+
+    def bnode_local_ids(context: str) -> set[str]:
+        rows = rdf_triples_repo.list_by_context(manager_no_rebuild._db, context)
+        ids: set[str] = set()
+        prefix = f"urn:ontos:bnode:{context}:"
+        for r in rows:
+            for value in (r.subject_uri, r.object_value):
+                if value.startswith(prefix):
+                    ids.add(value[len(prefix):])
+        return ids
+
+    ids_a = bnode_local_ids(ctx_a)
+    ids_b = bnode_local_ids(ctx_b)
+
+    assert ids_a, "expected skolemized blank nodes to be persisted"
+    # Same content parsed twice must yield the same canonical bnode local-ids.
+    assert ids_a == ids_b
+
+
+class TestBloatDiagnostics:
+    """The threshold-gated forensic snapshot for the unexplained triple bloat."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_throttle(self):
+        # Each test controls threshold/interval explicitly; clear the module
+        # throttle so ordering between tests doesn't matter.
+        rdf_repo_mod._diag_last_run_monotonic = 0.0
+        yield
+        rdf_repo_mod._diag_last_run_monotonic = 0.0
+
+    def _seed(self, db, n: int) -> None:
+        triples = [
+            {
+                "subject_uri": f"urn:test:s{i}",
+                "predicate_uri": "urn:test:p",
+                "object_value": f"urn:test:o{i}",
+                "object_is_uri": True,
+                "context_name": "urn:test:diag",
+            }
+            for i in range(n)
+        ]
+        rdf_triples_repo.add_triples_bulk(db, triples)
+
+    def test_no_op_below_threshold(self, db_session, monkeypatch):
+        # Very high threshold so the (small) test table is always under it,
+        # regardless of rows other tests left in the session-scoped DB.
+        monkeypatch.setattr(rdf_repo_mod, "_DIAG_THRESHOLD", 10_000_000)
+        monkeypatch.setattr(rdf_repo_mod, "_DIAG_INTERVAL_S", 0)
+        self._seed(db_session, 10)
+        rdf_repo_mod._diag_last_run_monotonic = 0.0
+
+        with patch.object(rdf_repo_mod.logger, "warning") as warn:
+            rdf_triples_repo.maybe_log_bloat_diagnostics(db_session, trigger="test")
+        warn.assert_not_called()
+
+    def test_disabled_when_threshold_zero(self, db_session, monkeypatch):
+        monkeypatch.setattr(rdf_repo_mod, "_DIAG_THRESHOLD", 0)  # disabled
+        monkeypatch.setattr(rdf_repo_mod, "_DIAG_INTERVAL_S", 0)
+        self._seed(db_session, 20)
+
+        with patch.object(rdf_repo_mod.logger, "warning") as warn:
+            rdf_triples_repo.maybe_log_bloat_diagnostics(db_session, trigger="test")
+        warn.assert_not_called()
+
+    def test_fires_above_threshold_then_throttles(self, db_session, monkeypatch):
+        monkeypatch.setattr(rdf_repo_mod, "_DIAG_THRESHOLD", 5)
+        monkeypatch.setattr(rdf_repo_mod, "_DIAG_INTERVAL_S", 300)  # long throttle
+        self._seed(db_session, 20)  # above 5
+        # add_triples_bulk already ran the diagnostic during seeding and armed
+        # the throttle; reset so this test controls the timing explicitly.
+        rdf_repo_mod._diag_last_run_monotonic = 0.0
+
+        with patch.object(rdf_repo_mod.logger, "warning") as warn:
+            rdf_triples_repo.maybe_log_bloat_diagnostics(db_session, trigger="first")
+            first_calls = warn.call_count
+            # Second call within the throttle window must NOT re-run the snapshot.
+            rdf_triples_repo.maybe_log_bloat_diagnostics(db_session, trigger="second")
+            second_calls = warn.call_count
+
+        assert first_calls > 0, "snapshot must emit warnings above threshold"
+        assert second_calls == first_calls, "throttle must suppress the immediate re-run"

--- a/src/backend/src/tests/unit/test_semantic_cache_warm.py
+++ b/src/backend/src/tests/unit/test_semantic_cache_warm.py
@@ -1,0 +1,123 @@
+"""Regression tests for semantic-models cache warming / persistence.
+
+Two defects made every dashboard request recompute SPARQL over the whole graph
+(the reported post-redeploy slowness):
+
+1. ``on_models_changed`` rebuilt the caches (files + in-memory) and then
+   immediately called ``_invalidate_cache()``, deleting exactly what it had just
+   built. Any concept/link mutation therefore wiped every cache tier.
+2. The read paths (``get_taxonomies`` / ``get_taxonomy_stats`` /
+   ``get_grouped_concepts``) recomputed live on a miss but never repopulated the
+   caches, so the miss recurred on every subsequent request.
+
+These tests pin the fixed behaviour: mutations leave the caches warm, and a cold
+read self-heals both cache tiers from the (always-fresh) singleton graph.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from rdflib import Graph
+
+from src.controller.semantic_models_manager import SemanticModelsManager
+
+
+# Minimal SKOS taxonomy so the compute paths return non-trivial data.
+CONCEPT_TTL = """
+@prefix ex: <http://example.org/gloss/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+ex:Customer a skos:Concept ; skos:prefLabel "Customer" .
+ex:Order a skos:Concept ; skos:prefLabel "Order" .
+"""
+
+
+@pytest.fixture
+def manager(db_session, tmp_path):
+    """A manager whose graph is seeded directly (no DB rebuild)."""
+    with patch.object(SemanticModelsManager, "rebuild_graph_from_enabled", lambda self: None):
+        mgr = SemanticModelsManager(db_session, data_dir=tmp_path)
+    # Seed a real graph context so _compute_* returns data.
+    ctx = mgr._graph.get_context("urn:taxonomy:demo")
+    g = Graph()
+    g.parse(data=CONCEPT_TTL, format="turtle")
+    for triple in g:
+        ctx.add(triple)
+    return mgr
+
+
+def _cache_files(mgr) -> list[str]:
+    cache_dir = mgr._data_dir / "cache"
+    if not cache_dir.exists():
+        return []
+    return sorted(p.name for p in cache_dir.glob("*.json"))
+
+
+def test_cold_read_warms_both_tiers(manager):
+    """A cold stats read repopulates in-memory + file caches (defect #2)."""
+    assert manager._cached_stats is None
+
+    stats = manager.get_taxonomy_stats()
+    assert stats is not None
+
+    # In-memory tier warmed.
+    assert manager._cached_stats is not None
+    assert manager._cached_concepts is not None
+    assert manager._cached_taxonomies is not None
+
+    # Persistent tier written.
+    assert "stats.json" in _cache_files(manager)
+    assert "concepts_all.json" in _cache_files(manager)
+    assert "taxonomies.json" in _cache_files(manager)
+
+
+def test_second_read_hits_cache_no_recompute(manager):
+    """After warming, subsequent reads must not recompute from the graph."""
+    manager.get_grouped_concepts()  # warms
+    assert manager._cached_concepts is not None
+
+    # If a second read recomputed, it would call _build_persistent_caches_atomic
+    # again. Assert it does NOT.
+    with patch.object(
+        manager, "_build_persistent_caches_atomic",
+        side_effect=AssertionError("recomputed on warm cache"),
+    ):
+        grouped = manager.get_grouped_concepts()
+    assert grouped  # still returns data from the warm cache
+
+
+def test_on_models_changed_leaves_cache_warm(manager):
+    """on_models_changed must NOT destroy the caches it rebuilt (defect #1).
+
+    Here rebuild_graph_from_enabled is patched to warm the caches (mirroring the
+    real rebuild's final _build_persistent_caches_atomic step). The regression is
+    that on_models_changed used to null them afterwards.
+    """
+    def fake_rebuild(self):
+        self._build_persistent_caches_atomic()
+
+    with patch.object(SemanticModelsManager, "rebuild_graph_from_enabled", fake_rebuild):
+        manager.on_models_changed()
+
+    assert manager._cached_stats is not None, "on_models_changed destroyed the cache"
+    assert manager._cached_concepts is not None
+    assert manager._cached_taxonomies is not None
+    assert "stats.json" in _cache_files(manager)
+
+
+def test_invalidate_then_read_rewarms(manager):
+    """Explicit invalidation (from incremental CRUD) self-heals on next read."""
+    manager.get_taxonomy_stats()  # warm
+    assert manager._cached_stats is not None
+
+    manager._invalidate_cache()
+    assert manager._cached_stats is None
+    assert _cache_files(manager) == []  # files deleted
+
+    # Next read must rewarm both tiers rather than recompute forever.
+    stats = manager.get_taxonomy_stats()
+    assert stats is not None
+    assert manager._cached_stats is not None
+    assert "stats.json" in _cache_files(manager)

--- a/src/backend/src/tests/unit/test_semantic_links_manager.py
+++ b/src/backend/src/tests/unit/test_semantic_links_manager.py
@@ -235,6 +235,29 @@ class TestSemanticLinksManager:
         assert inferred[0].entity_id == "inferred-123"
 
     @patch('src.controller.semantic_links_manager.entity_semantic_links_repo')
+    def test_list_for_iri_dedups_explicit_and_inferred_same_entity(
+        self, mock_repo, manager, sample_link_db, mock_semantic_models_manager
+    ):
+        """An entity present as BOTH an explicit link and an inferred graph link
+        must appear only once (the reported 'assignment shown twice' bug)."""
+        mock_repo.list_for_iri.return_value = [sample_link_db]  # data_product / entity-123
+
+        # Inferred link describes the SAME (entity_type, entity_id) pair.
+        mock_semantic_models_manager.query.return_value = [
+            {
+                'subject': 'urn:ontos:data_product:entity-123',
+                'label': 'Product (inferred)'
+            }
+        ]
+
+        result = manager.list_for_iri("http://example.com/schema/Product")
+
+        assert len(result) == 1, "duplicate (type,id) must collapse to one row"
+        # The explicit stored link wins (real id, not the synthetic 'inferred:' one).
+        assert not result[0].id.startswith("inferred:")
+        assert result[0].entity_id == "entity-123"
+
+    @patch('src.controller.semantic_links_manager.entity_semantic_links_repo')
     def test_list_for_iri_without_semantic_models_manager(
         self, mock_repo, manager, sample_link_db
     ):

--- a/src/backend/src/tests/unit/test_workflow_installations_repository.py
+++ b/src/backend/src/tests/unit/test_workflow_installations_repository.py
@@ -165,3 +165,54 @@ class TestWorkflowInstallationRepository:
         # Assert
         assert count == 5
 
+    def test_update_last_polled_only_if_changed_skips_unchanged(self, repository, db_session):
+        """update_last_polled(only_if_changed=True) must not write when the job
+        state is identical — this is what lets a quiet poll cycle perform zero
+        Lakebase writes so the instance can idle."""
+        from unittest.mock import patch
+
+        installation_db = WorkflowInstallationDb(
+            id=str(uuid.uuid4()),
+            workflow_id="poll-wf",
+            name="Poll WF",
+            job_id=999,
+            status="installed",
+        )
+        db_session.add(installation_db)
+        db_session.commit()
+
+        state = {'run_id': 1, 'life_cycle_state': 'TERMINATED', 'result_state': 'SUCCESS'}
+        # First call persists the state.
+        repository.update_last_polled(db_session, workflow_id="poll-wf", job_state=state, only_if_changed=True)
+
+        # Identical state → no write.
+        with patch.object(db_session, "commit") as spy_commit:
+            repository.update_last_polled(
+                db_session, workflow_id="poll-wf", job_state=dict(state), only_if_changed=True,
+            )
+            assert spy_commit.call_count == 0, "unchanged state should not commit"
+
+    def test_update_last_polled_writes_on_change(self, repository, db_session):
+        """A changed job state must still persist under only_if_changed."""
+        installation_db = WorkflowInstallationDb(
+            id=str(uuid.uuid4()),
+            workflow_id="poll-wf2",
+            name="Poll WF2",
+            job_id=1000,
+            status="installed",
+        )
+        db_session.add(installation_db)
+        db_session.commit()
+
+        repository.update_last_polled(
+            db_session, workflow_id="poll-wf2",
+            job_state={'run_id': 1, 'life_cycle_state': 'RUNNING'}, only_if_changed=True,
+        )
+        updated = repository.update_last_polled(
+            db_session, workflow_id="poll-wf2",
+            job_state={'run_id': 1, 'life_cycle_state': 'TERMINATED', 'result_state': 'SUCCESS'},
+            only_if_changed=True,
+        )
+        assert updated is not None
+        assert 'TERMINATED' in (updated.last_job_state or '')
+

--- a/src/backend/src/tests/unit/test_workflow_job_runs_repository.py
+++ b/src/backend/src/tests/unit/test_workflow_job_runs_repository.py
@@ -175,3 +175,66 @@ class TestWorkflowJobRunRepository:
         # Assert
         assert count == 5
 
+    def test_upsert_run_skips_commit_when_unchanged(self, repository, db_session, sample_installation):
+        """upsert_run must not write when the incoming state matches storage.
+
+        The background poll re-fetches the last N days of runs every cycle, so
+        most upserts are for already-terminal runs whose state is identical to
+        what we stored. Committing those every cycle kept Lakebase permanently
+        busy; a no-op upsert must skip the write entirely.
+        """
+        from unittest.mock import patch
+
+        run_data = {
+            'run_name': 'nightly',
+            'life_cycle_state': 'TERMINATED',
+            'result_state': 'SUCCESS',
+            'state_message': None,
+            'start_time': 1000,
+            'end_time': 2000,
+        }
+        # First upsert creates the row.
+        repository.upsert_run(
+            db_session, run_id=555, workflow_installation_id=sample_installation.id, run_data=run_data,
+        )
+
+        # Second upsert with identical data must not commit.
+        with patch.object(db_session, "commit") as spy_commit:
+            result = repository.upsert_run(
+                db_session, run_id=555, workflow_installation_id=sample_installation.id, run_data=dict(run_data),
+            )
+            assert spy_commit.call_count == 0, "unchanged upsert should not commit"
+        assert result.run_id == 555
+
+    def test_upsert_run_commits_on_state_change(self, repository, db_session, sample_installation):
+        """A real state transition must still be persisted."""
+        from unittest.mock import patch
+
+        base = {
+            'run_name': 'nightly',
+            'life_cycle_state': 'RUNNING',
+            'result_state': None,
+            'state_message': None,
+            'start_time': 1000,
+            'end_time': None,
+        }
+        repository.upsert_run(
+            db_session, run_id=556, workflow_installation_id=sample_installation.id, run_data=base,
+        )
+
+        # A changed upsert must commit (spy). Refresh-under-mocked-commit would
+        # reload the stale row, so assert the commit fired here...
+        changed = dict(base, life_cycle_state='TERMINATED', result_state='SUCCESS', end_time=2000)
+        with patch.object(db_session, "commit") as spy_commit:
+            repository.upsert_run(
+                db_session, run_id=556, workflow_installation_id=sample_installation.id, run_data=changed,
+            )
+            assert spy_commit.call_count == 1, "state change must commit"
+
+        # ...and verify it actually persisted with a real (unmocked) upsert.
+        result = repository.upsert_run(
+            db_session, run_id=556, workflow_installation_id=sample_installation.id, run_data=changed,
+        )
+        assert result.life_cycle_state == 'TERMINATED'
+        assert result.result_state == 'SUCCESS'
+

--- a/src/frontend/src/components/common/ownership-panel.tsx
+++ b/src/frontend/src/components/common/ownership-panel.tsx
@@ -97,7 +97,7 @@ export function OwnershipPanel({
     setIsLoading(true);
     try {
       const response = await apiGet<BusinessOwnerRead[]>(
-        `/api/business-owners/by-object/${objectType}/${objectId}?active_only=false`
+        `/api/business-owners/by-object/${objectType}?object_id=${encodeURIComponent(objectId)}&active_only=false`
       );
       if (response.error) throw new Error(response.error);
       const all = Array.isArray(response.data) ? response.data : [];

--- a/src/frontend/src/components/home/discovery-section.tsx
+++ b/src/frontend/src/components/home/discovery-section.tsx
@@ -104,12 +104,17 @@ export default function DiscoverySection({ maxItems = 12 }: DiscoverySectionProp
     loadSubscribedProducts();
   }, [loadSubscribedProducts]);
 
-  // Choose a sensible default domain (prefer a domain named "Core")
+  // Choose a sensible default domain. Prefer one named "Core", but fall back to
+  // a top-level (root) domain and finally to the first domain so the graph
+  // always renders — orgs without a "Core" domain previously got stuck on the
+  // "Select a domain" placeholder, making it look like domains never loaded.
   useEffect(() => {
     if (!domainsLoading && domains && domains.length > 0 && !selectedDomainId) {
       const core = domains.find(d => d.name.toLowerCase() === 'core');
-      if (core) {
-        setSelectedDomainId(core.id);
+      const firstRoot = domains.find(d => !d.parent_id);
+      const chosen = core || firstRoot || domains[0];
+      if (chosen) {
+        setSelectedDomainId(chosen.id);
       }
     }
   }, [domainsLoading, domains, selectedDomainId]);

--- a/src/frontend/src/components/metadata/entity-metadata-panel.tsx
+++ b/src/frontend/src/components/metadata/entity-metadata-panel.tsx
@@ -89,10 +89,10 @@ const EntityMetadataPanel: React.FC<Props> = ({ entityId, entityType }) => {
     try {
       setLoading(true);
       const [rt, li, docs, att] = await Promise.all([
-        fetch(`/api/entities/${entityType}/${entityId}/rich-texts`).then(r => r.json()),
-        fetch(`/api/entities/${entityType}/${entityId}/links`).then(r => r.json()),
-        fetch(`/api/entities/${entityType}/${entityId}/documents`).then(r => r.json()),
-        fetch(`/api/entities/${entityType}/${entityId}/attachments`).then(r => r.ok ? r.json() : []),
+        fetch(`/api/entities/${entityType}/rich-texts?entity_id=${encodeURIComponent(entityId)}`).then(r => r.json()),
+        fetch(`/api/entities/${entityType}/links?entity_id=${encodeURIComponent(entityId)}`).then(r => r.json()),
+        fetch(`/api/entities/${entityType}/documents?entity_id=${encodeURIComponent(entityId)}`).then(r => r.json()),
+        fetch(`/api/entities/${entityType}/attachments?entity_id=${encodeURIComponent(entityId)}`).then(r => r.ok ? r.json() : []),
       ]);
       // Sort by level ascending
       const sortByLevel = <T extends { level?: number; created_at?: string }>(arr: T[]) => 
@@ -276,7 +276,7 @@ const EntityMetadataPanel: React.FC<Props> = ({ entityId, entityType }) => {
                 <Button size="sm" onClick={async () => {
                   try {
                     const payload = { entity_id: entityId, entity_type: entityType, title: noteTitle, short_description: noteDesc || undefined, content_markdown: noteContent, level: noteLevel, inheritable: noteInheritable, is_shared: noteIsShared };
-                    const endpoint = noteIsShared ? '/api/metadata/shared/rich-texts' : `/api/entities/${entityType}/${entityId}/rich-texts`;
+                    const endpoint = noteIsShared ? '/api/metadata/shared/rich-texts' : `/api/entities/${entityType}/rich-texts?entity_id=${encodeURIComponent(entityId)}`;
                     const resp = await fetch(endpoint, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
                     if (!resp.ok) throw new Error(await resp.text());
                     setNoteTitle(''); setNoteDesc(''); setNoteContent(''); setNoteLevel(50); setNoteInheritable(true); setNoteIsShared(false); setAddingNote(false);
@@ -422,7 +422,7 @@ const EntityMetadataPanel: React.FC<Props> = ({ entityId, entityType }) => {
                 <Button size="sm" onClick={async () => {
                   try {
                     const payload = { entity_id: entityId, entity_type: entityType, title: linkTitle, short_description: linkDesc || undefined, url: linkUrl, level: linkLevel, inheritable: linkInheritable, is_shared: linkIsShared };
-                    const endpoint = linkIsShared ? '/api/metadata/shared/links' : `/api/entities/${entityType}/${entityId}/links`;
+                    const endpoint = linkIsShared ? '/api/metadata/shared/links' : `/api/entities/${entityType}/links?entity_id=${encodeURIComponent(entityId)}`;
                     const resp = await fetch(endpoint, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
                     if (!resp.ok) throw new Error(await resp.text());
                     setLinkTitle(''); setLinkDesc(''); setLinkUrl(''); setLinkLevel(50); setLinkInheritable(true); setLinkIsShared(false); setAddingLink(false);
@@ -505,7 +505,7 @@ const EntityMetadataPanel: React.FC<Props> = ({ entityId, entityType }) => {
                     form.append('level', String(docLevel));
                     form.append('inheritable', String(docInheritable));
                     form.append('file', docFile);
-                    const endpoint = docIsShared ? '/api/metadata/shared/documents' : `/api/entities/${entityType}/${entityId}/documents`;
+                    const endpoint = docIsShared ? '/api/metadata/shared/documents' : `/api/entities/${entityType}/documents?entity_id=${encodeURIComponent(entityId)}`;
                     const resp = await fetch(endpoint, { method: 'POST', body: form });
                     if (!resp.ok) throw new Error(await resp.text());
                     setDocTitle(''); setDocDesc(''); setDocFile(null); setDocLevel(50); setDocInheritable(true); setDocIsShared(false); setUploadingDoc(false); setAddingDoc(false);

--- a/src/frontend/src/components/semantic/linked-objects-panel.test.tsx
+++ b/src/frontend/src/components/semantic/linked-objects-panel.test.tsx
@@ -97,7 +97,7 @@ describe('LinkedObjectsPanel', () => {
     toastSpy.mockReset()
     // default mocks: links + entity enrichment
     mockGet.mockImplementation(async (url: string) => {
-      if (url.startsWith('/api/semantic-links/iri/')) {
+      if (url.startsWith('/api/semantic-links/by-iri')) {
         return { data: sampleLinks }
       }
       if (url.startsWith('/api/data-products/')) {
@@ -178,7 +178,7 @@ describe('LinkedObjectsPanel', () => {
 
   it('renders empty state when no links exist', async () => {
     mockGet.mockImplementation(async (url: string) => {
-      if (url.startsWith('/api/semantic-links/iri/')) {
+      if (url.startsWith('/api/semantic-links/by-iri')) {
         return { data: [] }
       }
       return { data: [] }

--- a/src/frontend/src/components/semantic/linked-objects-panel.tsx
+++ b/src/frontend/src/components/semantic/linked-objects-panel.tsx
@@ -208,7 +208,7 @@ export default function LinkedObjectsPanel({
     setIsLoading(true)
     try {
       const res = await get<SemanticLink[]>(
-        `/api/semantic-links/iri/${encodeURIComponent(conceptIri)}`
+        `/api/semantic-links/by-iri?iri=${encodeURIComponent(conceptIri)}`
       )
       const raw = res.data || []
       const enriched = await enrichLinks(raw)

--- a/src/frontend/src/stores/notifications-store.ts
+++ b/src/frontend/src/stores/notifications-store.ts
@@ -13,6 +13,8 @@ interface NotificationsState {
   deleteNotification: (notificationId: string) => Promise<void>;
   startPolling: () => void; // Action to start polling
   stopPolling: () => void; // Action to stop polling
+  resumePollingInterval: () => void; // Internal: (re)start the interval + fetch now
+  pausePollingInterval: () => void; // Internal: clear the interval, keep intent
 }
 
 // --- API Helper Functions (using fetch directly) ---
@@ -64,6 +66,13 @@ const apiDelete = async (endpoint: string): Promise<{ error?: string }> => {
 // Variable to hold the interval ID
 let pollingIntervalId: NodeJS.Timeout | null = null;
 const POLLING_INTERVAL = 60 * 1000; // 60 seconds
+
+// Whether the app wants polling active (set by start/stopPolling). We only run
+// the actual interval while the tab is visible so a backgrounded tab stops
+// hitting /api/notifications — otherwise the constant traffic keeps the
+// Lakebase compute from ever scaling down to idle.
+let pollingDesired = false;
+let visibilityHandler: (() => void) | null = null;
 
 // Guard flag to prevent concurrent fetches
 let isFetching = false;
@@ -196,21 +205,59 @@ export const useNotificationsStore = create<NotificationsState>((set, get) => ({
     }
   },
   
-  // --- Polling Actions --- 
+  // --- Polling Actions ---
   startPolling: () => {
-      // Clear existing interval before starting a new one
-      get().stopPolling(); 
-      pollingIntervalId = setInterval(() => {
-          get().fetchNotifications();
-      }, POLLING_INTERVAL);
-      // Fetch immediately when polling starts
-      get().fetchNotifications(); 
+      pollingDesired = true;
+
+      // Pause the interval whenever the tab is hidden and resume (with an
+      // immediate refresh) when it becomes visible again. Registered once.
+      if (visibilityHandler === null && typeof document !== 'undefined') {
+          visibilityHandler = () => {
+              if (!pollingDesired) return;
+              if (document.visibilityState === 'visible') {
+                  get().resumePollingInterval();
+              } else {
+                  get().pausePollingInterval();
+              }
+          };
+          document.addEventListener('visibilitychange', visibilityHandler);
+      }
+
+      // Only run the interval if the tab is currently visible; otherwise wait
+      // for the visibility handler to start it when the user returns.
+      if (typeof document === 'undefined' || document.visibilityState === 'visible') {
+          get().resumePollingInterval();
+      }
   },
 
-  stopPolling: () => {
+  // Start the interval and fetch immediately. Idempotent — clears any existing
+  // interval first so we never end up with two running.
+  resumePollingInterval: () => {
       if (pollingIntervalId) {
           clearInterval(pollingIntervalId);
           pollingIntervalId = null;
+      }
+      pollingIntervalId = setInterval(() => {
+          get().fetchNotifications();
+      }, POLLING_INTERVAL);
+      // Fetch immediately so returning to the tab shows fresh data at once.
+      get().fetchNotifications();
+  },
+
+  // Stop the interval but keep pollingDesired/listener so we resume on focus.
+  pausePollingInterval: () => {
+      if (pollingIntervalId) {
+          clearInterval(pollingIntervalId);
+          pollingIntervalId = null;
+      }
+  },
+
+  stopPolling: () => {
+      pollingDesired = false;
+      get().pausePollingInterval();
+      if (visibilityHandler !== null && typeof document !== 'undefined') {
+          document.removeEventListener('visibilitychange', visibilityHandler);
+          visibilityHandler = null;
       }
   },
 }));

--- a/src/frontend/src/views/data-contract-details.tsx
+++ b/src/frontend/src/views/data-contract-details.tsx
@@ -256,7 +256,7 @@ export default function DataContractDetails() {
   const [links, setLinks] = useState<EntitySemanticLink[]>([])
   const [selectedSchemaIndex, setSelectedSchemaIndex] = useState(0)
   const [schemaLinks, setSchemaLinks] = useState<Record<string, EntitySemanticLink[]>>({})
-  const [propertyLinks] = useState<Record<string, EntitySemanticLink[]>>({})
+  const [propertyLinks, setPropertyLinks] = useState<Record<string, EntitySemanticLink[]>>({})
 
   // Lazy-loaded schema properties with pagination
   const [schemaProperties, setSchemaProperties] = useState<Record<string, SchemaProperty[]>>({})
@@ -448,6 +448,41 @@ export default function DataContractDetails() {
       }
     } catch (e) {
       console.warn('Failed to fetch schema links for', schemaName, ':', e)
+    }
+  }, [contractId])
+
+  // Fetch column-level concept assignments for a schema in one call. Links are
+  // stored with entity_id "{contractId}#{schema}#{property}"; we key state by
+  // "{schema}#{property}" to match the column renderer (see propertyLinks use).
+  const fetchPropertySemanticLinks = useCallback(async (schemaName: string) => {
+    if (!contractId || !schemaName) return
+    try {
+      const prefix = `${contractId}#${schemaName}#`
+      const res = await fetch(`/api/semantic-links/entity-prefix/data_contract_property/${encodeURIComponent(prefix)}`)
+      if (!res.ok) return
+      const data = await res.json()
+      const byKey: Record<string, EntitySemanticLink[]> = {}
+      for (const link of (Array.isArray(data) ? data : [])) {
+        // entity_id: "{contractId}#{schema}#{property}" -> key "{schema}#{property}"
+        const parts = String(link.entity_id).split('#')
+        const propName = parts.slice(2).join('#')
+        if (!propName) continue
+        const key = `${schemaName}#${propName}`
+        ;(byKey[key] = byKey[key] || []).push(link)
+      }
+      // The prefix response is the authoritative full set for this schema, so
+      // replace every "{schemaName}#*" entry rather than merging — otherwise a
+      // property whose last assignment was removed would keep showing a stale
+      // link until a full reload.
+      setPropertyLinks(prev => {
+        const next: Record<string, EntitySemanticLink[]> = {}
+        for (const [key, value] of Object.entries(prev)) {
+          if (!key.startsWith(`${schemaName}#`)) next[key] = value
+        }
+        return { ...next, ...byKey }
+      })
+    } catch (e) {
+      console.warn('Failed to fetch property links for', schemaName, ':', e)
     }
   }, [contractId])
 
@@ -712,7 +747,8 @@ export default function DataContractDetails() {
     if (!schemaLinks[schema.name]) {
       fetchSchemaSemanticLinks(schema.name)
     }
-  }, [contract?.schema, selectedSchemaIndex, fetchSchemaProperties, fetchSchemaSemanticLinks])
+    fetchPropertySemanticLinks(schema.name)
+  }, [contract?.schema, selectedSchemaIndex, fetchSchemaProperties, fetchSchemaSemanticLinks, fetchPropertySemanticLinks])
 
   // Poll for profiling updates while profiling is running
   useEffect(() => {

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
+const proxyTarget = process.env.VITE_PROXY_TARGET || 'http://localhost:8000';
+
 export default defineConfig(({ command }) => ({
   base: command === 'build' ? '/static/' : '/',
   plugins: [react()],
@@ -58,17 +60,17 @@ export default defineConfig(({ command }) => ({
     },
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: proxyTarget,
         changeOrigin: true,
         secure: false,
       },
       '/docs': {
-        target: 'http://localhost:8000',
+        target: proxyTarget,
         changeOrigin: true,
         secure: false,
       },
       '/redoc': {
-        target: 'http://localhost:8000',
+        target: proxyTarget,
         changeOrigin: true,
         secure: false,
       },

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 
 const proxyTarget = process.env.VITE_PROXY_TARGET || 'http://localhost:8000';
+const devPort = Number(process.env.VITE_PORT) || 3000;
 
 export default defineConfig(({ command }) => ({
   base: command === 'build' ? '/static/' : '/',
@@ -45,7 +46,7 @@ export default defineConfig(({ command }) => ({
     }
   },
   server: {
-    port: 3000,
+    port: devPort,
     // Exclude test files from file watching to prevent bundling errors
     watch: {
       ignored: [

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -48,7 +48,7 @@ include = [
 
 [tool.hatch.envs.dev.scripts]
 dev-frontend = "yarn dev:frontend"
-dev-backend = "uvicorn --app-dir backend src.app:app --reload --host=0.0.0.0 --port=8000"
+dev-backend = "uvicorn --app-dir backend src.app:app --reload --host=${BACKEND_HOST:-0.0.0.0} --port=${BACKEND_PORT:-8000}"
 deploy-and-run = [
   'databricks bundle deploy --var="catalog=app_data" --var="schema=app_ontos"',
   "databricks bundle run app_ontos",

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -48,7 +48,7 @@ include = [
 
 [tool.hatch.envs.dev.scripts]
 dev-frontend = "yarn dev:frontend"
-dev-backend = "uvicorn --app-dir backend src.app:app --reload --host=${BACKEND_HOST:-0.0.0.0} --port=${BACKEND_PORT:-8000}"
+dev-backend = "uvicorn --app-dir backend src.app:app --reload --host=0.0.0.0 --port=8000"
 deploy-and-run = [
   'databricks bundle deploy --var="catalog=app_data" --var="schema=app_ontos"',
   "databricks bundle run app_ontos",


### PR DESCRIPTION
## Summary

Batch of fixes from customer report ("dfra"). All root causes reproduced locally against isolated servers (`:8100` / `:3100`) and verified end-to-end.

## Fixes

- **Owners on concept/term/property didn't render.** `business_owners /by-object`, `metadata /entities/{type}/{id}/…`, and `semantic-links /iri/…` used path params for IRI-valued ids, which the Databricks Apps proxy mangles by collapsing `%2F%2F` → `/` in path segments (see #536). Switched to `?iri=` / `?object_id=` / `?entity_id=` query params — inert to that transformation — matching the pattern #536 established. Frontend callers (`ownership-panel`, `entity-metadata-panel`, `linked-objects-panel`) updated.
- **Business concepts/properties disappeared from contract columns.** `data-contract-details.tsx` declared `propertyLinks` without a setter and never populated it. Added `fetchPropertySemanticLinks` (schema-level, one call per schema via new `/semantic-links/entity-prefix/{type}/{prefix}` endpoint) that replaces the slice per schema so removed assignments don't linger.
- **RDF triples duplicated unboundedly on re-import.** `_skolemize_bnode` embedded rdflib's random per-parse bnode id, so re-importing an ontology with blank nodes (OWL restrictions, SHACL shapes) never hit the `uq_rdf_triple` constraint. Now canonicalise the graph (RGDA1 `to_canonical_graph`) before persisting, so identical content produces identical rows and re-imports are true no-ops.
- **Threshold-gated bloat diagnostics on `RdfTriplesRepository`.** When the table exceeds `RDF_TRIPLES_DIAGNOSTIC_THRESHOLD` (default 30000), log a one-shot forensic snapshot: blank-node count, constraint-bypass check, source_type + context breakdown, per-(subject,predicate) churn. Needed because the customer's 64k-with-no-file case is not locally reproducible.
- **`_register_sources_as_collections` polluted the Collections list** by registering the dynamic recomputed `urn:app-entities` / `urn:semantic-links` contexts as KnowledgeCollections. Added them to the skip set.
- **"Assignment shown twice."** `list_for_iri` returned explicit DB links + inferred graph links with no dedup. Now deduped on `(entity_type, entity_id)`; explicit wins over the synthetic inferred link.
- **Data domains stuck loading** in Home Discovery when no domain named "Core" existed. Now falls back to first root domain, then first domain.
- **Notifications polling kept Lakebase compute warm 24/7** — no tab-visibility handling. Store now pauses the interval on `visibilitychange` and resumes (with an immediate fetch) on visible.
- **Dev ergonomics — parallel worktrees:** frontend/backend dev ports are now fully env-configurable so multiple git worktrees can run isolated servers without colliding on `3000`/`8000`. `vite.config.ts` reads `VITE_PORT` (server port) and `VITE_PROXY_TARGET` (proxy target); the `dev-backend` hatch script honors `BACKEND_PORT`/`BACKEND_HOST`. Documented in `CONTRIBUTING.md` ("Running Multiple Worktrees Side-by-Side") and mirrored into the LLM-agent instructions (`.cursor/rules/08-testing-and-deployment.mdc`, `CLAUDE.md`) so Cursor/Claude sessions in secondary worktrees don't restart or rebind the primary `:8000`/`:3000` servers.

- **Semantic caches were destroyed on every mutation and never repopulated (perf — the "still slow after redeploy" report).** Prod logs showed every dashboard request logging `Persistent cache not found for {stats,taxonomies,concepts}, computing live` against a 68,684-triple graph. Two defects: (1) `on_models_changed` ran `rebuild_graph_from_enabled` (which rebuilds both cache tiers) and then immediately `_invalidate_cache()`, deleting what it just built; (2) read paths recomputed live on a miss but never repopulated, so the miss recurred every request. Fix: drop the redundant post-rebuild invalidation, and add `_ensure_caches_warm()` so a cold read recomputes all tiers once from the (always-fresh) singleton graph via the existing atomic writer. Audited all 12 graph mutators for the invalidate-or-rebuild invariant so this does not reintroduce the historical "changes don't show" staleness (single-worker deploy, singleton read manager).

## Tests

- `src/backend/src/tests/unit/test_rdf_bnode_dedup.py` — re-import idempotency, stable bnode ids across parses, threshold-gated diagnostic firing + throttle + no-op-below-threshold + disabled-when-zero.
- `test_semantic_links_manager.py` — added `test_list_for_iri_dedups_explicit_and_inferred_same_entity`.
- `src/backend/src/tests/unit/test_semantic_cache_warm.py` — cold-read warms both cache tiers, warm reads don't recompute, `on_models_changed` leaves caches warm, invalidate→read rewarms.

## Test plan

- [ ] `hatch -e dev run pytest src/tests/unit/test_rdf_bnode_dedup.py src/tests/unit/test_semantic_links_manager.py` — new tests pass (2 pre-existing failures in `test_semantic_links_manager` are unrelated).
- [ ] Concept detail page with slash-bearing IRI (`/concepts/browser/urn%3Aglossary%3Atest-1%2Ftest-1.1-prop`) — assign an owner via Ownership panel, reload → owner persists.
- [ ] Contract detail (e.g. `00400001-0000-4000-8000-000000000001`, `customers` schema) — column concept badges render (customer_id → customerId/Unique Identifier, email → emailAddress/PII).
- [ ] Import a bnode-bearing TTL twice into an editable collection — second import returns `triples_imported: 0`; total row count stable across `POST /api/semantic-models/refresh-graph`.
- [ ] Home discovery `/marketplace` — domain graph auto-renders (no "Loading domains…" stuck state).
- [ ] Notifications polling: with a tab focused, `/api/notifications` hits every 60s; hide the tab → hits stop; return → immediate fetch then interval resumes.

## Non-code answers (for customer reply)

- **Business terms / LA via Assets:** same role as objects/features/concepts — use concepts for the pilot.
- **KPIs / metrics:** use concepts or add relations to a KPI object; dedicated KPI concept type noted as future ask.
- **"Domain" in concepts** is RDF/semantic terminology only; linking objects/properties to actual **data domains** is separate and being worked on.

## Follow-up (open)

The customer's **64k rdf_triples with no ontology file loaded** is *not* locally reproducible — `uq_rdf_triple` holds perfectly on the current schema (all 6 cols NOT NULL per `z8_fix_rdf_triple_nulls`, zero constraint bypass). Most likely cause: an older build predating `uq_rdf_triple` / `z8`'s NULL-coalesce, and/or the random-bnode vector now fixed. The diagnostics in this PR will identify the vector the next time it happens; ask the customer for `SELECT source_type, count(*) FROM rdf_triples GROUP BY 1 ORDER BY 2 DESC` + `alembic current` output.

This pull request and its description were written by Isaac.


