### PR TITLE
feat(domains): multi-domain assignment for teams, contracts, products, and assets (#520)

### DIFF
--- a/.cursor/rules/10-entity-panel-matrix.mdc
+++ b/.cursor/rules/10-entity-panel-matrix.mdc
@@ -34,6 +34,7 @@ These tables use an `entity_type` + `entity_id` pattern to link to any entity.
 | `entity_relationships` | Typed relationships between any two entities |
 | `entity_subscriptions` | User subscriptions / notifications |
 | `entity_tag_associations` | Tag assignments |
+| `entity_domain_associations` | Data domain assignments — multi-domain with one `is_primary` per entity (`entity_type` ∈ {`team`, `data_contract`, `data_product`, `asset`}). Primary feeds single-value integrations (ODCS/ODPS `domain`, UC `data_domain` tag); additional domains ride extension fields and any-of discovery. See `docs/prds/prd-multi-domain-assignment.md`. |
 | `entity_semantic_links` | Links to ontology concepts/properties (`entity_type` ∈ {`data_domain`, `data_product`, `data_contract`, `data_contract_schema`, `data_contract_property`, `asset`, `uc_catalog`, `uc_schema`, `uc_table`, `uc_column`, `dataset` _(legacy)_}) |
 | `rich_text_metadata` | Rich-text notes |
 | `link_metadata` | External link bookmarks |

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -2,9 +2,9 @@ name: Test Coverage
 
 on:
   push:
-    branches: [main, development]
+    branches: [main, develop, development]
   pull_request:
-    branches: [main, development]
+    branches: [main, develop, development]
   # Required by the merge queue: GitHub builds each batch on a temporary
   # gh-readonly-queue/<base>/... branch and fires a merge_group event. The
   # required status checks must run on that event or queued PRs hang forever

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -2,9 +2,10 @@ name: Test Coverage
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, development]
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, development]
+  merge_group:
 
 permissions:
   id-token: write

--- a/src/backend/alembic/versions/l1_add_entity_domain_associations.py
+++ b/src/backend/alembic/versions/l1_add_entity_domain_associations.py
@@ -1,0 +1,200 @@
+"""Add entity_domain_associations (multi-domain assignment) and drop legacy single-domain columns
+
+Introduces the polymorphic ``entity_domain_associations`` junction table (multi-domain
+assignment for teams, data contracts, data products and assets), backfills every existing
+single-domain value as a *primary* association, then drops the four legacy scalar columns
+(``teams.domain_id``, ``data_contracts.domain_id``, ``assets.domain_id``,
+``data_products.domain``).
+
+The data-product ``domain`` column is a free-text string that historically held either a
+domain ID or a domain name; the backfill resolves ID first, then name, and logs any values
+that cannot be resolved.
+
+Revision ID: l1_entity_domain_associations
+Revises: k1_merge_aa1_c1_g3
+Create Date: 2026-07-06
+"""
+import logging
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+
+revision: str = "l1_entity_domain_associations"
+down_revision: Union[str, Sequence[str], None] = "k1_merge_aa1_c1_g3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+TABLE = "entity_domain_associations"
+
+
+def _table_exists(conn, name: str) -> bool:
+    return conn.execute(
+        sa.text("SELECT 1 FROM information_schema.tables WHERE table_name = :n"),
+        {"n": name},
+    ).scalar() is not None
+
+
+def _column_exists(conn, table: str, column: str) -> bool:
+    return conn.execute(
+        sa.text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_name = :t AND column_name = :c"
+        ),
+        {"t": table, "c": column},
+    ).scalar() is not None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Create the junction table (idempotent guard for partial re-runs).
+    if not _table_exists(conn, TABLE):
+        op.create_table(
+            TABLE,
+            sa.Column("id", PG_UUID(as_uuid=True), primary_key=True),
+            sa.Column("domain_id", sa.String(), sa.ForeignKey("data_domains.id"), nullable=False),
+            sa.Column("entity_id", sa.String(), nullable=False),
+            sa.Column("entity_type", sa.String(), nullable=False),
+            sa.Column("is_primary", sa.Boolean(), nullable=False, server_default=sa.false()),
+            sa.Column("assigned_by", sa.String(), nullable=True),
+            sa.Column("assigned_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        )
+        # Indexes mirror the ORM model (db_models/domain_associations.py).
+        op.create_index(f"ix_{TABLE}_domain_id", TABLE, ["domain_id"])
+        op.create_index(f"ix_{TABLE}_entity_id", TABLE, ["entity_id"])
+        op.create_index(f"ix_{TABLE}_entity_type", TABLE, ["entity_type"])
+        op.create_index(f"ix_{TABLE}_is_primary", TABLE, ["is_primary"])
+        op.create_index("ix_entity_domain_entity", TABLE, ["entity_type", "entity_id"])
+        op.create_unique_constraint(
+            "uq_entity_domain_assignment", TABLE, ["domain_id", "entity_type", "entity_id"]
+        )
+        # At most one primary domain per entity.
+        op.create_index(
+            "uq_entity_domain_primary",
+            TABLE,
+            ["entity_type", "entity_id"],
+            unique=True,
+            postgresql_where=sa.text("is_primary"),
+        )
+
+    # 2. Backfill existing single-domain values as PRIMARY associations.
+    #    Only rows whose domain resolves to a real data_domains.id are inserted
+    #    (satisfies the FK and drops stale references).
+    def _backfill_by_id(source_table: str, id_expr: str, domain_col: str, entity_type: str):
+        conn.execute(sa.text(
+            f"""
+            INSERT INTO {TABLE} (id, domain_id, entity_id, entity_type, is_primary, assigned_by, assigned_at)
+            SELECT gen_random_uuid(), s.{domain_col}, {id_expr}, :etype, TRUE, 'migration', now()
+            FROM {source_table} s
+            JOIN data_domains d ON d.id = s.{domain_col}
+            WHERE s.{domain_col} IS NOT NULL
+            ON CONFLICT ON CONSTRAINT uq_entity_domain_assignment DO NOTHING
+            """
+        ), {"etype": entity_type})
+
+    _backfill_by_id("teams", "s.id", "domain_id", "team")
+    _backfill_by_id("data_contracts", "s.id", "domain_id", "data_contract")
+    _backfill_by_id("assets", "CAST(s.id AS VARCHAR)", "domain_id", "asset")
+
+    # data_products.domain is free-text (ID or name). Resolve ID first, then name.
+    # (a) domain value IS a domain id
+    conn.execute(sa.text(
+        f"""
+        INSERT INTO {TABLE} (id, domain_id, entity_id, entity_type, is_primary, assigned_by, assigned_at)
+        SELECT gen_random_uuid(), d.id, p.id, 'data_product', TRUE, 'migration', now()
+        FROM data_products p
+        JOIN data_domains d ON d.id = p.domain
+        WHERE p.domain IS NOT NULL
+        ON CONFLICT ON CONSTRAINT uq_entity_domain_assignment DO NOTHING
+        """
+    ))
+    # (b) domain value is a domain NAME (and was not already resolved as an id)
+    conn.execute(sa.text(
+        f"""
+        INSERT INTO {TABLE} (id, domain_id, entity_id, entity_type, is_primary, assigned_by, assigned_at)
+        SELECT gen_random_uuid(), d.id, p.id, 'data_product', TRUE, 'migration', now()
+        FROM data_products p
+        JOIN data_domains d ON d.name = p.domain
+        WHERE p.domain IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM data_domains d2 WHERE d2.id = p.domain)
+        ON CONFLICT ON CONSTRAINT uq_entity_domain_assignment DO NOTHING
+        """
+    ))
+    # (c) log unresolvable data-product domain values for manual reconciliation.
+    unresolved = conn.execute(sa.text(
+        """
+        SELECT p.id, p.domain
+        FROM data_products p
+        WHERE p.domain IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM data_domains d WHERE d.id = p.domain)
+          AND NOT EXISTS (SELECT 1 FROM data_domains d WHERE d.name = p.domain)
+        """
+    )).fetchall()
+    for row in unresolved:
+        logger.warning(
+            "Multi-domain migration: could not resolve data_product %s domain value %r; dropped.",
+            row[0], row[1],
+        )
+
+    # 3. Drop the four legacy scalar columns (Postgres cascades FK/index cleanup).
+    if _column_exists(conn, "teams", "domain_id"):
+        op.drop_column("teams", "domain_id")
+    if _column_exists(conn, "data_contracts", "domain_id"):
+        op.drop_column("data_contracts", "domain_id")
+    if _column_exists(conn, "assets", "domain_id"):
+        op.drop_column("assets", "domain_id")
+    if _column_exists(conn, "data_products", "domain"):
+        op.drop_column("data_products", "domain")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. Re-add the legacy columns (nullable).
+    if not _column_exists(conn, "teams", "domain_id"):
+        op.add_column("teams", sa.Column("domain_id", sa.String(), sa.ForeignKey("data_domains.id"), nullable=True))
+    if not _column_exists(conn, "data_contracts", "domain_id"):
+        op.add_column("data_contracts", sa.Column("domain_id", sa.String(), sa.ForeignKey("data_domains.id"), nullable=True))
+    if not _column_exists(conn, "assets", "domain_id"):
+        op.add_column("assets", sa.Column("domain_id", sa.String(), nullable=True))
+    if not _column_exists(conn, "data_products", "domain"):
+        op.add_column("data_products", sa.Column("domain", sa.String(), nullable=True))
+
+    # 2. Restore the primary domain into each legacy column.
+    conn.execute(sa.text(
+        f"""
+        UPDATE teams t SET domain_id = a.domain_id
+        FROM {TABLE} a
+        WHERE a.entity_type = 'team' AND a.entity_id = t.id AND a.is_primary = TRUE
+        """
+    ))
+    conn.execute(sa.text(
+        f"""
+        UPDATE data_contracts c SET domain_id = a.domain_id
+        FROM {TABLE} a
+        WHERE a.entity_type = 'data_contract' AND a.entity_id = c.id AND a.is_primary = TRUE
+        """
+    ))
+    conn.execute(sa.text(
+        f"""
+        UPDATE assets s SET domain_id = a.domain_id
+        FROM {TABLE} a
+        WHERE a.entity_type = 'asset' AND a.entity_id = CAST(s.id AS VARCHAR) AND a.is_primary = TRUE
+        """
+    ))
+    conn.execute(sa.text(
+        f"""
+        UPDATE data_products p SET domain = a.domain_id
+        FROM {TABLE} a
+        WHERE a.entity_type = 'data_product' AND a.entity_id = p.id AND a.is_primary = TRUE
+        """
+    ))
+
+    # 3. Drop the junction table.
+    if _table_exists(conn, TABLE):
+        op.drop_table(TABLE)

--- a/src/backend/src/common/compliance_entities.py
+++ b/src/backend/src/common/compliance_entities.py
@@ -216,14 +216,22 @@ class AppEntityLoader(EntityLoader):
             # Data Products
             if 'data_product' in entity_types:
                 from src.repositories.data_products_repository import data_product_repo
+                from src.repositories.entity_domain_association_repository import entity_domain_repo
                 products = data_product_repo.list(self.db)
+                # Domain moved to the entity_domain_associations junction; batch-load the
+                # primary domain name per product (the legacy `domain` column was dropped).
+                domains_map = entity_domain_repo.get_domains_for_entities(
+                    self.db, entity_type="data_product", entity_ids=[str(p.id) for p in products]
+                ) if products else {}
                 for product in products:
+                    assigned = domains_map.get(str(product.id), [])
+                    primary_domain = next((a.domain_name for a in assigned if a.is_primary), None)
                     yield {
                         'type': 'data_product',
                         'id': product.id,
                         'name': product.name,
                         'description': product.description,
-                        'domain': product.domain,
+                        'domain': primary_domain,
                         'status': product.status,
                         'version': product.version,
                         'owner': product.owner,

--- a/src/backend/src/common/genie_client.py
+++ b/src/backend/src/common/genie_client.py
@@ -227,7 +227,8 @@ def collect_rich_text_metadata(product_ids: List[str], db: Session) -> Dict[str,
 def format_metadata_for_genie(
     metadata_map: Dict[str, List],
     products: List,
-    max_length: int = 5000
+    max_length: int = 5000,
+    product_domains: Optional[Dict[str, str]] = None,
 ) -> str:
     """
     Format collected metadata as markdown instructions for Genie.
@@ -236,6 +237,9 @@ def format_metadata_for_genie(
         metadata_map: Dict of entity_id -> metadata entries
         products: List of DataProductDb objects
         max_length: Maximum character length (default 5000)
+        product_domains: Optional {product_id: primary domain name}. Domain moved to the
+            entity_domain_associations junction (the legacy DataProductDb.domain column was
+            dropped), so the caller resolves it and passes it in here.
 
     Returns:
         Formatted markdown string
@@ -251,9 +255,10 @@ def format_metadata_for_genie(
         if hasattr(product, 'description') and product.description:
             section_parts.append(f"**Description**: {product.description}\n")
 
-        # Add product domain if available
-        if hasattr(product, 'domain') and product.domain:
-            section_parts.append(f"**Domain**: {product.domain}\n")
+        # Add product domain if available (resolved from the junction by the caller).
+        primary_domain = (product_domains or {}).get(str(product.id))
+        if primary_domain:
+            section_parts.append(f"**Domain**: {primary_domain}\n")
 
         section_parts.append("\n")
 

--- a/src/backend/src/controller/asset_bulk_manager.py
+++ b/src/backend/src/controller/asset_bulk_manager.py
@@ -249,16 +249,18 @@ class AssetBulkManager:
         from sqlalchemy.orm import object_session
         from src.repositories.entity_domain_association_repository import entity_domain_repo
 
+        # Batch-load domains once for the whole export (avoids N+1), mirroring the
+        # list/search paths. get_domains_for_entities already orders primary-first.
+        _session = object_session(assets[0]) if assets else None
+        domains_map = entity_domain_repo.get_domains_for_entities(
+            _session, entity_type="asset", entity_ids=[str(a.id) for a in assets]
+        ) if _session is not None and assets else {}
+
         rows = []
         for a in assets:
             # Emit domain_ids as a semicolon-separated list, primary first (round-trips on import).
-            _session = object_session(a)
-            domain_ids_str = ""
-            if _session is not None:
-                assigned = entity_domain_repo.get_domains_for_entity(
-                    _session, entity_type="asset", entity_id=str(a.id)
-                )
-                domain_ids_str = ";".join(d.domain_id for d in assigned)
+            assigned = domains_map.get(str(a.id), [])
+            domain_ids_str = ";".join(d.domain_id for d in assigned)
             rows.append({
                 "id": str(a.id),
                 "name": a.name or "",

--- a/src/backend/src/controller/asset_bulk_manager.py
+++ b/src/backend/src/controller/asset_bulk_manager.py
@@ -45,7 +45,7 @@ EXPORT_COLUMNS = [
     "description",
     "platform",
     "location",
-    "domain_id",
+    "domain_ids",
     "status",
     "tags",
     "properties",
@@ -63,7 +63,7 @@ IMPORT_COLUMNS = [
     "description",
     "platform",
     "location",
-    "domain_id",
+    "domain_ids",
     "status",
     "tags",
     "properties",
@@ -151,6 +151,20 @@ class AssetBulkManager:
         self._rel_repo = asset_relationship_repo
         logger.debug("AssetBulkManager initialized.")
 
+    def _set_asset_domains(self, db, asset_id, domain_ids, primary_domain_id, user):
+        """Replace an asset's domain assignments from a bulk-import row (no-op if empty)."""
+        from src.repositories.entity_domain_association_repository import entity_domain_repo
+        if not domain_ids:
+            return
+        try:
+            entity_domain_repo.set_domains_for_entity(
+                db, entity_type="asset", entity_id=str(asset_id),
+                domain_ids=domain_ids, primary_domain_id=primary_domain_id, assigned_by=user,
+            )
+        except ValueError as e:
+            # Unknown domain IDs in the CSV — log and skip rather than fail the whole import.
+            logger.warning(f"Bulk import: domain assignment skipped for asset {asset_id}: {e}")
+
     # ------------------------------------------------------------------
     # Export
     # ------------------------------------------------------------------
@@ -183,7 +197,11 @@ class AssetBulkManager:
             if platform:
                 query = query.filter(AssetDb.platform == platform)
             if domain_id:
-                query = query.filter(AssetDb.domain_id == domain_id)
+                from src.repositories.entity_domain_association_repository import entity_domain_repo
+                asset_ids_for_domain = entity_domain_repo.find_entity_ids_by_domain(
+                    db, domain_id=domain_id, entity_type="asset"
+                )
+                query = query.filter(AssetDb.id.in_(asset_ids_for_domain or ["__none__"]))
             if status:
                 query = query.filter(AssetDb.status == status)
 
@@ -226,8 +244,19 @@ class AssetBulkManager:
         return self._rows_to_csv(rows, columns=IMPORT_COLUMNS), "assets-template.csv", "text/csv"
 
     def _assets_to_rows(self, assets: List[AssetDb]) -> List[Dict[str, str]]:
+        from sqlalchemy.orm import object_session
+        from src.repositories.entity_domain_association_repository import entity_domain_repo
+
         rows = []
         for a in assets:
+            # Emit domain_ids as a semicolon-separated list, primary first (round-trips on import).
+            _session = object_session(a)
+            domain_ids_str = ""
+            if _session is not None:
+                assigned = entity_domain_repo.get_domains_for_entity(
+                    _session, entity_type="asset", entity_id=str(a.id)
+                )
+                domain_ids_str = ";".join(d.domain_id for d in assigned)
             rows.append({
                 "id": str(a.id),
                 "name": a.name or "",
@@ -235,7 +264,7 @@ class AssetBulkManager:
                 "description": a.description or "",
                 "platform": a.platform or "",
                 "location": a.location or "",
-                "domain_id": a.domain_id or "",
+                "domain_ids": domain_ids_str,
                 "status": a.status or "",
                 "tags": _format_tags(a.tags),
                 "properties": _format_properties(a.properties),
@@ -586,7 +615,9 @@ class AssetBulkManager:
             description = row.get("description", "").strip() or None
             platform_val = row.get("platform", "").strip() or None
             location_val = row.get("location", "").strip() or None
-            domain_id_val = row.get("domain_id", "").strip() or None
+            # domain_ids: semicolon-separated; the first entry is treated as primary.
+            domain_ids_val = [d.strip() for d in row.get("domain_ids", "").split(";") if d.strip()]
+            primary_domain_val = domain_ids_val[0] if domain_ids_val else None
             status_val = AssetStatus(status_raw) if status_raw else AssetStatus.ACTIVE
 
             # Determine create vs update
@@ -609,7 +640,6 @@ class AssetBulkManager:
                         asset_type_id=type_id,
                         platform=platform_val,
                         location=location_val,
-                        domain_id=domain_id_val,
                         properties=properties,
                         tags=tags,
                         status=status_val,
@@ -618,6 +648,7 @@ class AssetBulkManager:
                         db=db, db_obj=existing, obj_in=update_data.model_dump(exclude_unset=True)
                     )
                     db.flush()
+                    self._set_asset_domains(db, updated.id, domain_ids_val, primary_domain_val, current_user_id)
                     item.action = ImportAction.UPDATE
                     item.asset_id = str(updated.id)
                     result.updated += 1
@@ -630,7 +661,6 @@ class AssetBulkManager:
                     if existing:
                         update_data = AssetUpdate(
                             description=description,
-                            domain_id=domain_id_val,
                             properties=properties,
                             tags=tags,
                             status=status_val,
@@ -639,6 +669,7 @@ class AssetBulkManager:
                             db=db, db_obj=existing, obj_in=update_data.model_dump(exclude_unset=True)
                         )
                         db.flush()
+                        self._set_asset_domains(db, updated.id, domain_ids_val, primary_domain_val, current_user_id)
                         item.action = ImportAction.UPDATE
                         item.asset_id = str(updated.id)
                         result.updated += 1
@@ -650,7 +681,6 @@ class AssetBulkManager:
                             "asset_type_id": type_id,
                             "platform": platform_val,
                             "location": location_val,
-                            "domain_id": domain_id_val,
                             "properties": properties,
                             "tags": tags,
                             "status": status_val.value,
@@ -660,6 +690,7 @@ class AssetBulkManager:
                         db.add(db_asset)
                         db.flush()
                         db.refresh(db_asset)
+                        self._set_asset_domains(db, db_asset.id, domain_ids_val, primary_domain_val, current_user_id)
                         item.action = ImportAction.CREATE
                         item.asset_id = str(db_asset.id)
                         result.created += 1

--- a/src/backend/src/controller/asset_bulk_manager.py
+++ b/src/backend/src/controller/asset_bulk_manager.py
@@ -201,7 +201,9 @@ class AssetBulkManager:
                 asset_ids_for_domain = entity_domain_repo.find_entity_ids_by_domain(
                     db, domain_id=domain_id, entity_type="asset"
                 )
-                query = query.filter(AssetDb.id.in_(asset_ids_for_domain or ["__none__"]))
+                # Empty list -> always-false predicate (no rows). A string sentinel
+                # would crash: AssetDb.id is a Postgres UUID column.
+                query = query.filter(AssetDb.id.in_(asset_ids_for_domain))
             if status:
                 query = query.filter(AssetDb.status == status)
 
@@ -616,7 +618,10 @@ class AssetBulkManager:
             platform_val = row.get("platform", "").strip() or None
             location_val = row.get("location", "").strip() or None
             # domain_ids: semicolon-separated; the first entry is treated as primary.
-            domain_ids_val = [d.strip() for d in row.get("domain_ids", "").split(";") if d.strip()]
+            # Accept the legacy single-value "domain_id" header too, so CSVs exported by
+            # the pre-#520 version still round-trip their domain on re-import.
+            domain_ids_raw = row.get("domain_ids", "") or row.get("domain_id", "")
+            domain_ids_val = [d.strip() for d in domain_ids_raw.split(";") if d.strip()]
             primary_domain_val = domain_ids_val[0] if domain_ids_val else None
             status_val = AssetStatus(status_raw) if status_raw else AssetStatus.ACTIVE
 

--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -589,20 +589,27 @@ class AssetsManager(SearchableAsset):
     # SearchableAsset implementation
     # ------------------------------------------------------------------
 
-    def _build_search_index_item(self, asset_db_obj: AssetDb) -> Optional[SearchIndexItem]:
-        """Convert a single asset DB object to a SearchIndexItem. Returns None for retired assets."""
+    def _build_search_index_item(self, asset_db_obj: AssetDb, preloaded_domains=None) -> Optional[SearchIndexItem]:
+        """Convert a single asset DB object to a SearchIndexItem. Returns None for retired assets.
+
+        ``preloaded_domains`` (a list of AssignedDomain) lets the bulk indexer batch the
+        junction lookup once instead of querying per asset (avoids N+1); when omitted the
+        single-item path queries via the object's session.
+        """
         if asset_db_obj.status == 'retired':
             return None
         type_name = asset_db_obj.asset_type.name if asset_db_obj.asset_type else 'Asset'
         tags = list(asset_db_obj.tags) if isinstance(asset_db_obj.tags, list) else []
-        _session = object_session(asset_db_obj)
         primary_domain_id = None
-        if _session is not None:
-            # Index every assigned domain NAME so domain-keyed search matches by any of
-            # an entity's domains (primary or additional) — issue #520 story 14.
+        assigned = preloaded_domains
+        if assigned is None:
+            _session = object_session(asset_db_obj)
             assigned = entity_domain_repo.get_domains_for_entity(
                 _session, entity_type="asset", entity_id=str(asset_db_obj.id)
-            )
+            ) if _session is not None else []
+        if assigned:
+            # Index every assigned domain NAME so domain-keyed search matches by any of
+            # an entity's domains (primary or additional) — issue #520 story 14.
             primary_domain_id = next((d.domain_id for d in assigned if d.is_primary), None)
             tags = tags + [d.domain_name for d in assigned if d.domain_name]
         return SearchIndexItem(
@@ -639,8 +646,12 @@ class AssetsManager(SearchableAsset):
 
             with session_factory() as db:
                 all_assets = db.query(AssetDb).filter(AssetDb.status != 'retired').all()
+                # Batch-load domains once for the whole index build (avoids N+1).
+                domains_map = entity_domain_repo.get_domains_for_entities(
+                    db, entity_type="asset", entity_ids=[str(a.id) for a in all_assets]
+                ) if all_assets else {}
                 for a in all_assets:
-                    item = self._build_search_index_item(a)
+                    item = self._build_search_index_item(a, preloaded_domains=domains_map.get(str(a.id), []))
                     if item is not None:
                         items.append(item)
 

--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -349,8 +349,20 @@ class AssetsManager(SearchableAsset):
             db, skip=skip, limit=limit, **filter_kwargs,
         )
         total = self._asset_repo.count_filtered(db, **filter_kwargs)
+        summaries = [self._asset_to_summary(a) for a in db_assets]
+        # Batch-load domain assignments for the page (avoids N+1) and attach to summaries
+        # so list rows show domain badges and edit dialogs preserve domains on save (#520).
+        if summaries:
+            domains_map = entity_domain_repo.get_domains_for_entities(
+                db, entity_type="asset", entity_ids=[str(s.id) for s in summaries]
+            )
+            for s in summaries:
+                assigned = domains_map.get(str(s.id), [])
+                s.domains = assigned
+                s.domain_ids = [d.domain_id for d in assigned]
+                s.primary_domain_id = next((d.domain_id for d in assigned if d.is_primary), None)
         return PaginatedAssetSummary(
-            items=[self._asset_to_summary(a) for a in db_assets],
+            items=summaries,
             total=total,
             skip=skip,
             limit=limit,

--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -582,12 +582,17 @@ class AssetsManager(SearchableAsset):
         if asset_db_obj.status == 'retired':
             return None
         type_name = asset_db_obj.asset_type.name if asset_db_obj.asset_type else 'Asset'
-        tags = asset_db_obj.tags if isinstance(asset_db_obj.tags, list) else []
+        tags = list(asset_db_obj.tags) if isinstance(asset_db_obj.tags, list) else []
         _session = object_session(asset_db_obj)
-        primary_domain_id = (
-            entity_domain_repo.get_primary_domain_id(_session, entity_type="asset", entity_id=str(asset_db_obj.id))
-            if _session is not None else None
-        )
+        primary_domain_id = None
+        if _session is not None:
+            # Index every assigned domain NAME so domain-keyed search matches by any of
+            # an entity's domains (primary or additional) — issue #520 story 14.
+            assigned = entity_domain_repo.get_domains_for_entity(
+                _session, entity_type="asset", entity_id=str(asset_db_obj.id)
+            )
+            primary_domain_id = next((d.domain_id for d in assigned if d.is_primary), None)
+            tags = tags + [d.domain_name for d in assigned if d.domain_name]
         return SearchIndexItem(
             id=f"asset::{asset_db_obj.id}",
             type=f"asset-{type_name.lower().replace(' ', '-')}",

--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -1,11 +1,12 @@
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, object_session
 from sqlalchemy.exc import IntegrityError
 
 from src.repositories.assets_repository import asset_type_repo, asset_repo, asset_relationship_repo
 from src.common.version_visibility import is_visible_consumer
+from src.repositories.entity_domain_association_repository import entity_domain_repo
 from src.models.assets import (
     AssetTypeCreate, AssetTypeUpdate, AssetTypeRead, AssetTypeSummary,
     AssetCreate, AssetUpdate, AssetRead, AssetSummary,
@@ -55,6 +56,15 @@ class AssetsManager(SearchableAsset):
         if db_asset.target_relationships:
             rels.extend([AssetRelationshipRead.model_validate(r) for r in db_asset.target_relationships])
         read.relationships = rels
+        # Attach polymorphic domain assignments from the junction table.
+        session = object_session(db_asset)
+        if session is not None:
+            assigned = entity_domain_repo.get_domains_for_entity(
+                session, entity_type="asset", entity_id=str(db_asset.id)
+            )
+            read.domains = assigned
+            read.domain_ids = [d.domain_id for d in assigned]
+            read.primary_domain_id = next((d.domain_id for d in assigned if d.is_primary), None)
         return read
 
     # Hierarchical relationship types where source = parent, target = child
@@ -78,7 +88,7 @@ class AssetsManager(SearchableAsset):
     # inside the free-form ``properties`` dict.
     _TOP_LEVEL_ASSET_FIELDS = frozenset({
         "name", "description", "status", "platform", "location",
-        "domain_id", "tags",
+        "domain_ids", "primary_domain_id", "tags",
     })
 
     def _validate_properties(self, db: Session, asset_type_id: UUID, properties: Optional[Dict[str, Any]]) -> None:
@@ -205,6 +215,8 @@ class AssetsManager(SearchableAsset):
         self._validate_properties(db, asset_in.asset_type_id, asset_in.properties)
 
         data = asset_in.model_dump()
+        domain_ids = data.pop("domain_ids", None) or []
+        primary_domain_id = data.pop("primary_domain_id", None)
         data["created_by"] = current_user_id
         db_asset = AssetDb(**data)
 
@@ -212,6 +224,13 @@ class AssetsManager(SearchableAsset):
             db.add(db_asset)
             db.flush()
             db.refresh(db_asset)
+            # Assign domains via the junction table.
+            if domain_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="asset", entity_id=str(db_asset.id),
+                    domain_ids=domain_ids, primary_domain_id=primary_domain_id,
+                    assigned_by=current_user_id,
+                )
             # Reload with relationships
             db_asset = self._asset_repo.get_with_relationships(db, db_asset.id)
             logger.info(f"Created asset '{db_asset.name}' (id: {db_asset.id})")
@@ -310,6 +329,7 @@ class AssetsManager(SearchableAsset):
         self, db: Session, *, skip: int = 0, limit: int = 100,
         asset_type_id: Optional[UUID] = None, asset_type_names: Optional[List[str]] = None,
         platform: Optional[str] = None, domain_id: Optional[str] = None,
+        domain_ids: Optional[List[str]] = None,
         status: Optional[str] = None, name: Optional[str] = None,
         restrict_to_ids: Optional[List[UUID]] = None,
     ) -> PaginatedAssetSummary:
@@ -317,11 +337,12 @@ class AssetsManager(SearchableAsset):
 
         ``restrict_to_ids`` (when not None) limits results to the given asset
         UUIDs — used by role-aware Data Product scoping. An empty list
-        intentionally yields zero results.
+        intentionally yields zero results. Domain filtering (``domain_id`` /
+        ``domain_ids``) is any-of via the junction table.
         """
         filter_kwargs = dict(
             asset_type_id=asset_type_id, asset_type_names=asset_type_names,
-            platform=platform, domain_id=domain_id, status=status, name=name,
+            platform=platform, domain_id=domain_id, domain_ids=domain_ids, status=status, name=name,
             restrict_to_ids=restrict_to_ids,
         )
         db_assets = self._asset_repo.get_multi_filtered(
@@ -350,10 +371,20 @@ class AssetsManager(SearchableAsset):
             self._validate_properties(db, effective_type_id, asset_in.properties)
 
         update_data = asset_in.model_dump(exclude_unset=True)
+        domains_provided = 'domain_ids' in update_data
+        domain_ids = update_data.pop('domain_ids', None) or []
+        primary_domain_id = update_data.pop('primary_domain_id', None)
         try:
             updated = self._asset_repo.update(db=db, db_obj=db_asset, obj_in=update_data)
             db.flush()
             db.refresh(updated)
+            # Replace domain assignments if the caller supplied domain_ids.
+            if domains_provided:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="asset", entity_id=str(updated.id),
+                    domain_ids=domain_ids, primary_domain_id=primary_domain_id,
+                    assigned_by=current_user_id,
+                )
             updated = self._asset_repo.get_with_relationships(db, updated.id)
             logger.info(f"Updated asset '{updated.name}' (id: {asset_id})")
             try:
@@ -381,6 +412,7 @@ class AssetsManager(SearchableAsset):
             raise NotFoundError(f"Asset '{asset_id}' not found.")
 
         read = self._asset_to_read(db_asset)
+        entity_domain_repo.remove_all_for_entity(db, entity_type="asset", entity_id=str(asset_id))
         self._asset_repo.remove(db=db, id=asset_id)
         self._notify_index_remove(f"asset::{asset_id}")
         logger.info(f"Deleted asset '{read.name}' (id: {asset_id})")
@@ -551,6 +583,11 @@ class AssetsManager(SearchableAsset):
             return None
         type_name = asset_db_obj.asset_type.name if asset_db_obj.asset_type else 'Asset'
         tags = asset_db_obj.tags if isinstance(asset_db_obj.tags, list) else []
+        _session = object_session(asset_db_obj)
+        primary_domain_id = (
+            entity_domain_repo.get_primary_domain_id(_session, entity_type="asset", entity_id=str(asset_db_obj.id))
+            if _session is not None else None
+        )
         return SearchIndexItem(
             id=f"asset::{asset_db_obj.id}",
             type=f"asset-{type_name.lower().replace(' ', '-')}",
@@ -563,7 +600,7 @@ class AssetsManager(SearchableAsset):
                 "asset_type": type_name,
                 "platform": asset_db_obj.platform or '',
                 "status": asset_db_obj.status or '',
-                "domain_id": str(asset_db_obj.domain_id) if asset_db_obj.domain_id else '',
+                "domain_id": primary_domain_id or '',
             },
         )
 

--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -587,20 +587,27 @@ class AssetsManager(SearchableAsset):
     # SearchableAsset implementation
     # ------------------------------------------------------------------
 
-    def _build_search_index_item(self, asset_db_obj: AssetDb) -> Optional[SearchIndexItem]:
-        """Convert a single asset DB object to a SearchIndexItem. Returns None for retired assets."""
+    def _build_search_index_item(self, asset_db_obj: AssetDb, preloaded_domains=None) -> Optional[SearchIndexItem]:
+        """Convert a single asset DB object to a SearchIndexItem. Returns None for retired assets.
+
+        ``preloaded_domains`` (a list of AssignedDomain) lets the bulk indexer batch the
+        junction lookup once instead of querying per asset (avoids N+1); when omitted the
+        single-item path queries via the object's session.
+        """
         if asset_db_obj.status == 'retired':
             return None
         type_name = asset_db_obj.asset_type.name if asset_db_obj.asset_type else 'Asset'
         tags = list(asset_db_obj.tags) if isinstance(asset_db_obj.tags, list) else []
-        _session = object_session(asset_db_obj)
         primary_domain_id = None
-        if _session is not None:
-            # Index every assigned domain NAME so domain-keyed search matches by any of
-            # an entity's domains (primary or additional) — issue #520 story 14.
+        assigned = preloaded_domains
+        if assigned is None:
+            _session = object_session(asset_db_obj)
             assigned = entity_domain_repo.get_domains_for_entity(
                 _session, entity_type="asset", entity_id=str(asset_db_obj.id)
-            )
+            ) if _session is not None else []
+        if assigned:
+            # Index every assigned domain NAME so domain-keyed search matches by any of
+            # an entity's domains (primary or additional) — issue #520 story 14.
             primary_domain_id = next((d.domain_id for d in assigned if d.is_primary), None)
             tags = tags + [d.domain_name for d in assigned if d.domain_name]
         return SearchIndexItem(
@@ -637,8 +644,12 @@ class AssetsManager(SearchableAsset):
 
             with session_factory() as db:
                 all_assets = db.query(AssetDb).filter(AssetDb.status != 'retired').all()
+                # Batch-load domains once for the whole index build (avoids N+1).
+                domains_map = entity_domain_repo.get_domains_for_entities(
+                    db, entity_type="asset", entity_ids=[str(a.id) for a in all_assets]
+                ) if all_assets else {}
                 for a in all_assets:
-                    item = self._build_search_index_item(a)
+                    item = self._build_search_index_item(a, preloaded_domains=domains_map.get(str(a.id), []))
                     if item is not None:
                         items.append(item)
 

--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -347,8 +347,20 @@ class AssetsManager(SearchableAsset):
             db, skip=skip, limit=limit, **filter_kwargs,
         )
         total = self._asset_repo.count_filtered(db, **filter_kwargs)
+        summaries = [self._asset_to_summary(a) for a in db_assets]
+        # Batch-load domain assignments for the page (avoids N+1) and attach to summaries
+        # so list rows show domain badges and edit dialogs preserve domains on save (#520).
+        if summaries:
+            domains_map = entity_domain_repo.get_domains_for_entities(
+                db, entity_type="asset", entity_ids=[str(s.id) for s in summaries]
+            )
+            for s in summaries:
+                assigned = domains_map.get(str(s.id), [])
+                s.domains = assigned
+                s.domain_ids = [d.domain_id for d in assigned]
+                s.primary_domain_id = next((d.domain_id for d in assigned if d.is_primary), None)
         return PaginatedAssetSummary(
-            items=[self._asset_to_summary(a) for a in db_assets],
+            items=summaries,
             total=total,
             skip=skip,
             limit=limit,

--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -580,12 +580,17 @@ class AssetsManager(SearchableAsset):
         if asset_db_obj.status == 'retired':
             return None
         type_name = asset_db_obj.asset_type.name if asset_db_obj.asset_type else 'Asset'
-        tags = asset_db_obj.tags if isinstance(asset_db_obj.tags, list) else []
+        tags = list(asset_db_obj.tags) if isinstance(asset_db_obj.tags, list) else []
         _session = object_session(asset_db_obj)
-        primary_domain_id = (
-            entity_domain_repo.get_primary_domain_id(_session, entity_type="asset", entity_id=str(asset_db_obj.id))
-            if _session is not None else None
-        )
+        primary_domain_id = None
+        if _session is not None:
+            # Index every assigned domain NAME so domain-keyed search matches by any of
+            # an entity's domains (primary or additional) — issue #520 story 14.
+            assigned = entity_domain_repo.get_domains_for_entity(
+                _session, entity_type="asset", entity_id=str(asset_db_obj.id)
+            )
+            primary_domain_id = next((d.domain_id for d in assigned if d.is_primary), None)
+            tags = tags + [d.domain_name for d in assigned if d.domain_name]
         return SearchIndexItem(
             id=f"asset::{asset_db_obj.id}",
             type=f"asset-{type_name.lower().replace(' ', '-')}",

--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -1,10 +1,11 @@
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, object_session
 from sqlalchemy.exc import IntegrityError
 
 from src.repositories.assets_repository import asset_type_repo, asset_repo, asset_relationship_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
 from src.models.assets import (
     AssetTypeCreate, AssetTypeUpdate, AssetTypeRead, AssetTypeSummary,
     AssetCreate, AssetUpdate, AssetRead, AssetSummary,
@@ -54,6 +55,15 @@ class AssetsManager(SearchableAsset):
         if db_asset.target_relationships:
             rels.extend([AssetRelationshipRead.model_validate(r) for r in db_asset.target_relationships])
         read.relationships = rels
+        # Attach polymorphic domain assignments from the junction table.
+        session = object_session(db_asset)
+        if session is not None:
+            assigned = entity_domain_repo.get_domains_for_entity(
+                session, entity_type="asset", entity_id=str(db_asset.id)
+            )
+            read.domains = assigned
+            read.domain_ids = [d.domain_id for d in assigned]
+            read.primary_domain_id = next((d.domain_id for d in assigned if d.is_primary), None)
         return read
 
     # Hierarchical relationship types where source = parent, target = child
@@ -77,7 +87,7 @@ class AssetsManager(SearchableAsset):
     # inside the free-form ``properties`` dict.
     _TOP_LEVEL_ASSET_FIELDS = frozenset({
         "name", "description", "status", "platform", "location",
-        "domain_id", "tags",
+        "domain_ids", "primary_domain_id", "tags",
     })
 
     def _validate_properties(self, db: Session, asset_type_id: UUID, properties: Optional[Dict[str, Any]]) -> None:
@@ -204,6 +214,8 @@ class AssetsManager(SearchableAsset):
         self._validate_properties(db, asset_in.asset_type_id, asset_in.properties)
 
         data = asset_in.model_dump()
+        domain_ids = data.pop("domain_ids", None) or []
+        primary_domain_id = data.pop("primary_domain_id", None)
         data["created_by"] = current_user_id
         db_asset = AssetDb(**data)
 
@@ -211,6 +223,13 @@ class AssetsManager(SearchableAsset):
             db.add(db_asset)
             db.flush()
             db.refresh(db_asset)
+            # Assign domains via the junction table.
+            if domain_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="asset", entity_id=str(db_asset.id),
+                    domain_ids=domain_ids, primary_domain_id=primary_domain_id,
+                    assigned_by=current_user_id,
+                )
             # Reload with relationships
             db_asset = self._asset_repo.get_with_relationships(db, db_asset.id)
             logger.info(f"Created asset '{db_asset.name}' (id: {db_asset.id})")
@@ -308,6 +327,7 @@ class AssetsManager(SearchableAsset):
         self, db: Session, *, skip: int = 0, limit: int = 100,
         asset_type_id: Optional[UUID] = None, asset_type_names: Optional[List[str]] = None,
         platform: Optional[str] = None, domain_id: Optional[str] = None,
+        domain_ids: Optional[List[str]] = None,
         status: Optional[str] = None, name: Optional[str] = None,
         restrict_to_ids: Optional[List[UUID]] = None,
     ) -> PaginatedAssetSummary:
@@ -315,11 +335,12 @@ class AssetsManager(SearchableAsset):
 
         ``restrict_to_ids`` (when not None) limits results to the given asset
         UUIDs — used by role-aware Data Product scoping. An empty list
-        intentionally yields zero results.
+        intentionally yields zero results. Domain filtering (``domain_id`` /
+        ``domain_ids``) is any-of via the junction table.
         """
         filter_kwargs = dict(
             asset_type_id=asset_type_id, asset_type_names=asset_type_names,
-            platform=platform, domain_id=domain_id, status=status, name=name,
+            platform=platform, domain_id=domain_id, domain_ids=domain_ids, status=status, name=name,
             restrict_to_ids=restrict_to_ids,
         )
         db_assets = self._asset_repo.get_multi_filtered(
@@ -348,10 +369,20 @@ class AssetsManager(SearchableAsset):
             self._validate_properties(db, effective_type_id, asset_in.properties)
 
         update_data = asset_in.model_dump(exclude_unset=True)
+        domains_provided = 'domain_ids' in update_data
+        domain_ids = update_data.pop('domain_ids', None) or []
+        primary_domain_id = update_data.pop('primary_domain_id', None)
         try:
             updated = self._asset_repo.update(db=db, db_obj=db_asset, obj_in=update_data)
             db.flush()
             db.refresh(updated)
+            # Replace domain assignments if the caller supplied domain_ids.
+            if domains_provided:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="asset", entity_id=str(updated.id),
+                    domain_ids=domain_ids, primary_domain_id=primary_domain_id,
+                    assigned_by=current_user_id,
+                )
             updated = self._asset_repo.get_with_relationships(db, updated.id)
             logger.info(f"Updated asset '{updated.name}' (id: {asset_id})")
             try:
@@ -379,6 +410,7 @@ class AssetsManager(SearchableAsset):
             raise NotFoundError(f"Asset '{asset_id}' not found.")
 
         read = self._asset_to_read(db_asset)
+        entity_domain_repo.remove_all_for_entity(db, entity_type="asset", entity_id=str(asset_id))
         self._asset_repo.remove(db=db, id=asset_id)
         self._notify_index_remove(f"asset::{asset_id}")
         logger.info(f"Deleted asset '{read.name}' (id: {asset_id})")
@@ -549,6 +581,11 @@ class AssetsManager(SearchableAsset):
             return None
         type_name = asset_db_obj.asset_type.name if asset_db_obj.asset_type else 'Asset'
         tags = asset_db_obj.tags if isinstance(asset_db_obj.tags, list) else []
+        _session = object_session(asset_db_obj)
+        primary_domain_id = (
+            entity_domain_repo.get_primary_domain_id(_session, entity_type="asset", entity_id=str(asset_db_obj.id))
+            if _session is not None else None
+        )
         return SearchIndexItem(
             id=f"asset::{asset_db_obj.id}",
             type=f"asset-{type_name.lower().replace(' ', '-')}",
@@ -561,7 +598,7 @@ class AssetsManager(SearchableAsset):
                 "asset_type": type_name,
                 "platform": asset_db_obj.platform or '',
                 "status": asset_db_obj.status or '',
-                "domain_id": str(asset_db_obj.domain_id) if asset_db_obj.domain_id else '',
+                "domain_id": primary_domain_id or '',
             },
         )
 

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -345,8 +345,11 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
 
     # --- Implementation of SearchableAsset --- 
 
-    def _build_search_index_item(self, contract_db_obj, db, preloaded_tags=None) -> Optional[SearchIndexItem]:
-        """Build a SearchIndexItem from a contract DB object. Returns None if id or name missing."""
+    def _build_search_index_item(self, contract_db_obj, db, preloaded_tags=None, preloaded_domains=None) -> Optional[SearchIndexItem]:
+        """Build a SearchIndexItem from a contract DB object. Returns None if id or name missing.
+
+        ``preloaded_domains`` (list of AssignedDomain) lets the bulk indexer batch the junction
+        lookup once instead of querying per contract; when omitted it queries per contract."""
         contract_id = getattr(contract_db_obj, 'id', None)
         name = getattr(contract_db_obj, 'name', None)
         if not contract_id or not name:
@@ -399,7 +402,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         # contract's domains (primary or additional) — issue #520 story 14.
         primary_domain = ""
         try:
-            assigned = entity_domain_repo.get_domains_for_entity(
+            assigned = preloaded_domains if preloaded_domains is not None else entity_domain_repo.get_domains_for_entity(
                 db, entity_type="data_contract", entity_id=str(contract_id)
             )
             primary_domain = next((d.domain_name for d in assigned if d.is_primary), "") or ""
@@ -455,8 +458,21 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 except Exception as e:
                     logger.debug(f"Batch tag loading for search index failed: {e}")
 
+                # Batch-load domains for all contracts at once (avoids N+1).
+                batch_domains: dict = {}
+                try:
+                    batch_domains = entity_domain_repo.get_domains_for_entities(
+                        db, entity_type="data_contract", entity_ids=contract_ids
+                    )
+                except Exception as e:
+                    logger.debug(f"Batch domain loading for search index failed: {e}")
+
                 for contract_db in contracts_db:
-                    item = self._build_search_index_item(contract_db, db, preloaded_tags=batch_tags.get(str(contract_db.id), []))
+                    item = self._build_search_index_item(
+                        contract_db, db,
+                        preloaded_tags=batch_tags.get(str(contract_db.id), []),
+                        preloaded_domains=batch_domains.get(str(contract_db.id), []),
+                    )
                     if item:
                         items.append(item)
 

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -394,13 +394,24 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 logger.debug(f"Could not load unified tags for contract {contract_id}: {tag_err}")
 
         owner = ""
-        domain = ""
+
+        # Index every assigned domain NAME so domain-keyed search matches by any of the
+        # contract's domains (primary or additional) — issue #520 story 14.
+        primary_domain = ""
+        try:
+            assigned = entity_domain_repo.get_domains_for_entity(
+                db, entity_type="data_contract", entity_id=str(contract_id)
+            )
+            primary_domain = next((d.domain_name for d in assigned if d.is_primary), "") or ""
+            tag_names = tag_names + [d.domain_name for d in assigned if d.domain_name]
+        except Exception as dom_err:
+            logger.debug(f"Could not load domains for contract {contract_id} search index: {dom_err}")
 
         extra_data = {
             "version": str(version) if version else "",
             "status": str(status) if status else "",
             "owner": owner,
-            "domain": domain,
+            "domain": primary_domain,
         }
 
         return SearchIndexItem(
@@ -6060,6 +6071,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         latest_only=True,
         status=None,
         *,
+        domain_ids=None,
         caller_email: Optional[str] = None,
         caller_team_ids: Optional[Set[str]] = None,
     ):
@@ -6079,10 +6091,13 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             is_visible_consumer,
         )
 
-        if domain_id:
+        wanted_domain_ids = list(domain_ids or [])
+        if domain_id and domain_id not in wanted_domain_ids:
+            wanted_domain_ids.append(domain_id)
+        if wanted_domain_ids:
             # Any-of domain filter via the junction table (primary OR additional).
-            contract_ids = entity_domain_repo.find_entity_ids_by_domain(
-                db, domain_id=domain_id, entity_type="data_contract"
+            contract_ids = entity_domain_repo.find_entity_ids_by_domains(
+                db, domain_ids=wanted_domain_ids, entity_type="data_contract"
             )
             query = db.query(DataContractDb).filter(DataContractDb.id.in_(contract_ids or ["__none__"]))
             if not is_admin and project_id:
@@ -6160,6 +6175,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         latest_only: bool = True,
         include_history: bool = False,
         *,
+        domain_ids: Optional[List[str]] = None,
         caller_email: Optional[str] = None,
         caller_team_ids: Optional[Set[str]] = None,
     ):
@@ -6179,6 +6195,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             is_admin,
             latest_only,
             status=status,
+            domain_ids=domain_ids,
             caller_email=caller_email,
             caller_team_ids=caller_team_ids,
         )

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -1454,7 +1454,11 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 if getattr(prop, 'stable_id', None):
                     cp_item['id'] = prop.stable_id
                 custom_props_list.append(cp_item)
-            odcs['customProperties'] = custom_props_list
+            # Preserve the additionalDomains entry apply_odcs injected above; a plain
+            # overwrite here drops additional domains on export/round-trip.
+            odcs['customProperties'] = domain_export_adapter.merge_custom_properties(
+                custom_props_list, odcs.get('customProperties')
+            )
 
         # Build authoritative definitions
         if hasattr(db_obj, 'authoritative_defs') and db_obj.authoritative_defs:

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -57,6 +57,8 @@ from src.db_models.data_contracts import (
 )
 from src.repositories.data_contracts_repository import data_contract_repo
 from src.repositories.teams_repository import team_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
+from src.controller.domain_export_adapter import domain_export_adapter
 
 from src.common.logging import get_logger
 from src.common.delivery_mixin import DeliveryMixin
@@ -790,19 +792,14 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             'status': db_obj.status,
         }
         
-        # Resolve and include domain name if domain_id is set
-        domain_resolution_failed = False
+        # Apply multi-domain fields via the export adapter: primary name in `domain`,
+        # additional domains under customProperties.additionalDomains, plus app round-trip
+        # keys (domainIds / primaryDomainId). Best-effort; skip if resolution fails.
         try:
-            if getattr(db_obj, 'domain_id', None) and db_session is not None:
-                from src.repositories.data_domain_repository import data_domain_repo
-                domain = data_domain_repo.get(db_session, id=db_obj.domain_id)
-                if domain and getattr(domain, 'name', None):
-                    odcs['domain'] = domain.name
+            if db_session is not None:
+                domain_export_adapter.apply_odcs(odcs, db_session, "data_contract", db_obj.id)
         except Exception:
-            # Best-effort; skip if resolution fails
-            domain_resolution_failed = True
-
-        # Do not emit domainId in ODCS export; only emit human-readable domain name when resolvable
+            logger.warning("Failed to apply domain fields for contract %s", getattr(db_obj, 'id', '?'))
 
         # Add optional top-level fields
         if db_obj.tenant:
@@ -1641,7 +1638,37 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         except Exception as e:
             logger.warning(f"Domain resolution failed: {e}")
             return None
-    
+
+    def _resolve_domain_assignment(self, db, data_dict: dict) -> tuple[List[str], Optional[str]]:
+        """Resolve a contract payload's domain assignment to (domain_ids, primary_domain_id).
+
+        Preference order:
+        1. ``domain_ids`` (list of IDs) + optional ``primary_domain_id``.
+        2. Legacy single ``domainId`` (ID) or ``domain`` (name) → single primary.
+        Each ID is validated (and names resolved) via ``_resolve_domain``.
+        """
+        raw_ids = data_dict.get('domain_ids') or data_dict.get('domainIds')
+        if isinstance(raw_ids, list) and raw_ids:
+            resolved = []
+            for did in raw_ids:
+                rid = self._resolve_domain(db, domain_id=str(did))
+                if rid:
+                    resolved.append(rid)
+            primary = data_dict.get('primary_domain_id') or data_dict.get('primaryDomainId')
+            if primary:
+                primary = self._resolve_domain(db, domain_id=str(primary))
+            if primary not in resolved:
+                primary = resolved[0] if resolved else None
+            return resolved, primary
+
+        # Legacy single-domain fallback.
+        single = None
+        if data_dict.get('domainId'):
+            single = self._resolve_domain(db, domain_id=data_dict.get('domainId'))
+        elif data_dict.get('domain'):
+            single = self._resolve_domain(db, domain_name=data_dict.get('domain'))
+        return ([single], single) if single else ([], None)
+
     def _create_schema_objects(self, db, contract_id: str, schema_data: List, current_user: Optional[str] = None):
         """
         Create schema objects and properties for a contract using bulk inserts.
@@ -2227,34 +2254,32 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             if not data_dict.get('name') or not data_dict.get('name', '').strip():
                 raise ValueError("Contract name is required")
             
-            # Resolve domain_id from provided domainId or domain name
-            domain_id = None
-            if data_dict.get('domainId'):
-                domain_id = self._resolve_domain(db, domain_id=data_dict.get('domainId'))
-            elif data_dict.get('domain'):
-                domain_id = self._resolve_domain(db, domain_name=data_dict.get('domain'))
+            # Resolve the domain assignment set (multi-domain). Accepts domain_ids +
+            # primary_domain_id (preferred) and falls back to legacy single domainId/domain name.
+            resolved_domain_ids, resolved_primary_domain_id = self._resolve_domain_assignment(db, data_dict)
 
-            # Reject a duplicate contract name within the same domain. This path
-            # always creates a *new* version family (new versions go through
-            # create_version), so any existing contract sharing the name+domain
-            # is a genuine duplicate, not another version of the same family
-            # (ONT-NEG-002). Name match is case-insensitive.
+            # Reject a duplicate contract name within the same (primary) domain. This
+            # path always creates a *new* version family (new versions go through
+            # create_version), so any existing contract sharing the name + primary
+            # domain is a genuine duplicate, not another version of the same family
+            # (ONT-NEG-002). Name match is case-insensitive. Domain now lives in the
+            # entity_domain_associations junction, so resolve each name match's primary
+            # domain there rather than reading the dropped DataContractDb.domain_id.
             from sqlalchemy import func as _sa_func
             from src.common.errors import ConflictError
             new_name = data_dict.get('name', '').strip()
-            dup_query = db.query(DataContractDb).filter(
+            name_matches = db.query(DataContractDb.id).filter(
                 _sa_func.lower(DataContractDb.name) == new_name.lower()
-            )
-            dup_query = (
-                dup_query.filter(DataContractDb.domain_id == domain_id)
-                if domain_id is not None
-                else dup_query.filter(DataContractDb.domain_id.is_(None))
-            )
-            if dup_query.first() is not None:
-                where = "domain" if domain_id is not None else "global scope"
-                raise ConflictError(
-                    f"A data contract named '{new_name}' already exists in this {where}"
+            ).all()
+            for (existing_id,) in name_matches:
+                existing_primary = entity_domain_repo.get_primary_domain_id(
+                    db, entity_type="data_contract", entity_id=str(existing_id)
                 )
+                if existing_primary == resolved_primary_domain_id:
+                    where = "domain" if resolved_primary_domain_id is not None else "global scope"
+                    raise ConflictError(
+                        f"A data contract named '{new_name}' already exists in this {where}"
+                    )
 
             # Resolve owner team if provided
             owner_team_id = data_dict.get('owner_team_id')
@@ -2308,7 +2333,6 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 api_version=data_dict.get('apiVersion', 'v3.1.0'),
                 tenant=data_dict.get('tenant'),
                 data_product=data_dict.get('dataProduct'),
-                domain_id=domain_id,
                 description_usage=description.get('usage'),
                 description_purpose=description.get('purpose'),
                 description_limitations=description.get('limitations'),
@@ -2316,6 +2340,14 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 updated_by=current_user,
             )
             created = data_contract_repo.create(db=db, obj_in=db_obj)
+
+            # Assign domains via the junction table.
+            if resolved_domain_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_contract", entity_id=created.id,
+                    domain_ids=resolved_domain_ids, primary_domain_id=resolved_primary_domain_id,
+                    assigned_by=current_user,
+                )
             
             # Create schema objects and properties if provided
             if data_dict.get('contract_schema') or data_dict.get('schema'):
@@ -2427,14 +2459,15 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             # Extract tags (handled separately)
             tags_data = data_dict.get('tags')
             
-            # Handle domain_id - convert empty string to None and validate existence
-            domain_id = data_dict.get('domainId')
-            if domain_id is not None:
-                if not domain_id.strip():
-                    domain_id = None
-                else:
-                    domain_id = self._resolve_domain(db, domain_id=domain_id)
-            
+            # Determine whether the caller supplied a domain assignment (multi-domain).
+            domains_provided = any(
+                k in data_dict and data_dict.get(k) is not None
+                for k in ('domain_ids', 'domainIds', 'primary_domain_id', 'primaryDomainId', 'domainId', 'domain')
+            )
+            resolved_domain_ids, resolved_primary_domain_id = (
+                self._resolve_domain_assignment(db, data_dict) if domains_provided else ([], None)
+            )
+
             # Extract description fields from nested dict or flat keys
             description = data_dict.get('description')
             if isinstance(description, str):
@@ -2461,7 +2494,6 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 'description_limitations': desc_limitations,
                 'api_version': data_dict.get('apiVersion'),
                 'kind': data_dict.get('kind'),
-                'domain_id': domain_id,
             }
             for k, v in payload_map.items():
                 if v is not None:
@@ -2473,7 +2505,15 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             logger.info(f"[DEBUG MANAGER] Full update_payload: {update_payload}")
             
             updated = data_contract_repo.update(db=db, db_obj=db_obj, obj_in=update_payload)
-            
+
+            # Replace domain assignments when the caller supplied any domain field.
+            if domains_provided:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_contract", entity_id=updated.id,
+                    domain_ids=resolved_domain_ids, primary_domain_id=resolved_primary_domain_id,
+                    assigned_by=current_user,
+                )
+
             logger.info(f"[DEBUG MANAGER] After update, db_obj.owner_team_id = {updated.owner_team_id}")
             
             # Handle schema objects if provided
@@ -2689,8 +2729,9 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             raise ValueError(f"Contract {contract_id} not found")
         
         contract_name = db_obj.name
-        
-        # Perform deletion
+
+        # Remove domain assignments, then perform deletion
+        entity_domain_repo.remove_all_for_entity(db, entity_type="data_contract", entity_id=contract_id)
         data_contract_repo.remove(db=db, id=contract_id)
         
         # Log to change log for timeline
@@ -2853,15 +2894,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             elif not isinstance(description, dict):
                 description = {}
             
-            # Resolve domain_id from parsed payload
-            domain_id = None
-            parsed_domain_id = parsed_odcs.get('domainId') or parsed_odcs.get('domain_id')
-            parsed_domain_name = parsed_odcs.get('domain')
-            if parsed_domain_id:
-                domain_id = self._resolve_domain(db, domain_id=parsed_domain_id)
-            elif parsed_domain_name:
-                domain_id = self._resolve_domain(db, domain_name=parsed_domain_name)
-            
+            # Resolve the domain assignment from the parsed ODCS payload (primary name +
+            # customProperties.additionalDomains, or app round-trip domainIds).
+            import_domain_ids, import_primary_domain_id = domain_export_adapter.parse_odcs(parsed_odcs, db)
+
             # Try to resolve owner as team name
             owner_team_id = self._resolve_team_name_to_id(db, owner_val)
             
@@ -2886,7 +2922,6 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 tenant=parsed_odcs.get('tenant'),
                 # Store dataProduct from imported ODCS for reference, but actual linkage is via Output Ports
                 data_product=parsed_odcs.get('dataProduct') or parsed_odcs.get('data_product'),
-                domain_id=domain_id,
                 description_usage=description.get('usage'),
                 description_purpose=description.get('purpose'),
                 description_limitations=description.get('limitations'),
@@ -2896,7 +2931,15 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 updated_by=current_user,
             )
             created = data_contract_repo.create(db=db, obj_in=db_obj)
-            
+
+            # Assign imported domains via the junction table.
+            if import_domain_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_contract", entity_id=created.id,
+                    domain_ids=import_domain_ids, primary_domain_id=import_primary_domain_id,
+                    assigned_by=current_user,
+                )
+
             # Parse and create schema objects if present
             # Accept both ODCS standard 'schema' and Pydantic field name 'contract_schema'
             schema_data = parsed_odcs.get('schema') or parsed_odcs.get('contract_schema', [])
@@ -4355,7 +4398,19 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             db.add(new_contract)
             db.flush()
             db.refresh(new_contract)
-            
+
+            # Copy domain assignments from the source contract.
+            src_domains = entity_domain_repo.get_domains_for_entity(
+                db, entity_type="data_contract", entity_id=source_contract.id
+            )
+            if src_domains:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_contract", entity_id=new_contract.id,
+                    domain_ids=[d.domain_id for d in src_domains],
+                    primary_domain_id=next((d.domain_id for d in src_domains if d.is_primary), None),
+                    assigned_by=current_user or "system",
+                )
+
             # Clone all nested entities
             # Tags
             if source_contract.tags:
@@ -4862,7 +4917,6 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             description_usage=original.description_usage,
             description_purpose=original.description_purpose,
             description_limitations=original.description_limitations,
-            domain_id=original.domain_id,
             parent_contract_id=original.id,
             version_family_id=original.version_family_id,
             created_by=current_user,
@@ -4870,9 +4924,22 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         )
         db.add(clone)
         db.flush()
+
+        # Copy the original's domain assignments onto the clone.
+        original_domains = entity_domain_repo.get_domains_for_entity(
+            db, entity_type="data_contract", entity_id=original.id
+        )
+        if original_domains:
+            entity_domain_repo.set_domains_for_entity(
+                db, entity_type="data_contract", entity_id=clone.id,
+                domain_ids=[d.domain_id for d in original_domains],
+                primary_domain_id=next((d.domain_id for d in original_domains if d.is_primary), None),
+                assigned_by=current_user,
+            )
+
         db.commit()
         db.refresh(clone)
-        
+
         self._update_search_index(clone, db)
         return clone
     
@@ -6013,7 +6080,11 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         )
 
         if domain_id:
-            query = db.query(DataContractDb).filter(DataContractDb.domain_id == domain_id)
+            # Any-of domain filter via the junction table (primary OR additional).
+            contract_ids = entity_domain_repo.find_entity_ids_by_domain(
+                db, domain_id=domain_id, entity_type="data_contract"
+            )
+            query = db.query(DataContractDb).filter(DataContractDb.id.in_(contract_ids or ["__none__"]))
             if not is_admin and project_id:
                 logger.debug(f"Filtering contracts by project_id: {project_id} and domain_id: {domain_id}")
                 query = query.filter(
@@ -6131,16 +6202,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if not contracts:
             return []
 
-        # Batch-resolve domain names
-        domain_ids = {c.domain_id for c in contracts if c.domain_id}
-        domain_map = {}
-        if domain_ids:
-            try:
-                from src.db_models.data_domains import DataDomainDb
-                rows = db.query(DataDomainDb.id, DataDomainDb.name).filter(DataDomainDb.id.in_(domain_ids)).all()
-                domain_map = {str(r.id): r.name for r in rows}
-            except Exception as e:
-                logger.debug(f"Batch domain resolution failed: {e}")
+        # Batch-resolve domain assignments via the junction table (any-of, avoids N+1).
+        domains_map = entity_domain_repo.get_domains_for_entities(
+            db, entity_type="data_contract", entity_ids=[c.id for c in contracts]
+        )
 
         # Batch-resolve team names
         team_ids = {c.owner_team_id for c in contracts if c.owner_team_id}
@@ -6213,6 +6278,9 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 family_counts.get(family_id) if family_counts is not None else None
             )
 
+            assigned_domains = domains_map.get(c.id, [])
+            primary_domain = next((d for d in assigned_domains if d.is_primary), None)
+
             results.append(DataContractSummary(
                 id=c.id,
                 name=c.name,
@@ -6225,8 +6293,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 kind=c.kind,
                 apiVersion=c.api_version,
                 tenant=c.tenant,
-                domain=domain_map.get(c.domain_id) if c.domain_id else None,
-                domainId=c.domain_id,
+                domain=primary_domain.domain_name if primary_domain else None,
+                domainId=primary_domain.domain_id if primary_domain else None,
+                domainIds=[d.domain_id for d in assigned_domains],
+                primaryDomainId=primary_domain.domain_id if primary_domain else None,
                 dataProduct=c.data_product,
                 description=description,
                 tags=tags_map.get(c.id, []),
@@ -6267,20 +6337,18 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         from src.repositories.data_domain_repository import data_domain_repo
         from src.repositories.tags_repository import entity_tag_repo
         
-        # Resolve domain name from domain_id if available
-        logger.debug(f"[BUILD API] db_contract.domain_id = {db_contract.domain_id}")
         logger.debug(f"[BUILD API] db_contract.project_id = {db_contract.project_id}")
         logger.debug(f"[BUILD API] db_contract.owner_team_id = {db_contract.owner_team_id}")
-        
-        domain_name = None
-        if db_contract.domain_id:
-            try:
-                domain = data_domain_repo.get(db, id=db_contract.domain_id)
-                if domain:
-                    domain_name = domain.name
-            except Exception as e:
-                logger.warning(f"Failed to resolve domain name for domain_id {db_contract.domain_id}: {e}")
-        
+
+        # Resolve domain assignments from the junction table.
+        assigned_domains = entity_domain_repo.get_domains_for_entity(
+            db, entity_type="data_contract", entity_id=db_contract.id
+        )
+        primary_domain = next((d for d in assigned_domains if d.is_primary), None)
+        domain_name = primary_domain.domain_name if primary_domain else None
+        contract_domain_ids = [d.domain_id for d in assigned_domains]
+        contract_primary_domain_id = primary_domain.domain_id if primary_domain else None
+
         # Build description
         description = None
         if db_contract.description_usage or db_contract.description_purpose or db_contract.description_limitations:
@@ -6521,8 +6589,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             kind=db_contract.kind,
             apiVersion=db_contract.api_version,
             tenant=db_contract.tenant,
-            domain=domain_name,  # Resolved domain name
-            domainId=db_contract.domain_id,  # Provide domain ID for frontend resolution
+            domain=domain_name,  # Primary domain name
+            domainId=contract_primary_domain_id,  # Primary domain ID
+            domainIds=contract_domain_ids,  # All assigned domain IDs (primary first)
+            primaryDomainId=contract_primary_domain_id,
             dataProduct=db_contract.data_product,
             description=description,
             tags=tags,  # Include tags in response

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -405,7 +405,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             primary_domain = next((d.domain_name for d in assigned if d.is_primary), "") or ""
             tag_names = tag_names + [d.domain_name for d in assigned if d.domain_name]
         except Exception as dom_err:
-            logger.debug(f"Could not load domains for contract {contract_id} search index: {dom_err}")
+            logger.debug("Could not load domains for contract %s search index: %s", contract_id, dom_err)
 
         extra_data = {
             "version": str(version) if version else "",

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -57,6 +57,8 @@ from src.db_models.data_contracts import (
 )
 from src.repositories.data_contracts_repository import data_contract_repo
 from src.repositories.teams_repository import team_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
+from src.controller.domain_export_adapter import domain_export_adapter
 
 from src.common.logging import get_logger
 from src.common.delivery_mixin import DeliveryMixin
@@ -790,19 +792,14 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             'status': db_obj.status,
         }
         
-        # Resolve and include domain name if domain_id is set
-        domain_resolution_failed = False
+        # Apply multi-domain fields via the export adapter: primary name in `domain`,
+        # additional domains under customProperties.additionalDomains, plus app round-trip
+        # keys (domainIds / primaryDomainId). Best-effort; skip if resolution fails.
         try:
-            if getattr(db_obj, 'domain_id', None) and db_session is not None:
-                from src.repositories.data_domain_repository import data_domain_repo
-                domain = data_domain_repo.get(db_session, id=db_obj.domain_id)
-                if domain and getattr(domain, 'name', None):
-                    odcs['domain'] = domain.name
+            if db_session is not None:
+                domain_export_adapter.apply_odcs(odcs, db_session, "data_contract", db_obj.id)
         except Exception:
-            # Best-effort; skip if resolution fails
-            domain_resolution_failed = True
-
-        # Do not emit domainId in ODCS export; only emit human-readable domain name when resolvable
+            logger.warning("Failed to apply domain fields for contract %s", getattr(db_obj, 'id', '?'))
 
         # Add optional top-level fields
         if db_obj.tenant:
@@ -1641,7 +1638,37 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         except Exception as e:
             logger.warning(f"Domain resolution failed: {e}")
             return None
-    
+
+    def _resolve_domain_assignment(self, db, data_dict: dict) -> tuple[List[str], Optional[str]]:
+        """Resolve a contract payload's domain assignment to (domain_ids, primary_domain_id).
+
+        Preference order:
+        1. ``domain_ids`` (list of IDs) + optional ``primary_domain_id``.
+        2. Legacy single ``domainId`` (ID) or ``domain`` (name) → single primary.
+        Each ID is validated (and names resolved) via ``_resolve_domain``.
+        """
+        raw_ids = data_dict.get('domain_ids') or data_dict.get('domainIds')
+        if isinstance(raw_ids, list) and raw_ids:
+            resolved = []
+            for did in raw_ids:
+                rid = self._resolve_domain(db, domain_id=str(did))
+                if rid:
+                    resolved.append(rid)
+            primary = data_dict.get('primary_domain_id') or data_dict.get('primaryDomainId')
+            if primary:
+                primary = self._resolve_domain(db, domain_id=str(primary))
+            if primary not in resolved:
+                primary = resolved[0] if resolved else None
+            return resolved, primary
+
+        # Legacy single-domain fallback.
+        single = None
+        if data_dict.get('domainId'):
+            single = self._resolve_domain(db, domain_id=data_dict.get('domainId'))
+        elif data_dict.get('domain'):
+            single = self._resolve_domain(db, domain_name=data_dict.get('domain'))
+        return ([single], single) if single else ([], None)
+
     def _create_schema_objects(self, db, contract_id: str, schema_data: List, current_user: Optional[str] = None):
         """
         Create schema objects and properties for a contract using bulk inserts.
@@ -2205,13 +2232,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             if not data_dict.get('name') or not data_dict.get('name', '').strip():
                 raise ValueError("Contract name is required")
             
-            # Resolve domain_id from provided domainId or domain name
-            domain_id = None
-            if data_dict.get('domainId'):
-                domain_id = self._resolve_domain(db, domain_id=data_dict.get('domainId'))
-            elif data_dict.get('domain'):
-                domain_id = self._resolve_domain(db, domain_name=data_dict.get('domain'))
-            
+            # Resolve the domain assignment set (multi-domain). Accepts domain_ids +
+            # primary_domain_id (preferred) and falls back to legacy single domainId/domain name.
+            resolved_domain_ids, resolved_primary_domain_id = self._resolve_domain_assignment(db, data_dict)
+
             # Resolve owner team if provided
             owner_team_id = data_dict.get('owner_team_id')
             if not owner_team_id and data_dict.get('owner'):
@@ -2248,7 +2272,6 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 api_version=data_dict.get('apiVersion', 'v3.1.0'),
                 tenant=data_dict.get('tenant'),
                 data_product=data_dict.get('dataProduct'),
-                domain_id=domain_id,
                 description_usage=description.get('usage'),
                 description_purpose=description.get('purpose'),
                 description_limitations=description.get('limitations'),
@@ -2256,6 +2279,14 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 updated_by=current_user,
             )
             created = data_contract_repo.create(db=db, obj_in=db_obj)
+
+            # Assign domains via the junction table.
+            if resolved_domain_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_contract", entity_id=created.id,
+                    domain_ids=resolved_domain_ids, primary_domain_id=resolved_primary_domain_id,
+                    assigned_by=current_user,
+                )
             
             # Create schema objects and properties if provided
             if data_dict.get('contract_schema') or data_dict.get('schema'):
@@ -2367,14 +2398,15 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             # Extract tags (handled separately)
             tags_data = data_dict.get('tags')
             
-            # Handle domain_id - convert empty string to None and validate existence
-            domain_id = data_dict.get('domainId')
-            if domain_id is not None:
-                if not domain_id.strip():
-                    domain_id = None
-                else:
-                    domain_id = self._resolve_domain(db, domain_id=domain_id)
-            
+            # Determine whether the caller supplied a domain assignment (multi-domain).
+            domains_provided = any(
+                k in data_dict and data_dict.get(k) is not None
+                for k in ('domain_ids', 'domainIds', 'primary_domain_id', 'primaryDomainId', 'domainId', 'domain')
+            )
+            resolved_domain_ids, resolved_primary_domain_id = (
+                self._resolve_domain_assignment(db, data_dict) if domains_provided else ([], None)
+            )
+
             # Extract description fields from nested dict or flat keys
             description = data_dict.get('description')
             if isinstance(description, str):
@@ -2401,7 +2433,6 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 'description_limitations': desc_limitations,
                 'api_version': data_dict.get('apiVersion'),
                 'kind': data_dict.get('kind'),
-                'domain_id': domain_id,
             }
             for k, v in payload_map.items():
                 if v is not None:
@@ -2413,7 +2444,15 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             logger.info(f"[DEBUG MANAGER] Full update_payload: {update_payload}")
             
             updated = data_contract_repo.update(db=db, db_obj=db_obj, obj_in=update_payload)
-            
+
+            # Replace domain assignments when the caller supplied any domain field.
+            if domains_provided:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_contract", entity_id=updated.id,
+                    domain_ids=resolved_domain_ids, primary_domain_id=resolved_primary_domain_id,
+                    assigned_by=current_user,
+                )
+
             logger.info(f"[DEBUG MANAGER] After update, db_obj.owner_team_id = {updated.owner_team_id}")
             
             # Handle schema objects if provided
@@ -2625,8 +2664,9 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             raise ValueError(f"Contract {contract_id} not found")
         
         contract_name = db_obj.name
-        
-        # Perform deletion
+
+        # Remove domain assignments, then perform deletion
+        entity_domain_repo.remove_all_for_entity(db, entity_type="data_contract", entity_id=contract_id)
         data_contract_repo.remove(db=db, id=contract_id)
         
         # Log to change log for timeline
@@ -2789,15 +2829,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             elif not isinstance(description, dict):
                 description = {}
             
-            # Resolve domain_id from parsed payload
-            domain_id = None
-            parsed_domain_id = parsed_odcs.get('domainId') or parsed_odcs.get('domain_id')
-            parsed_domain_name = parsed_odcs.get('domain')
-            if parsed_domain_id:
-                domain_id = self._resolve_domain(db, domain_id=parsed_domain_id)
-            elif parsed_domain_name:
-                domain_id = self._resolve_domain(db, domain_name=parsed_domain_name)
-            
+            # Resolve the domain assignment from the parsed ODCS payload (primary name +
+            # customProperties.additionalDomains, or app round-trip domainIds).
+            import_domain_ids, import_primary_domain_id = domain_export_adapter.parse_odcs(parsed_odcs, db)
+
             # Try to resolve owner as team name
             owner_team_id = self._resolve_team_name_to_id(db, owner_val)
             
@@ -2822,7 +2857,6 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 tenant=parsed_odcs.get('tenant'),
                 # Store dataProduct from imported ODCS for reference, but actual linkage is via Output Ports
                 data_product=parsed_odcs.get('dataProduct') or parsed_odcs.get('data_product'),
-                domain_id=domain_id,
                 description_usage=description.get('usage'),
                 description_purpose=description.get('purpose'),
                 description_limitations=description.get('limitations'),
@@ -2832,7 +2866,15 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 updated_by=current_user,
             )
             created = data_contract_repo.create(db=db, obj_in=db_obj)
-            
+
+            # Assign imported domains via the junction table.
+            if import_domain_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_contract", entity_id=created.id,
+                    domain_ids=import_domain_ids, primary_domain_id=import_primary_domain_id,
+                    assigned_by=current_user,
+                )
+
             # Parse and create schema objects if present
             # Accept both ODCS standard 'schema' and Pydantic field name 'contract_schema'
             schema_data = parsed_odcs.get('schema') or parsed_odcs.get('contract_schema', [])
@@ -4291,7 +4333,19 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             db.add(new_contract)
             db.flush()
             db.refresh(new_contract)
-            
+
+            # Copy domain assignments from the source contract.
+            src_domains = entity_domain_repo.get_domains_for_entity(
+                db, entity_type="data_contract", entity_id=source_contract.id
+            )
+            if src_domains:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_contract", entity_id=new_contract.id,
+                    domain_ids=[d.domain_id for d in src_domains],
+                    primary_domain_id=next((d.domain_id for d in src_domains if d.is_primary), None),
+                    assigned_by=current_user or "system",
+                )
+
             # Clone all nested entities
             # Tags
             if source_contract.tags:
@@ -4798,7 +4852,6 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             description_usage=original.description_usage,
             description_purpose=original.description_purpose,
             description_limitations=original.description_limitations,
-            domain_id=original.domain_id,
             parent_contract_id=original.id,
             version_family_id=original.version_family_id,
             created_by=current_user,
@@ -4806,9 +4859,22 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         )
         db.add(clone)
         db.flush()
+
+        # Copy the original's domain assignments onto the clone.
+        original_domains = entity_domain_repo.get_domains_for_entity(
+            db, entity_type="data_contract", entity_id=original.id
+        )
+        if original_domains:
+            entity_domain_repo.set_domains_for_entity(
+                db, entity_type="data_contract", entity_id=clone.id,
+                domain_ids=[d.domain_id for d in original_domains],
+                primary_domain_id=next((d.domain_id for d in original_domains if d.is_primary), None),
+                assigned_by=current_user,
+            )
+
         db.commit()
         db.refresh(clone)
-        
+
         self._update_search_index(clone, db)
         return clone
     
@@ -5938,7 +6004,11 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         )
 
         if domain_id:
-            query = db.query(DataContractDb).filter(DataContractDb.domain_id == domain_id)
+            # Any-of domain filter via the junction table (primary OR additional).
+            contract_ids = entity_domain_repo.find_entity_ids_by_domain(
+                db, domain_id=domain_id, entity_type="data_contract"
+            )
+            query = db.query(DataContractDb).filter(DataContractDb.id.in_(contract_ids or ["__none__"]))
             if not is_admin and project_id:
                 logger.debug(f"Filtering contracts by project_id: {project_id} and domain_id: {domain_id}")
                 query = query.filter(
@@ -6044,16 +6114,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if not contracts:
             return []
 
-        # Batch-resolve domain names
-        domain_ids = {c.domain_id for c in contracts if c.domain_id}
-        domain_map = {}
-        if domain_ids:
-            try:
-                from src.db_models.data_domains import DataDomainDb
-                rows = db.query(DataDomainDb.id, DataDomainDb.name).filter(DataDomainDb.id.in_(domain_ids)).all()
-                domain_map = {str(r.id): r.name for r in rows}
-            except Exception as e:
-                logger.debug(f"Batch domain resolution failed: {e}")
+        # Batch-resolve domain assignments via the junction table (any-of, avoids N+1).
+        domains_map = entity_domain_repo.get_domains_for_entities(
+            db, entity_type="data_contract", entity_ids=[c.id for c in contracts]
+        )
 
         # Batch-resolve team names
         team_ids = {c.owner_team_id for c in contracts if c.owner_team_id}
@@ -6126,6 +6190,9 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 family_counts.get(family_id) if family_counts is not None else None
             )
 
+            assigned_domains = domains_map.get(c.id, [])
+            primary_domain = next((d for d in assigned_domains if d.is_primary), None)
+
             results.append(DataContractSummary(
                 id=c.id,
                 name=c.name,
@@ -6138,8 +6205,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 kind=c.kind,
                 apiVersion=c.api_version,
                 tenant=c.tenant,
-                domain=domain_map.get(c.domain_id) if c.domain_id else None,
-                domainId=c.domain_id,
+                domain=primary_domain.domain_name if primary_domain else None,
+                domainId=primary_domain.domain_id if primary_domain else None,
+                domainIds=[d.domain_id for d in assigned_domains],
+                primaryDomainId=primary_domain.domain_id if primary_domain else None,
                 dataProduct=c.data_product,
                 description=description,
                 tags=tags_map.get(c.id, []),
@@ -6180,20 +6249,18 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         from src.repositories.data_domain_repository import data_domain_repo
         from src.repositories.tags_repository import entity_tag_repo
         
-        # Resolve domain name from domain_id if available
-        logger.debug(f"[BUILD API] db_contract.domain_id = {db_contract.domain_id}")
         logger.debug(f"[BUILD API] db_contract.project_id = {db_contract.project_id}")
         logger.debug(f"[BUILD API] db_contract.owner_team_id = {db_contract.owner_team_id}")
-        
-        domain_name = None
-        if db_contract.domain_id:
-            try:
-                domain = data_domain_repo.get(db, id=db_contract.domain_id)
-                if domain:
-                    domain_name = domain.name
-            except Exception as e:
-                logger.warning(f"Failed to resolve domain name for domain_id {db_contract.domain_id}: {e}")
-        
+
+        # Resolve domain assignments from the junction table.
+        assigned_domains = entity_domain_repo.get_domains_for_entity(
+            db, entity_type="data_contract", entity_id=db_contract.id
+        )
+        primary_domain = next((d for d in assigned_domains if d.is_primary), None)
+        domain_name = primary_domain.domain_name if primary_domain else None
+        contract_domain_ids = [d.domain_id for d in assigned_domains]
+        contract_primary_domain_id = primary_domain.domain_id if primary_domain else None
+
         # Build description
         description = None
         if db_contract.description_usage or db_contract.description_purpose or db_contract.description_limitations:
@@ -6434,8 +6501,10 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             kind=db_contract.kind,
             apiVersion=db_contract.api_version,
             tenant=db_contract.tenant,
-            domain=domain_name,  # Resolved domain name
-            domainId=db_contract.domain_id,  # Provide domain ID for frontend resolution
+            domain=domain_name,  # Primary domain name
+            domainId=contract_primary_domain_id,  # Primary domain ID
+            domainIds=contract_domain_ids,  # All assigned domain IDs (primary first)
+            primaryDomainId=contract_primary_domain_id,
             dataProduct=db_contract.data_product,
             description=description,
             tags=tags,  # Include tags in response

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -394,13 +394,24 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
                 logger.debug(f"Could not load unified tags for contract {contract_id}: {tag_err}")
 
         owner = ""
-        domain = ""
+
+        # Index every assigned domain NAME so domain-keyed search matches by any of the
+        # contract's domains (primary or additional) — issue #520 story 14.
+        primary_domain = ""
+        try:
+            assigned = entity_domain_repo.get_domains_for_entity(
+                db, entity_type="data_contract", entity_id=str(contract_id)
+            )
+            primary_domain = next((d.domain_name for d in assigned if d.is_primary), "") or ""
+            tag_names = tag_names + [d.domain_name for d in assigned if d.domain_name]
+        except Exception as dom_err:
+            logger.debug(f"Could not load domains for contract {contract_id} search index: {dom_err}")
 
         extra_data = {
             "version": str(version) if version else "",
             "status": str(status) if status else "",
             "owner": owner,
-            "domain": domain,
+            "domain": primary_domain,
         }
 
         return SearchIndexItem(
@@ -5984,6 +5995,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         is_admin=False,
         latest_only=True,
         *,
+        domain_ids=None,
         caller_email: Optional[str] = None,
         caller_team_ids: Optional[Set[str]] = None,
     ):
@@ -6003,10 +6015,13 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             is_visible_consumer,
         )
 
-        if domain_id:
+        wanted_domain_ids = list(domain_ids or [])
+        if domain_id and domain_id not in wanted_domain_ids:
+            wanted_domain_ids.append(domain_id)
+        if wanted_domain_ids:
             # Any-of domain filter via the junction table (primary OR additional).
-            contract_ids = entity_domain_repo.find_entity_ids_by_domain(
-                db, domain_id=domain_id, entity_type="data_contract"
+            contract_ids = entity_domain_repo.find_entity_ids_by_domains(
+                db, domain_ids=wanted_domain_ids, entity_type="data_contract"
             )
             query = db.query(DataContractDb).filter(DataContractDb.id.in_(contract_ids or ["__none__"]))
             if not is_admin and project_id:
@@ -6073,6 +6088,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         latest_only: bool = True,
         include_history: bool = False,
         *,
+        domain_ids: Optional[List[str]] = None,
         caller_email: Optional[str] = None,
         caller_team_ids: Optional[Set[str]] = None,
     ):
@@ -6091,6 +6107,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
             project_id,
             is_admin,
             latest_only,
+            domain_ids=domain_ids,
             caller_email=caller_email,
             caller_team_ids=caller_team_ids,
         )

--- a/src/backend/src/controller/data_domains_manager.py
+++ b/src/backend/src/controller/data_domains_manager.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 from uuid import UUID
 import json # Import json
 
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session, joinedload, selectinload # Added joinedload,
 from sqlalchemy.exc import IntegrityError # Import IntegrityError
 
 from src.repositories.data_domain_repository import DataDomainRepository
+from src.repositories.entity_domain_association_repository import entity_domain_repo
 from src.models.data_domains import DataDomainCreate, DataDomainUpdate, DataDomainRead, DataDomainBasicInfo # Added DataDomainBasicInfo
 from src.db_models.data_domains import DataDomain
 from src.common.errors import ConflictError, NotFoundError, AppError # Import custom errors, AppError for validation
@@ -286,6 +287,46 @@ class DataDomainManager(DeliveryMixin, SearchableAsset):
             logger.exception(f"Error updating data domain {domain_id}: {e}")
             raise
 
+    @staticmethod
+    def _collect_domain_and_descendant_ids(domain: DataDomain) -> List[str]:
+        """Return the domain's id plus every descendant id (children cascade-delete)."""
+        ids = [str(domain.id)]
+        for child in (domain.children or []):
+            ids.extend(DataDomainManager._collect_domain_and_descendant_ids(child))
+        return ids
+
+    def get_domain_deletion_impact(self, db: Session, domain_id: UUID) -> Dict[str, Any]:
+        """Report which entities would block deletion of a domain and the assignment counts.
+
+        Returns ``{"domain_id", "domain_name", "deletable" (bool), "primary_assignments":
+        [{entity_type, entity_id}], "assignment_counts": {entity_type: {primary, additional}}}``.
+        Lets the UI warn before attempting a delete (which 409s if primary anywhere)."""
+        db_domain = self.repository.get_with_details(db, domain_id)
+        if not db_domain:
+            raise NotFoundError(f"Data domain with id '{domain_id}' not found.")
+
+        affected_domain_ids = self._collect_domain_and_descendant_ids(db_domain)
+        primary_entities: List[Tuple[str, str]] = []
+        assignment_counts: Dict[str, Dict[str, int]] = {}
+        for did in affected_domain_ids:
+            primary_entities.extend(
+                entity_domain_repo.get_entities_with_primary_domain(db, domain_id=did)
+            )
+            for etype, bucket in entity_domain_repo.get_assignment_counts_for_domain(db, domain_id=did).items():
+                agg = assignment_counts.setdefault(etype, {"primary": 0, "additional": 0})
+                agg["primary"] += bucket.get("primary", 0)
+                agg["additional"] += bucket.get("additional", 0)
+
+        return {
+            "domain_id": str(domain_id),
+            "domain_name": db_domain.name,
+            "deletable": len(primary_entities) == 0,
+            "primary_assignments": [
+                {"entity_type": etype, "entity_id": eid} for etype, eid in primary_entities
+            ],
+            "assignment_counts": assignment_counts,
+        }
+
     def delete_domain(self, db: Session, domain_id: UUID, current_user_id: str) -> Optional[DataDomainRead]:
         """Deletes a data domain by its ID."""
         logger.debug(f"Attempting to delete data domain with id: {domain_id}")
@@ -301,13 +342,54 @@ class DataDomainManager(DeliveryMixin, SearchableAsset):
         if db_domain_to_delete.children:
             # Current cascade rule will delete children. If this is not desired, raise error.
             # logger.warning(f"Attempt to delete domain {domain_id} which has {len(db_domain_to_delete.children)} children. Deletion allowed due to cascade rule.")
-            # To prevent deletion: 
+            # To prevent deletion:
             # raise ConflictError(f"Cannot delete domain '{db_domain_to_delete.name}' because it has child domains. Please delete or re-parent children first.")
             pass # Current setup allows cascade delete.
 
+        # Multi-domain assignment (#520): a domain (or any descendant that would be
+        # cascade-deleted with it) that is the PRIMARY domain for any entity cannot be
+        # deleted — the primary feeds single-value integrations (ODCS domain, UC tag).
+        # Domains that are only ever *additional* can be deleted; their association rows
+        # are cleaned up below (the junction FK has no ON DELETE CASCADE).
+        affected_domain_ids = self._collect_domain_and_descendant_ids(db_domain_to_delete)
+        primary_entities: List[Tuple[str, str]] = []
+        for did in affected_domain_ids:
+            primary_entities.extend(
+                entity_domain_repo.get_entities_with_primary_domain(db, domain_id=did)
+            )
+        if primary_entities:
+            assignment_counts: Dict[str, Dict[str, int]] = {}
+            for did in affected_domain_ids:
+                for etype, bucket in entity_domain_repo.get_assignment_counts_for_domain(db, domain_id=did).items():
+                    agg = assignment_counts.setdefault(etype, {"primary": 0, "additional": 0})
+                    agg["primary"] += bucket.get("primary", 0)
+                    agg["additional"] += bucket.get("additional", 0)
+            logger.warning(
+                "Blocking deletion of domain %s ('%s'): primary for %d entity assignment(s).",
+                domain_id, db_domain_to_delete.name, len(primary_entities),
+            )
+            raise ConflictError(detail={
+                "code": "domain_primary_in_use",
+                "message": (
+                    f"Cannot delete domain '{db_domain_to_delete.name}': it is the primary domain "
+                    f"for {len(primary_entities)} entity assignment(s). Reassign those entities to a "
+                    f"different primary domain (or remove the assignment) before deleting."
+                ),
+                "domain_id": str(domain_id),
+                "domain_name": db_domain_to_delete.name,
+                "primary_assignments": [
+                    {"entity_type": etype, "entity_id": eid} for etype, eid in primary_entities
+                ],
+                "assignment_counts": assignment_counts,
+            })
+
         read_model_of_deleted = self._convert_db_to_read_model(db_domain_to_delete, db)
-        
+
         try:
+            # Clean up any additional-only association rows first (FK to data_domains has
+            # no ON DELETE CASCADE), across the domain and its cascade-deleted descendants.
+            for did in affected_domain_ids:
+                entity_domain_repo.remove_all_for_domain(db, domain_id=did)
             # The repository.remove(db, id) should work.
             # The actual object `db_domain_to_delete` will become stale after deletion from session.
             self.repository.remove(db=db, id=domain_id)

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -2479,7 +2479,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             )
             tag_strings = tag_strings + [d.domain_name for d in assigned if d.domain_name]
         except Exception as dom_err:
-            logger.debug(f"Could not load domains for product {product.id} search index: {dom_err}")
+            logger.debug("Could not load domains for product %s search index: %s", product.id, dom_err)
 
         extra_data = {
             "status": product.status or "",

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -2422,7 +2422,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
     # --- SearchableAsset implementation ---
 
-    def _build_search_index_item(self, product: DataProductApi) -> Optional[SearchIndexItem]:
+    def _build_search_index_item(self, product: DataProductApi, preloaded_domains=None) -> Optional[SearchIndexItem]:
         """Convert a single DataProduct API model to a SearchIndexItem."""
         if not product.id or not product.name:
             return None
@@ -2474,7 +2474,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         # Index every assigned domain NAME so domain-keyed search matches by any of the
         # product's domains (primary or additional) — issue #520 story 14.
         try:
-            assigned = entity_domain_repo.get_domains_for_entity(
+            assigned = preloaded_domains if preloaded_domains is not None else entity_domain_repo.get_domains_for_entity(
                 self._db, entity_type="data_product", entity_id=str(product.id)
             )
             tag_strings = tag_strings + [d.domain_name for d in assigned if d.domain_name]
@@ -2519,8 +2519,12 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         items = []
         try:
             products_api = self.list_products(limit=10000, is_admin=True)
+            # Batch-load domains once for the whole index build (avoids N+1).
+            domains_map = entity_domain_repo.get_domains_for_entities(
+                self._db, entity_type="data_product", entity_ids=[str(p.id) for p in products_api]
+            ) if products_api else {}
             for product in products_api:
-                item = self._build_search_index_item(product)
+                item = self._build_search_index_item(product, preloaded_domains=domains_map.get(str(product.id), []))
                 if item:
                     items.append(item)
             logger.info(f"Prepared {len(items)} ODPS products for search index.")

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -116,13 +116,19 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         if not self._tags_manager:
             logger.warning("TagsManager not provided. Tag operations will not be available.")
 
-    def _attach_domains(self, api_obj):
-        """Populate a DataProduct API model's domain fields from the junction table."""
+    def _attach_domains(self, api_obj, db: Optional[Session] = None):
+        """Populate a DataProduct API model's domain fields from the junction table.
+
+        Callers that operate on an explicit session (clone/new-version/import) must pass
+        that ``db`` so associations written-but-not-yet-committed on it are visible;
+        otherwise the manager's own session is used.
+        """
         if api_obj is None or not getattr(api_obj, "id", None):
             return api_obj
+        session = db if db is not None else self._db
         try:
             assigned = entity_domain_repo.get_domains_for_entity(
-                self._db, entity_type="data_product", entity_id=str(api_obj.id)
+                session, entity_type="data_product", entity_id=str(api_obj.id)
             )
             api_obj.domain_ids = [d.domain_id for d in assigned]
             primary = next((d for d in assigned if d.is_primary), None)
@@ -1987,7 +1993,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             db.refresh(new_product)
             
             logger.info(f"Successfully cloned product {product_id} to new version {new_version} (ID: {new_id})")
-            return self._attach_domains(DataProductApi.model_validate(new_product))
+            return self._attach_domains(DataProductApi.model_validate(new_product), db=db)
             
         except SQLAlchemyError as e:
             db.rollback()
@@ -2089,7 +2095,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             db.refresh(draft)
             
             logger.info(f"Committed personal draft {draft_id} as version {new_version}")
-            return self._attach_domains(DataProductApi.model_validate(draft))
+            return self._attach_domains(DataProductApi.model_validate(draft), db=db)
             
         except SQLAlchemyError as e:
             db.rollback()

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -138,20 +138,23 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             logger.warning(f"Failed to attach domains for product {getattr(api_obj, 'id', '?')}: {e}")
         return api_obj
 
-    def _resolve_product_domain_assignment(self, data: dict) -> tuple:
+    def _resolve_product_domain_assignment(self, data: dict, db: Optional[Session] = None) -> tuple:
         """Resolve a product payload to (domain_ids, primary_domain_id).
 
         Prefers domain_ids + primary_domain_id; falls back to the legacy single ``domain``
         (which may be a domain ID or name). Names are resolved via the data domain repo.
+        Uses the caller's ``db`` session when provided so resolution sees rows written in
+        the same request transaction.
         """
         from src.repositories.data_domain_repository import data_domain_repo
+        session = db if db is not None else self._db
 
         def _resolve_one(value):
             if not value:
                 return None
-            if data_domain_repo.get(self._db, value):
+            if data_domain_repo.get(session, value):
                 return value
-            byname = data_domain_repo.get_by_name(self._db, name=value)
+            byname = data_domain_repo.get_by_name(session, name=value)
             return byname.id if byname else None
 
         raw_ids = data.get('domain_ids')
@@ -246,7 +249,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
             # Assign domains via the junction table (accepts domain_ids/primary_domain_id
             # or legacy single `domain` id/name).
-            prod_domain_ids, prod_primary = self._resolve_product_domain_assignment(product_data)
+            prod_domain_ids, prod_primary = self._resolve_product_domain_assignment(product_data, db=db_session)
             if prod_domain_ids:
                 entity_domain_repo.set_domains_for_entity(
                     db_session, entity_type="data_product", entity_id=created_db_obj.id,
@@ -261,7 +264,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                     logger.error(f"Failed to assign tags to product {created_db_obj.id}: {e}")
 
             # Load product with tags
-            result = self._load_product_with_tags(created_db_obj)
+            result = self._load_product_with_tags(created_db_obj, db=db_session)
             
             # Log to change log for timeline
             try:
@@ -540,7 +543,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
             # Replace domain assignments when the caller supplied any domain field.
             if any(k in product_data_dict for k in ('domain_ids', 'primary_domain_id', 'domain')):
-                upd_domain_ids, upd_primary = self._resolve_product_domain_assignment(product_data_dict)
+                upd_domain_ids, upd_primary = self._resolve_product_domain_assignment(product_data_dict, db=db_session)
                 entity_domain_repo.set_domains_for_entity(
                     db_session, entity_type="data_product", entity_id=product_id,
                     domain_ids=upd_domain_ids, primary_domain_id=upd_primary, assigned_by=user,
@@ -557,7 +560,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                     raise
 
             # Load product with tags
-            result = self._load_product_with_tags(updated_db_obj)
+            result = self._load_product_with_tags(updated_db_obj, db=db_session)
             
             # Log to change log for timeline
             try:
@@ -2556,10 +2559,15 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         except Exception as e:
             logger.error(f"Failed to assign tags to ODPS product {product_id}: {e}", exc_info=True)
 
-    def _load_product_with_tags(self, db_obj) -> DataProductApi:
-        """Helper to load an ODPS data product with its associated tags."""
+    def _load_product_with_tags(self, db_obj, db: Optional[Session] = None) -> DataProductApi:
+        """Helper to load an ODPS data product with its associated tags.
+
+        ``db`` must be the caller's request session on write paths (create/update) so the
+        domains just written in that transaction are visible; otherwise the manager's
+        startup session is used and the response would show empty domains.
+        """
         try:
-            product_api = self._attach_domains(DataProductApi.model_validate(db_obj))
+            product_api = self._attach_domains(DataProductApi.model_validate(db_obj), db=db)
 
             if self._tags_manager:
                 try:

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -2471,6 +2471,16 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 if member.username and member.username != member.name:
                     team_member_names.append(member.username)
 
+        # Index every assigned domain NAME so domain-keyed search matches by any of the
+        # product's domains (primary or additional) — issue #520 story 14.
+        try:
+            assigned = entity_domain_repo.get_domains_for_entity(
+                self._db, entity_type="data_product", entity_id=str(product.id)
+            )
+            tag_strings = tag_strings + [d.domain_name for d in assigned if d.domain_name]
+        except Exception as dom_err:
+            logger.debug(f"Could not load domains for product {product.id} search index: {dom_err}")
+
         extra_data = {
             "status": product.status or "",
             "version": product.version or "",

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -2299,8 +2299,21 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 # Step 3: Get product details for formatting
                 products = [self._repo.get(db, id=pid) for pid in product_ids if self._repo.get(db, id=pid)]
 
+                # Resolve each product's primary domain from the junction (the legacy
+                # DataProductDb.domain column was dropped) so the Genie instructions keep
+                # showing the Domain line.
+                genie_domains_map = entity_domain_repo.get_domains_for_entities(
+                    db, entity_type="data_product", entity_ids=[str(p.id) for p in products]
+                ) if products else {}
+                product_domains = {
+                    str(pid): next((a.domain_name for a in assigned if a.is_primary), None)
+                    for pid, assigned in genie_domains_map.items()
+                }
+
                 # Step 4: Format metadata as instructions
-                instructions = genie_client.format_metadata_for_genie(metadata_map, products)
+                instructions = genie_client.format_metadata_for_genie(
+                    metadata_map, products, product_domains=product_domains
+                )
                 logger.info(f"Formatted {len(instructions)} characters of metadata")
 
                 # Step 5: Create Genie Space via API
@@ -3187,10 +3200,15 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 odps["team"]["name"] = team_name
 
         if product.custom_properties:
-            odps["customProperties"] = [
+            rebuilt_props = [
                 {"property": cp.property, "value": cp.value}
                 for cp in product.custom_properties
             ]
+            # Preserve the additionalDomains entry apply_odcs injected above; a plain
+            # overwrite here drops additional domains on export/round-trip.
+            odps["customProperties"] = domain_export_adapter.merge_custom_properties(
+                rebuilt_props, odps.get("customProperties")
+            )
 
         if product.authoritative_definitions:
             odps["authoritativeDefinitions"] = [

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -116,18 +116,22 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         if not self._tags_manager:
             logger.warning("TagsManager not provided. Tag operations will not be available.")
 
-    def _attach_domains(self, api_obj, db: Optional[Session] = None):
+    def _attach_domains(self, api_obj, db: Optional[Session] = None, preloaded_domains=None):
         """Populate a DataProduct API model's domain fields from the junction table.
 
         Callers that operate on an explicit session (clone/new-version/import) must pass
         that ``db`` so associations written-but-not-yet-committed on it are visible;
         otherwise the manager's own session is used.
+
+        ``preloaded_domains`` lets a batch caller (e.g. ``list_products``) hand in the
+        already-loaded ``[AssignedDomain, ...]`` for this product, avoiding a per-row
+        query (N+1) — mirrors the search-index batch path.
         """
         if api_obj is None or not getattr(api_obj, "id", None):
             return api_obj
         session = db if db is not None else self._db
         try:
-            assigned = entity_domain_repo.get_domains_for_entity(
+            assigned = preloaded_domains if preloaded_domains is not None else entity_domain_repo.get_domains_for_entity(
                 session, entity_type="data_product", entity_id=str(api_obj.id)
             )
             api_obj.domain_ids = [d.domain_id for d in assigned]
@@ -157,6 +161,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             byname = data_domain_repo.get_by_name(session, name=value)
             return byname.id if byname else None
 
+        # 1. App/API snake_case payload (create/edit forms, batch import rows).
         raw_ids = data.get('domain_ids')
         if isinstance(raw_ids, list) and raw_ids:
             resolved = [r for r in (_resolve_one(str(x)) for x in raw_ids) if r]
@@ -166,8 +171,19 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 primary = resolved[0] if resolved else None
             return resolved, primary
 
-        single = _resolve_one(data.get('domain'))
-        return ([single], single) if single else ([], None)
+        # 2. Legacy single ``domain`` that is a domain *ID* (pre-#520 form): resolve
+        #    it directly. parse_odcs only resolves a bare ``domain`` by *name*, so an
+        #    ID here would be silently dropped. This form never carried additionals.
+        single = data.get('domain')
+        if single and data_domain_repo.get(session, str(single)):
+            return [str(single)], str(single)
+
+        # 3. ODPS round-trip / re-import: delegate to the shared export adapter so
+        #    camelCase round-trip keys (domainIds/primaryDomainId/domainId) AND the
+        #    ODCS-standard primary ``domain`` name + ``customProperties.additionalDomains``
+        #    are all honoured. Reading only the single ``domain`` name here previously
+        #    dropped additional domains on re-import (round-trip loss).
+        return domain_export_adapter.parse_odcs(data, session)
 
     def get_statuses(self) -> List[str]:
         """Get all ODPS v1.0.0 status values."""
@@ -443,9 +459,17 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                     is_admin=is_admin,
                 )
 
+            # Batch-load domains once for the whole page (avoids N+1: every sibling
+            # list path batches via get_domains_for_entities).
+            domains_map = entity_domain_repo.get_domains_for_entities(
+                self._db, entity_type="data_product", entity_ids=[str(p.id) for p in products_db]
+            ) if products_db else {}
+
             products_with_tags = []
             for product_db in products_db:
-                product_with_tags = self._load_product_with_tags(product_db)
+                product_with_tags = self._load_product_with_tags(
+                    product_db, preloaded_domains=domains_map.get(str(product_db.id), [])
+                )
                 fid = getattr(product_db, "version_family_id", None) or product_db.id
                 # Only emit a count on the collapsed view; on the expanded
                 # view the rows speak for themselves and a per-row count
@@ -2573,15 +2597,20 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         except Exception as e:
             logger.error(f"Failed to assign tags to ODPS product {product_id}: {e}", exc_info=True)
 
-    def _load_product_with_tags(self, db_obj, db: Optional[Session] = None) -> DataProductApi:
+    def _load_product_with_tags(self, db_obj, db: Optional[Session] = None, preloaded_domains=None) -> DataProductApi:
         """Helper to load an ODPS data product with its associated tags.
 
         ``db`` must be the caller's request session on write paths (create/update) so the
         domains just written in that transaction are visible; otherwise the manager's
         startup session is used and the response would show empty domains.
+
+        ``preloaded_domains`` is forwarded to ``_attach_domains`` so batch list callers
+        can supply pre-fetched domains and avoid a per-row lookup (N+1).
         """
         try:
-            product_api = self._attach_domains(DataProductApi.model_validate(db_obj), db=db)
+            product_api = self._attach_domains(
+                DataProductApi.model_validate(db_obj), db=db, preloaded_domains=preloaded_domains
+            )
 
             if self._tags_manager:
                 try:

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -56,6 +56,8 @@ from src.models.data_products import (
 from src.models.users import UserInfo
 from src.repositories.data_products_repository import data_product_repo, subscription_repo
 from src.repositories.teams_repository import team_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
+from src.controller.domain_export_adapter import domain_export_adapter
 from src.repositories.genie_spaces_repository import genie_space_repo
 from src.models.genie_spaces import GenieSpaceCreate
 from src.common.search_interfaces import SearchableAsset, SearchIndexItem
@@ -113,6 +115,50 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             logger.warning("NotificationsManager not provided. Notifications will not be sent.")
         if not self._tags_manager:
             logger.warning("TagsManager not provided. Tag operations will not be available.")
+
+    def _attach_domains(self, api_obj):
+        """Populate a DataProduct API model's domain fields from the junction table."""
+        if api_obj is None or not getattr(api_obj, "id", None):
+            return api_obj
+        try:
+            assigned = entity_domain_repo.get_domains_for_entity(
+                self._db, entity_type="data_product", entity_id=str(api_obj.id)
+            )
+            api_obj.domain_ids = [d.domain_id for d in assigned]
+            primary = next((d for d in assigned if d.is_primary), None)
+            api_obj.primary_domain_id = primary.domain_id if primary else None
+            api_obj.domain = primary.domain_name if primary else None
+        except Exception as e:
+            logger.warning(f"Failed to attach domains for product {getattr(api_obj, 'id', '?')}: {e}")
+        return api_obj
+
+    def _resolve_product_domain_assignment(self, data: dict) -> tuple:
+        """Resolve a product payload to (domain_ids, primary_domain_id).
+
+        Prefers domain_ids + primary_domain_id; falls back to the legacy single ``domain``
+        (which may be a domain ID or name). Names are resolved via the data domain repo.
+        """
+        from src.repositories.data_domain_repository import data_domain_repo
+
+        def _resolve_one(value):
+            if not value:
+                return None
+            if data_domain_repo.get(self._db, value):
+                return value
+            byname = data_domain_repo.get_by_name(self._db, name=value)
+            return byname.id if byname else None
+
+        raw_ids = data.get('domain_ids')
+        if isinstance(raw_ids, list) and raw_ids:
+            resolved = [r for r in (_resolve_one(str(x)) for x in raw_ids) if r]
+            primary = data.get('primary_domain_id')
+            primary = _resolve_one(str(primary)) if primary else None
+            if primary not in resolved:
+                primary = resolved[0] if resolved else None
+            return resolved, primary
+
+        single = _resolve_one(data.get('domain'))
+        return ([single], single) if single else ([], None)
 
     def get_statuses(self) -> List[str]:
         """Get all ODPS v1.0.0 status values."""
@@ -191,6 +237,15 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
             # Create via repository
             created_db_obj = self._repo.create(db=db_session, obj_in=product_api_model)
+
+            # Assign domains via the junction table (accepts domain_ids/primary_domain_id
+            # or legacy single `domain` id/name).
+            prod_domain_ids, prod_primary = self._resolve_product_domain_assignment(product_data)
+            if prod_domain_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    db_session, entity_type="data_product", entity_id=created_db_obj.id,
+                    domain_ids=prod_domain_ids, primary_domain_id=prod_primary, assigned_by=user,
+                )
 
             # Handle tag assignments
             if tags_data and self._tags_manager:
@@ -477,6 +532,14 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             # Update via repository
             updated_db_obj = self._repo.update(db=db_session, db_obj=db_obj, obj_in=product_update_model)
 
+            # Replace domain assignments when the caller supplied any domain field.
+            if any(k in product_data_dict for k in ('domain_ids', 'primary_domain_id', 'domain')):
+                upd_domain_ids, upd_primary = self._resolve_product_domain_assignment(product_data_dict)
+                entity_domain_repo.set_domains_for_entity(
+                    db_session, entity_type="data_product", entity_id=product_id,
+                    domain_ids=upd_domain_ids, primary_domain_id=upd_primary, assigned_by=user,
+                )
+
             # Handle tag updates
             if tags_data is not None and self._tags_manager:
                 try:
@@ -673,7 +736,8 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             # Get product info before deletion for change log
             product_db = self._repo.get(db=self._db, id=product_id)
             product_name = product_db.name if product_db else None
-            
+
+            entity_domain_repo.remove_all_for_entity(self._db, entity_type="data_product", entity_id=product_id)
             deleted_obj = self._repo.remove(db=self._db, id=product_id)
             
             if deleted_obj:
@@ -1559,8 +1623,16 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             new_product_api_model = DataProductCreate(**new_product_data)
             created_db_obj = self._repo.create(db=self._db, obj_in=new_product_api_model)
 
+            # Carry the source product's domain assignments onto the new version.
+            d_ids, d_primary = self._resolve_product_domain_assignment(new_product_data)
+            if d_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    self._db, entity_type="data_product", entity_id=created_db_obj.id,
+                    domain_ids=d_ids, primary_domain_id=d_primary, assigned_by="system",
+                )
+
             logger.info(f"Successfully created new version {request.new_version} (ID: {created_db_obj.id})")
-            result = DataProductApi.model_validate(created_db_obj)
+            result = self._attach_domains(DataProductApi.model_validate(created_db_obj))
             self._update_search_index(result)
             return result
 
@@ -1678,7 +1750,6 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 status='draft' if as_personal_draft else DataProductStatus.DRAFT.value,
                 name=source_product.name,
                 version=new_version,
-                domain=source_product.domain,
                 tenant=source_product.tenant,
                 project_id=source_product.project_id,
                 owner_team_id=source_product.owner_team_id,
@@ -1692,6 +1763,18 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             )
             db.add(new_product)
             db.flush()
+
+            # Copy domain assignments from the source product.
+            src_domains = entity_domain_repo.get_domains_for_entity(
+                db, entity_type="data_product", entity_id=source_product.id
+            )
+            if src_domains:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_product", entity_id=new_product.id,
+                    domain_ids=[d.domain_id for d in src_domains],
+                    primary_domain_id=next((d.domain_id for d in src_domains if d.is_primary), None),
+                    assigned_by=current_user,
+                )
             
             # Clone Description (One-to-One)
             if source_product.description:
@@ -1904,7 +1987,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             db.refresh(new_product)
             
             logger.info(f"Successfully cloned product {product_id} to new version {new_version} (ID: {new_id})")
-            return DataProductApi.model_validate(new_product)
+            return self._attach_domains(DataProductApi.model_validate(new_product))
             
         except SQLAlchemyError as e:
             db.rollback()
@@ -2006,7 +2089,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             db.refresh(draft)
             
             logger.info(f"Committed personal draft {draft_id} as version {new_version}")
-            return DataProductApi.model_validate(draft)
+            return self._attach_domains(DataProductApi.model_validate(draft))
             
         except SQLAlchemyError as e:
             db.rollback()
@@ -2470,7 +2553,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
     def _load_product_with_tags(self, db_obj) -> DataProductApi:
         """Helper to load an ODPS data product with its associated tags."""
         try:
-            product_api = DataProductApi.model_validate(db_obj)
+            product_api = self._attach_domains(DataProductApi.model_validate(db_obj))
 
             if self._tags_manager:
                 try:
@@ -2526,7 +2609,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
         except Exception as e:
             logger.error(f"Failed to load ODPS product with tags: {e}")
-            return DataProductApi.model_validate(db_obj)
+            return self._attach_domains(DataProductApi.model_validate(db_obj))
 
     def assign_tag_to_product(self, product_id: str, tag_id: str, assigned_value: Optional[str] = None,
                               assigned_by: str = "system") -> bool:
@@ -2663,7 +2746,6 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             'name': product_name,
             'version': version,
             'status': DataProductStatus.DRAFT.value,
-            'domain': contract_db.domain_id,  # Inherit from contract
             'description': {
                 'purpose': f"Data Product created from contract: {contract_db.name}",
                 'limitations': None,
@@ -2686,6 +2768,16 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 'name': f"Team from contract {contract_db.name}",
                 'members': []  # Could populate from contract owner
             }
+
+        # Inherit the contract's domain assignments.
+        contract_domains = entity_domain_repo.get_domains_for_entity(
+            self._db, entity_type="data_contract", entity_id=contract_id
+        )
+        if contract_domains:
+            product_data['domain_ids'] = [d.domain_id for d in contract_domains]
+            product_data['primary_domain_id'] = next(
+                (d.domain_id for d in contract_domains if d.is_primary), None
+            )
 
         # Create the product
         created_product = self.create_product(product_data)
@@ -2974,8 +3066,8 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             odps["name"] = product.name
         if product.version:
             odps["version"] = product.version
-        if product.domain:
-            odps["domain"] = product.domain
+        # Domain fields (primary name + additionalDomains) via the shared export adapter.
+        domain_export_adapter.apply_odcs(odps, session, "data_product", product_id)
         if product.tenant:
             odps["tenant"] = product.tenant
 

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -2392,7 +2392,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
     # --- SearchableAsset implementation ---
 
-    def _build_search_index_item(self, product: DataProductApi) -> Optional[SearchIndexItem]:
+    def _build_search_index_item(self, product: DataProductApi, preloaded_domains=None) -> Optional[SearchIndexItem]:
         """Convert a single DataProduct API model to a SearchIndexItem."""
         if not product.id or not product.name:
             return None
@@ -2444,7 +2444,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         # Index every assigned domain NAME so domain-keyed search matches by any of the
         # product's domains (primary or additional) — issue #520 story 14.
         try:
-            assigned = entity_domain_repo.get_domains_for_entity(
+            assigned = preloaded_domains if preloaded_domains is not None else entity_domain_repo.get_domains_for_entity(
                 self._db, entity_type="data_product", entity_id=str(product.id)
             )
             tag_strings = tag_strings + [d.domain_name for d in assigned if d.domain_name]
@@ -2489,8 +2489,12 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         items = []
         try:
             products_api = self.list_products(limit=10000, is_admin=True)
+            # Batch-load domains once for the whole index build (avoids N+1).
+            domains_map = entity_domain_repo.get_domains_for_entities(
+                self._db, entity_type="data_product", entity_ids=[str(p.id) for p in products_api]
+            ) if products_api else {}
             for product in products_api:
-                item = self._build_search_index_item(product)
+                item = self._build_search_index_item(product, preloaded_domains=domains_map.get(str(product.id), []))
                 if item:
                     items.append(item)
             logger.info(f"Prepared {len(items)} ODPS products for search index.")

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -2441,6 +2441,16 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 if member.username and member.username != member.name:
                     team_member_names.append(member.username)
 
+        # Index every assigned domain NAME so domain-keyed search matches by any of the
+        # product's domains (primary or additional) — issue #520 story 14.
+        try:
+            assigned = entity_domain_repo.get_domains_for_entity(
+                self._db, entity_type="data_product", entity_id=str(product.id)
+            )
+            tag_strings = tag_strings + [d.domain_name for d in assigned if d.domain_name]
+        except Exception as dom_err:
+            logger.debug(f"Could not load domains for product {product.id} search index: {dom_err}")
+
         extra_data = {
             "status": product.status or "",
             "version": product.version or "",

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -2449,7 +2449,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             )
             tag_strings = tag_strings + [d.domain_name for d in assigned if d.domain_name]
         except Exception as dom_err:
-            logger.debug(f"Could not load domains for product {product.id} search index: {dom_err}")
+            logger.debug("Could not load domains for product %s search index: %s", product.id, dom_err)
 
         extra_data = {
             "status": product.status or "",

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -56,6 +56,8 @@ from src.models.data_products import (
 from src.models.users import UserInfo
 from src.repositories.data_products_repository import data_product_repo, subscription_repo
 from src.repositories.teams_repository import team_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
+from src.controller.domain_export_adapter import domain_export_adapter
 from src.repositories.genie_spaces_repository import genie_space_repo
 from src.models.genie_spaces import GenieSpaceCreate
 from src.common.search_interfaces import SearchableAsset, SearchIndexItem
@@ -113,6 +115,50 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             logger.warning("NotificationsManager not provided. Notifications will not be sent.")
         if not self._tags_manager:
             logger.warning("TagsManager not provided. Tag operations will not be available.")
+
+    def _attach_domains(self, api_obj):
+        """Populate a DataProduct API model's domain fields from the junction table."""
+        if api_obj is None or not getattr(api_obj, "id", None):
+            return api_obj
+        try:
+            assigned = entity_domain_repo.get_domains_for_entity(
+                self._db, entity_type="data_product", entity_id=str(api_obj.id)
+            )
+            api_obj.domain_ids = [d.domain_id for d in assigned]
+            primary = next((d for d in assigned if d.is_primary), None)
+            api_obj.primary_domain_id = primary.domain_id if primary else None
+            api_obj.domain = primary.domain_name if primary else None
+        except Exception as e:
+            logger.warning(f"Failed to attach domains for product {getattr(api_obj, 'id', '?')}: {e}")
+        return api_obj
+
+    def _resolve_product_domain_assignment(self, data: dict) -> tuple:
+        """Resolve a product payload to (domain_ids, primary_domain_id).
+
+        Prefers domain_ids + primary_domain_id; falls back to the legacy single ``domain``
+        (which may be a domain ID or name). Names are resolved via the data domain repo.
+        """
+        from src.repositories.data_domain_repository import data_domain_repo
+
+        def _resolve_one(value):
+            if not value:
+                return None
+            if data_domain_repo.get(self._db, value):
+                return value
+            byname = data_domain_repo.get_by_name(self._db, name=value)
+            return byname.id if byname else None
+
+        raw_ids = data.get('domain_ids')
+        if isinstance(raw_ids, list) and raw_ids:
+            resolved = [r for r in (_resolve_one(str(x)) for x in raw_ids) if r]
+            primary = data.get('primary_domain_id')
+            primary = _resolve_one(str(primary)) if primary else None
+            if primary not in resolved:
+                primary = resolved[0] if resolved else None
+            return resolved, primary
+
+        single = _resolve_one(data.get('domain'))
+        return ([single], single) if single else ([], None)
 
     def get_statuses(self) -> List[str]:
         """Get all ODPS v1.0.0 status values."""
@@ -176,6 +222,15 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
             # Create via repository
             created_db_obj = self._repo.create(db=db_session, obj_in=product_api_model)
+
+            # Assign domains via the junction table (accepts domain_ids/primary_domain_id
+            # or legacy single `domain` id/name).
+            prod_domain_ids, prod_primary = self._resolve_product_domain_assignment(product_data)
+            if prod_domain_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    db_session, entity_type="data_product", entity_id=created_db_obj.id,
+                    domain_ids=prod_domain_ids, primary_domain_id=prod_primary, assigned_by=user,
+                )
 
             # Handle tag assignments
             if tags_data and self._tags_manager:
@@ -462,6 +517,14 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             # Update via repository
             updated_db_obj = self._repo.update(db=db_session, db_obj=db_obj, obj_in=product_update_model)
 
+            # Replace domain assignments when the caller supplied any domain field.
+            if any(k in product_data_dict for k in ('domain_ids', 'primary_domain_id', 'domain')):
+                upd_domain_ids, upd_primary = self._resolve_product_domain_assignment(product_data_dict)
+                entity_domain_repo.set_domains_for_entity(
+                    db_session, entity_type="data_product", entity_id=product_id,
+                    domain_ids=upd_domain_ids, primary_domain_id=upd_primary, assigned_by=user,
+                )
+
             # Handle tag updates
             if tags_data is not None and self._tags_manager:
                 try:
@@ -650,7 +713,8 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             # Get product info before deletion for change log
             product_db = self._repo.get(db=self._db, id=product_id)
             product_name = product_db.name if product_db else None
-            
+
+            entity_domain_repo.remove_all_for_entity(self._db, entity_type="data_product", entity_id=product_id)
             deleted_obj = self._repo.remove(db=self._db, id=product_id)
             
             if deleted_obj:
@@ -1536,8 +1600,16 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             new_product_api_model = DataProductCreate(**new_product_data)
             created_db_obj = self._repo.create(db=self._db, obj_in=new_product_api_model)
 
+            # Carry the source product's domain assignments onto the new version.
+            d_ids, d_primary = self._resolve_product_domain_assignment(new_product_data)
+            if d_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    self._db, entity_type="data_product", entity_id=created_db_obj.id,
+                    domain_ids=d_ids, primary_domain_id=d_primary, assigned_by="system",
+                )
+
             logger.info(f"Successfully created new version {request.new_version} (ID: {created_db_obj.id})")
-            result = DataProductApi.model_validate(created_db_obj)
+            result = self._attach_domains(DataProductApi.model_validate(created_db_obj))
             self._update_search_index(result)
             return result
 
@@ -1655,7 +1727,6 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 status='draft' if as_personal_draft else DataProductStatus.DRAFT.value,
                 name=source_product.name,
                 version=new_version,
-                domain=source_product.domain,
                 tenant=source_product.tenant,
                 project_id=source_product.project_id,
                 owner_team_id=source_product.owner_team_id,
@@ -1669,6 +1740,18 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             )
             db.add(new_product)
             db.flush()
+
+            # Copy domain assignments from the source product.
+            src_domains = entity_domain_repo.get_domains_for_entity(
+                db, entity_type="data_product", entity_id=source_product.id
+            )
+            if src_domains:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="data_product", entity_id=new_product.id,
+                    domain_ids=[d.domain_id for d in src_domains],
+                    primary_domain_id=next((d.domain_id for d in src_domains if d.is_primary), None),
+                    assigned_by=current_user,
+                )
             
             # Clone Description (One-to-One)
             if source_product.description:
@@ -1881,7 +1964,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             db.refresh(new_product)
             
             logger.info(f"Successfully cloned product {product_id} to new version {new_version} (ID: {new_id})")
-            return DataProductApi.model_validate(new_product)
+            return self._attach_domains(DataProductApi.model_validate(new_product))
             
         except SQLAlchemyError as e:
             db.rollback()
@@ -1983,7 +2066,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             db.refresh(draft)
             
             logger.info(f"Committed personal draft {draft_id} as version {new_version}")
-            return DataProductApi.model_validate(draft)
+            return self._attach_domains(DataProductApi.model_validate(draft))
             
         except SQLAlchemyError as e:
             db.rollback()
@@ -2440,7 +2523,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
     def _load_product_with_tags(self, db_obj) -> DataProductApi:
         """Helper to load an ODPS data product with its associated tags."""
         try:
-            product_api = DataProductApi.model_validate(db_obj)
+            product_api = self._attach_domains(DataProductApi.model_validate(db_obj))
 
             if self._tags_manager:
                 try:
@@ -2496,7 +2579,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
         except Exception as e:
             logger.error(f"Failed to load ODPS product with tags: {e}")
-            return DataProductApi.model_validate(db_obj)
+            return self._attach_domains(DataProductApi.model_validate(db_obj))
 
     def assign_tag_to_product(self, product_id: str, tag_id: str, assigned_value: Optional[str] = None,
                               assigned_by: str = "system") -> bool:
@@ -2633,7 +2716,6 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             'name': product_name,
             'version': version,
             'status': DataProductStatus.DRAFT.value,
-            'domain': contract_db.domain_id,  # Inherit from contract
             'description': {
                 'purpose': f"Data Product created from contract: {contract_db.name}",
                 'limitations': None,
@@ -2656,6 +2738,16 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                 'name': f"Team from contract {contract_db.name}",
                 'members': []  # Could populate from contract owner
             }
+
+        # Inherit the contract's domain assignments.
+        contract_domains = entity_domain_repo.get_domains_for_entity(
+            self._db, entity_type="data_contract", entity_id=contract_id
+        )
+        if contract_domains:
+            product_data['domain_ids'] = [d.domain_id for d in contract_domains]
+            product_data['primary_domain_id'] = next(
+                (d.domain_id for d in contract_domains if d.is_primary), None
+            )
 
         # Create the product
         created_product = self.create_product(product_data)
@@ -2944,8 +3036,8 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             odps["name"] = product.name
         if product.version:
             odps["version"] = product.version
-        if product.domain:
-            odps["domain"] = product.domain
+        # Domain fields (primary name + additionalDomains) via the shared export adapter.
+        domain_export_adapter.apply_odcs(odps, session, "data_product", product_id)
         if product.tenant:
             odps["tenant"] = product.tenant
 

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -116,13 +116,19 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         if not self._tags_manager:
             logger.warning("TagsManager not provided. Tag operations will not be available.")
 
-    def _attach_domains(self, api_obj):
-        """Populate a DataProduct API model's domain fields from the junction table."""
+    def _attach_domains(self, api_obj, db: Optional[Session] = None):
+        """Populate a DataProduct API model's domain fields from the junction table.
+
+        Callers that operate on an explicit session (clone/new-version/import) must pass
+        that ``db`` so associations written-but-not-yet-committed on it are visible;
+        otherwise the manager's own session is used.
+        """
         if api_obj is None or not getattr(api_obj, "id", None):
             return api_obj
+        session = db if db is not None else self._db
         try:
             assigned = entity_domain_repo.get_domains_for_entity(
-                self._db, entity_type="data_product", entity_id=str(api_obj.id)
+                session, entity_type="data_product", entity_id=str(api_obj.id)
             )
             api_obj.domain_ids = [d.domain_id for d in assigned]
             primary = next((d for d in assigned if d.is_primary), None)
@@ -1964,7 +1970,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             db.refresh(new_product)
             
             logger.info(f"Successfully cloned product {product_id} to new version {new_version} (ID: {new_id})")
-            return self._attach_domains(DataProductApi.model_validate(new_product))
+            return self._attach_domains(DataProductApi.model_validate(new_product), db=db)
             
         except SQLAlchemyError as e:
             db.rollback()
@@ -2066,7 +2072,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             db.refresh(draft)
             
             logger.info(f"Committed personal draft {draft_id} as version {new_version}")
-            return self._attach_domains(DataProductApi.model_validate(draft))
+            return self._attach_domains(DataProductApi.model_validate(draft), db=db)
             
         except SQLAlchemyError as e:
             db.rollback()

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -138,20 +138,23 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
             logger.warning(f"Failed to attach domains for product {getattr(api_obj, 'id', '?')}: {e}")
         return api_obj
 
-    def _resolve_product_domain_assignment(self, data: dict) -> tuple:
+    def _resolve_product_domain_assignment(self, data: dict, db: Optional[Session] = None) -> tuple:
         """Resolve a product payload to (domain_ids, primary_domain_id).
 
         Prefers domain_ids + primary_domain_id; falls back to the legacy single ``domain``
         (which may be a domain ID or name). Names are resolved via the data domain repo.
+        Uses the caller's ``db`` session when provided so resolution sees rows written in
+        the same request transaction.
         """
         from src.repositories.data_domain_repository import data_domain_repo
+        session = db if db is not None else self._db
 
         def _resolve_one(value):
             if not value:
                 return None
-            if data_domain_repo.get(self._db, value):
+            if data_domain_repo.get(session, value):
                 return value
-            byname = data_domain_repo.get_by_name(self._db, name=value)
+            byname = data_domain_repo.get_by_name(session, name=value)
             return byname.id if byname else None
 
         raw_ids = data.get('domain_ids')
@@ -231,7 +234,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
             # Assign domains via the junction table (accepts domain_ids/primary_domain_id
             # or legacy single `domain` id/name).
-            prod_domain_ids, prod_primary = self._resolve_product_domain_assignment(product_data)
+            prod_domain_ids, prod_primary = self._resolve_product_domain_assignment(product_data, db=db_session)
             if prod_domain_ids:
                 entity_domain_repo.set_domains_for_entity(
                     db_session, entity_type="data_product", entity_id=created_db_obj.id,
@@ -246,7 +249,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                     logger.error(f"Failed to assign tags to product {created_db_obj.id}: {e}")
 
             # Load product with tags
-            result = self._load_product_with_tags(created_db_obj)
+            result = self._load_product_with_tags(created_db_obj, db=db_session)
             
             # Log to change log for timeline
             try:
@@ -525,7 +528,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
             # Replace domain assignments when the caller supplied any domain field.
             if any(k in product_data_dict for k in ('domain_ids', 'primary_domain_id', 'domain')):
-                upd_domain_ids, upd_primary = self._resolve_product_domain_assignment(product_data_dict)
+                upd_domain_ids, upd_primary = self._resolve_product_domain_assignment(product_data_dict, db=db_session)
                 entity_domain_repo.set_domains_for_entity(
                     db_session, entity_type="data_product", entity_id=product_id,
                     domain_ids=upd_domain_ids, primary_domain_id=upd_primary, assigned_by=user,
@@ -542,7 +545,7 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                     raise
 
             # Load product with tags
-            result = self._load_product_with_tags(updated_db_obj)
+            result = self._load_product_with_tags(updated_db_obj, db=db_session)
             
             # Log to change log for timeline
             try:
@@ -2526,10 +2529,15 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
         except Exception as e:
             logger.error(f"Failed to assign tags to ODPS product {product_id}: {e}", exc_info=True)
 
-    def _load_product_with_tags(self, db_obj) -> DataProductApi:
-        """Helper to load an ODPS data product with its associated tags."""
+    def _load_product_with_tags(self, db_obj, db: Optional[Session] = None) -> DataProductApi:
+        """Helper to load an ODPS data product with its associated tags.
+
+        ``db`` must be the caller's request session on write paths (create/update) so the
+        domains just written in that transaction are visible; otherwise the manager's
+        startup session is used and the response would show empty domains.
+        """
         try:
-            product_api = self._attach_domains(DataProductApi.model_validate(db_obj))
+            product_api = self._attach_domains(DataProductApi.model_validate(db_obj), db=db)
 
             if self._tags_manager:
                 try:

--- a/src/backend/src/controller/domain_export_adapter.py
+++ b/src/backend/src/controller/domain_export_adapter.py
@@ -69,6 +69,33 @@ class DomainExportAdapter:
                 odcs["customProperties"] = custom
         return odcs
 
+    def merge_custom_properties(
+        self, rebuilt: List[Any], previous: Optional[List[Any]]
+    ) -> List[Any]:
+        """Re-attach the domain-managed customProperties entries (``additionalDomains``)
+        onto a freshly rebuilt customProperties list.
+
+        Export builders that reconstruct ``customProperties`` from the entity's own stored
+        properties would otherwise overwrite the ``additionalDomains`` entry that
+        :meth:`apply_odcs` injected, silently dropping additional domains on export (and
+        thus on ODCS/ODPS round-trip). Call this with the newly built list and the value
+        ``apply_odcs`` had placed on the dict to preserve that entry.
+        """
+        if not previous:
+            return rebuilt
+        preserved = [
+            c for c in previous
+            if isinstance(c, dict) and c.get("property") == ADDITIONAL_DOMAINS_PROPERTY
+        ]
+        if not preserved:
+            return rebuilt
+        # Drop any stale additionalDomains the rebuilt list may carry, then re-attach.
+        kept = [
+            c for c in rebuilt
+            if not (isinstance(c, dict) and c.get("property") == ADDITIONAL_DOMAINS_PROPERTY)
+        ]
+        return kept + preserved
+
     def uc_tags(self, db: Session, entity_type: str, entity_id: str) -> List[Tuple[str, str]]:
         """Return the Unity Catalog (tag_key, tag_value) pairs for an entity's domains:
         the primary as ``data_domain`` first, then one tag per additional domain.

--- a/src/backend/src/controller/domain_export_adapter.py
+++ b/src/backend/src/controller/domain_export_adapter.py
@@ -2,9 +2,10 @@
 
 Single-value integrations (ODCS/ODPS ``domain`` field, Unity Catalog ``data_domain`` tag)
 consume the *primary* domain as their canonical value; *additional* domains are emitted
-through extension fields (``customProperties.additionalDomains`` for ODCS/ODPS, a repeated
-``data_domain_additional`` tag for UC). This adapter centralises those conventions so both
-the export and import code paths stay consistent and testable.
+through extension fields (``customProperties.additionalDomains`` for ODCS/ODPS, numbered
+``data_domain_1`` / ``data_domain_2`` / ... tags for UC — a securable holds one value per
+tag key, so additional domains cannot share a single key). This adapter centralises those
+conventions so both the export and import code paths stay consistent and testable.
 """
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -19,7 +20,6 @@ logger = get_logger(__name__)
 
 ADDITIONAL_DOMAINS_PROPERTY = "additionalDomains"
 UC_DOMAIN_TAG = "data_domain"
-UC_ADDITIONAL_DOMAIN_TAG = "data_domain_additional"
 
 
 class DomainExportAdapter:
@@ -71,15 +71,20 @@ class DomainExportAdapter:
 
     def uc_tags(self, db: Session, entity_type: str, entity_id: str) -> List[Tuple[str, str]]:
         """Return the Unity Catalog (tag_key, tag_value) pairs for an entity's domains:
-        the primary as ``data_domain`` first, then one ``data_domain_additional`` per extra."""
+        the primary as ``data_domain`` first, then one tag per additional domain.
+
+        A UC securable holds one value per tag key, so additional domains cannot share
+        a single ``data_domain_additional`` key — each gets its own numbered key derived
+        from the primary key (``data_domain_1``, ``data_domain_2``, ...), matching the
+        uc_tag_sync workflow. Names are sorted for deterministic key assignment."""
         assigned = self.get_assigned(db, entity_type, entity_id)
         primary, additional = self.split_primary_additional(assigned)
         tags: List[Tuple[str, str]] = []
         if primary and primary.domain_name:
             tags.append((UC_DOMAIN_TAG, primary.domain_name))
-        for d in additional:
-            if d.domain_name:
-                tags.append((UC_ADDITIONAL_DOMAIN_TAG, d.domain_name))
+        additional_names = sorted(d.domain_name for d in additional if d.domain_name)
+        for idx, name in enumerate(additional_names, start=1):
+            tags.append((f"{UC_DOMAIN_TAG}_{idx}", name))
         return tags
 
     # ---------------------------------------------------------------- imports

--- a/src/backend/src/controller/domain_export_adapter.py
+++ b/src/backend/src/controller/domain_export_adapter.py
@@ -1,0 +1,142 @@
+"""DomainExportAdapter — single place for domain export/import conventions.
+
+Single-value integrations (ODCS/ODPS ``domain`` field, Unity Catalog ``data_domain`` tag)
+consume the *primary* domain as their canonical value; *additional* domains are emitted
+through extension fields (``customProperties.additionalDomains`` for ODCS/ODPS, a repeated
+``data_domain_additional`` tag for UC). This adapter centralises those conventions so both
+the export and import code paths stay consistent and testable.
+"""
+from typing import Any, Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from src.common.logging import get_logger
+from src.models.domain_associations import AssignedDomain
+from src.repositories.data_domain_repository import data_domain_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
+
+logger = get_logger(__name__)
+
+ADDITIONAL_DOMAINS_PROPERTY = "additionalDomains"
+UC_DOMAIN_TAG = "data_domain"
+UC_ADDITIONAL_DOMAIN_TAG = "data_domain_additional"
+
+
+class DomainExportAdapter:
+    def __init__(self, repo=entity_domain_repo, domain_repo=data_domain_repo):
+        self.repo = repo
+        self.domain_repo = domain_repo
+
+    # ------------------------------------------------------------------ reads
+
+    def get_assigned(self, db: Session, entity_type: str, entity_id: str) -> List[AssignedDomain]:
+        return self.repo.get_domains_for_entity(db, entity_type=entity_type, entity_id=entity_id)
+
+    def split_primary_additional(
+        self, assigned: List[AssignedDomain]
+    ) -> Tuple[Optional[AssignedDomain], List[AssignedDomain]]:
+        primary = next((d for d in assigned if d.is_primary), None)
+        additional = [d for d in assigned if not d.is_primary]
+        return primary, additional
+
+    # ---------------------------------------------------------------- exports
+
+    def apply_odcs(self, odcs: Dict[str, Any], db: Session, entity_type: str, entity_id: str) -> Dict[str, Any]:
+        """Apply domain fields onto an ODCS/ODPS dict in place.
+
+        * ``domain`` = primary domain name (ODCS standard single value).
+        * ``customProperties`` gains ``additionalDomains`` = list of additional domain names.
+        * App round-trip helpers ``domainIds`` (all ids, primary first) and ``primaryDomainId``
+          are also included so the UI and re-import preserve the full assignment.
+        """
+        assigned = self.get_assigned(db, entity_type, entity_id)
+        if not assigned:
+            return odcs
+        primary, additional = self.split_primary_additional(assigned)
+
+        if primary and primary.domain_name:
+            odcs["domain"] = primary.domain_name
+        odcs["domainIds"] = [d.domain_id for d in assigned]
+        odcs["primaryDomainId"] = primary.domain_id if primary else None
+
+        if additional:
+            names = [d.domain_name for d in additional if d.domain_name]
+            if names:
+                custom = odcs.setdefault("customProperties", [])
+                # Drop any stale additionalDomains entry, then append the current one.
+                custom = [c for c in custom if not (isinstance(c, dict) and c.get("property") == ADDITIONAL_DOMAINS_PROPERTY)]
+                custom.append({"property": ADDITIONAL_DOMAINS_PROPERTY, "value": names})
+                odcs["customProperties"] = custom
+        return odcs
+
+    def uc_tags(self, db: Session, entity_type: str, entity_id: str) -> List[Tuple[str, str]]:
+        """Return the Unity Catalog (tag_key, tag_value) pairs for an entity's domains:
+        the primary as ``data_domain`` first, then one ``data_domain_additional`` per extra."""
+        assigned = self.get_assigned(db, entity_type, entity_id)
+        primary, additional = self.split_primary_additional(assigned)
+        tags: List[Tuple[str, str]] = []
+        if primary and primary.domain_name:
+            tags.append((UC_DOMAIN_TAG, primary.domain_name))
+        for d in additional:
+            if d.domain_name:
+                tags.append((UC_ADDITIONAL_DOMAIN_TAG, d.domain_name))
+        return tags
+
+    # ---------------------------------------------------------------- imports
+
+    def parse_odcs(self, odcs: Dict[str, Any], db: Session) -> Tuple[List[str], Optional[str]]:
+        """Extract (domain_ids, primary_domain_id) from an ODCS/ODPS dict.
+
+        Prefers the app round-trip keys (``domainIds``/``primaryDomainId`` or ``domainId``),
+        then falls back to the ODCS-standard ``domain`` name + ``customProperties.additionalDomains``.
+        Names are resolved to IDs; unresolved names are skipped with a warning.
+        """
+        # 1. App round-trip keys.
+        domain_ids: List[str] = []
+        primary_domain_id: Optional[str] = None
+
+        raw_ids = odcs.get("domainIds")
+        if isinstance(raw_ids, list) and raw_ids:
+            domain_ids = [str(x) for x in raw_ids]
+            primary_domain_id = odcs.get("primaryDomainId") or (domain_ids[0] if domain_ids else None)
+            return self._filter_existing(db, domain_ids, primary_domain_id)
+
+        single_id = odcs.get("domainId")
+        if single_id:
+            return self._filter_existing(db, [str(single_id)], str(single_id))
+
+        # 2. ODCS-standard: primary name + additionalDomains names.
+        names: List[str] = []
+        primary_name = odcs.get("domain")
+        if primary_name:
+            names.append(primary_name)
+        for c in odcs.get("customProperties", []) or []:
+            if isinstance(c, dict) and c.get("property") == ADDITIONAL_DOMAINS_PROPERTY:
+                value = c.get("value") or []
+                if isinstance(value, list):
+                    names.extend(str(v) for v in value)
+
+        resolved: List[str] = []
+        for name in names:
+            domain = self.domain_repo.get_by_name(db, name=name)
+            if domain:
+                resolved.append(domain.id)
+            else:
+                logger.warning("DomainExportAdapter: could not resolve domain name %r on import; skipped.", name)
+        primary = resolved[0] if resolved else None
+        return resolved, primary
+
+    def _filter_existing(self, db: Session, domain_ids: List[str], primary: Optional[str]) -> Tuple[List[str], Optional[str]]:
+        existing = []
+        for did in domain_ids:
+            if self.domain_repo.get(db, did):
+                existing.append(did)
+            else:
+                logger.warning("DomainExportAdapter: domain id %r not found on import; skipped.", did)
+        if primary not in existing:
+            primary = existing[0] if existing else None
+        return existing, primary
+
+
+# Module-level singleton
+domain_export_adapter = DomainExportAdapter()

--- a/src/backend/src/controller/teams_manager.py
+++ b/src/backend/src/controller/teams_manager.py
@@ -124,6 +124,18 @@ class TeamsManager:
             logger.error(f"Error resolving domain name '{domain_name}': {e}")
             return None
 
+    @staticmethod
+    def _normalize_primary_domain(domain_ids: List[str], primary_domain_id: Optional[str]) -> Optional[str]:
+        """Clamp the primary to the assigned set: keep it when present, else fall back to
+        the first id (or None when unassigned). Mirrors the contract/product resolvers so a
+        primary_domain_id outside domain_ids can't reach set_domains_for_entity and turn its
+        ValueError into an HTTP 500."""
+        if not domain_ids:
+            return None
+        if primary_domain_id and primary_domain_id in domain_ids:
+            return primary_domain_id
+        return domain_ids[0]
+
     # Team CRUD operations
     def create_team(self, db: Session, team_in: TeamCreate, current_user_id: str) -> TeamRead:
         """Creates a new team."""
@@ -142,7 +154,7 @@ class TeamsManager:
         # Extract tags + domains before serialization
         tags_data = db_obj_data.get('tags', [])
         domain_ids = team_in.domain_ids or []
-        primary_domain_id = team_in.primary_domain_id
+        primary_domain_id = self._normalize_primary_domain(domain_ids, team_in.primary_domain_id)
         self._serialize_list_fields(db_obj_data)
 
         db_team = TeamDb(**db_obj_data)
@@ -263,7 +275,7 @@ class TeamsManager:
         tags_data = update_data.get('tags')
         domains_provided = 'domain_ids' in update_data
         domain_ids = update_data.get('domain_ids') or []
-        primary_domain_id = update_data.get('primary_domain_id')
+        primary_domain_id = self._normalize_primary_domain(domain_ids, update_data.get('primary_domain_id'))
         self._serialize_list_fields(update_data)
 
         try:

--- a/src/backend/src/controller/teams_manager.py
+++ b/src/backend/src/controller/teams_manager.py
@@ -5,6 +5,7 @@ from sqlalchemy.exc import IntegrityError
 
 from src.repositories.teams_repository import team_repo, team_member_repo
 from src.repositories.data_domain_repository import data_domain_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
 from src.controller.tags_manager import TagsManager
 from src.models.teams import (
     TeamCreate,
@@ -36,24 +37,39 @@ class TeamsManager:
         # Tags are now handled through TagsManager, remove from data
         if 'tags' in data:
             del data['tags']
+        # Domain assignment is handled through the junction table, not a column.
+        data.pop('domain_ids', None)
+        data.pop('primary_domain_id', None)
         if 'metadata' in data and isinstance(data['metadata'], dict):
             data['extra_metadata'] = json.dumps(data.pop('metadata'))
         elif 'metadata' in data:
             data.pop('metadata')
         return data
 
-    def _convert_db_to_read_model(self, db_team: TeamDb, db: Optional[Session] = None) -> TeamRead:
+    def _apply_domains(self, team_read: TeamRead, assigned_domains) -> TeamRead:
+        """Populate the read model's domain fields from a list of AssignedDomain."""
+        team_read.domains = assigned_domains or []
+        team_read.domain_ids = [d.domain_id for d in team_read.domains]
+        primary = next((d.domain_id for d in team_read.domains if d.is_primary), None)
+        team_read.primary_domain_id = primary
+        return team_read
+
+    def _convert_db_to_read_model(
+        self, db_team: TeamDb, db: Optional[Session] = None, assigned_domains=None
+    ) -> TeamRead:
         """Helper to convert DB model to Read model."""
         team_read = TeamRead.model_validate(db_team)
 
-        # Populate domain_name if domain_id exists and we have a session
-        if db and db_team.domain_id:
+        # Populate domain assignments (from batch map if provided, else fetch).
+        if assigned_domains is None and db:
             try:
-                domain = self.domain_repo.get(db, db_team.domain_id)
-                if domain:
-                    team_read.domain_name = domain.name
+                assigned_domains = entity_domain_repo.get_domains_for_entity(
+                    db, entity_type="team", entity_id=db_team.id
+                )
             except Exception as e:
-                logger.warning(f"Failed to resolve domain name for domain_id {db_team.domain_id}: {e}")
+                logger.warning(f"Failed to load domains for team {db_team.id}: {e}")
+                assigned_domains = []
+        self._apply_domains(team_read, assigned_domains or [])
 
         # Load tags from TagsManager
         if db:
@@ -68,13 +84,27 @@ class TeamsManager:
 
         return team_read
 
-    def _convert_db_to_summary_model(self, db_team: TeamDb) -> TeamSummary:
+    def _convert_many_to_read_models(self, db: Session, db_teams: List[TeamDb]) -> List[TeamRead]:
+        """Convert many teams to read models, batch-loading domain assignments (no N+1)."""
+        if not db_teams:
+            return []
+        domains_map = entity_domain_repo.get_domains_for_entities(
+            db, entity_type="team", entity_ids=[t.id for t in db_teams]
+        )
+        return [
+            self._convert_db_to_read_model(t, db, assigned_domains=domains_map.get(t.id, []))
+            for t in db_teams
+        ]
+
+    def _convert_db_to_summary_model(self, db_team: TeamDb, assigned_domains=None) -> TeamSummary:
         """Helper to convert DB model to Summary model."""
+        assigned_domains = assigned_domains or []
         return TeamSummary(
             id=db_team.id,
             name=db_team.name,
             title=db_team.title,
-            domain_id=db_team.domain_id,
+            domain_ids=[d.domain_id for d in assigned_domains],
+            primary_domain_id=next((d.domain_id for d in assigned_domains if d.is_primary), None),
             member_count=len(db_team.members) if db_team.members else 0
         )
 
@@ -109,8 +139,10 @@ class TeamsManager:
         db_obj_data['created_by'] = current_user_id
         db_obj_data['updated_by'] = current_user_id
 
-        # Extract tags before serialization
+        # Extract tags + domains before serialization
         tags_data = db_obj_data.get('tags', [])
+        domain_ids = team_in.domain_ids or []
+        primary_domain_id = team_in.primary_domain_id
         self._serialize_list_fields(db_obj_data)
 
         db_team = TeamDb(**db_obj_data)
@@ -119,6 +151,14 @@ class TeamsManager:
             db.add(db_team)
             db.flush()
             db.refresh(db_team)
+
+            # Assign domains via the junction table
+            if domain_ids:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="team", entity_id=db_team.id,
+                    domain_ids=domain_ids, primary_domain_id=primary_domain_id,
+                    assigned_by=current_user_id,
+                )
 
             # Handle tags if provided
             if tags_data:
@@ -157,34 +197,50 @@ class TeamsManager:
             return None
         return self._convert_db_to_read_model(db_team, db)
 
-    def get_all_teams(self, db: Session, skip: int = 0, limit: int = 100, domain_id: Optional[str] = None) -> List[TeamRead]:
-        """Gets a list of all teams, optionally filtered by domain."""
-        logger.debug(f"Fetching teams with skip={skip}, limit={limit}, domain_id={domain_id}")
-        db_teams = self.team_repo.get_multi_with_members(db, skip=skip, limit=limit, domain_id=domain_id)
-        return [self._convert_db_to_read_model(team, db) for team in db_teams]
+    def get_all_teams(
+        self,
+        db: Session,
+        skip: int = 0,
+        limit: int = 100,
+        domain_id: Optional[str] = None,
+        domain_ids: Optional[List[str]] = None,
+    ) -> List[TeamRead]:
+        """Gets a list of all teams, optionally filtered by domain(s) (any-of)."""
+        logger.debug(f"Fetching teams with skip={skip}, limit={limit}, domain_id={domain_id}, domain_ids={domain_ids}")
+        db_teams = self.team_repo.get_multi_with_members(
+            db, skip=skip, limit=limit, domain_id=domain_id, domain_ids=domain_ids
+        )
+        return self._convert_many_to_read_models(db, db_teams)
 
-    def get_teams_summary(self, db: Session, domain_id: Optional[str] = None) -> List[TeamSummary]:
+    def get_teams_summary(
+        self, db: Session, domain_id: Optional[str] = None, domain_ids: Optional[List[str]] = None
+    ) -> List[TeamSummary]:
         """Gets a summary list of teams for dropdowns/selection."""
-        logger.debug(f"Fetching teams summary for domain_id={domain_id}")
-        db_teams = self.team_repo.get_multi_with_members(db, limit=1000, domain_id=domain_id)
-        return [self._convert_db_to_summary_model(team) for team in db_teams]
+        logger.debug(f"Fetching teams summary for domain_id={domain_id}, domain_ids={domain_ids}")
+        db_teams = self.team_repo.get_multi_with_members(
+            db, limit=1000, domain_id=domain_id, domain_ids=domain_ids
+        )
+        domains_map = entity_domain_repo.get_domains_for_entities(
+            db, entity_type="team", entity_ids=[t.id for t in db_teams]
+        )
+        return [self._convert_db_to_summary_model(t, domains_map.get(t.id, [])) for t in db_teams]
 
     def get_teams_by_domain(self, db: Session, domain_id: str) -> List[TeamRead]:
-        """Gets all teams belonging to a specific domain."""
+        """Gets all teams that include this domain (primary or additional)."""
         db_teams = self.team_repo.get_teams_by_domain(db, domain_id)
-        return [self._convert_db_to_read_model(team, db) for team in db_teams]
+        return self._convert_many_to_read_models(db, db_teams)
 
     def get_standalone_teams(self, db: Session) -> List[TeamRead]:
-        """Gets all standalone teams (not assigned to a domain)."""
+        """Gets all standalone teams (zero domain assignments)."""
         db_teams = self.team_repo.get_standalone_teams(db)
-        return [self._convert_db_to_read_model(team, db) for team in db_teams]
+        return self._convert_many_to_read_models(db, db_teams)
 
     def get_teams_for_user(
         self, db: Session, user_identifier: str, user_groups: Optional[List[str]] = None
     ) -> List[TeamRead]:
         """Gets all teams where a user is a member (either directly or via group)."""
         db_teams = self.team_repo.get_teams_for_user(db, user_identifier, user_groups)
-        return [self._convert_db_to_read_model(team, db) for team in db_teams]
+        return self._convert_many_to_read_models(db, db_teams)
 
     def update_team(self, db: Session, team_id: str, team_in: TeamUpdate, current_user_id: str) -> Optional[TeamRead]:
         """Updates an existing team."""
@@ -203,14 +259,25 @@ class TeamsManager:
         update_data = team_in.model_dump(exclude_unset=True)
         update_data['updated_by'] = current_user_id
 
-        # Extract tags before serialization
+        # Extract tags + domains before serialization
         tags_data = update_data.get('tags')
+        domains_provided = 'domain_ids' in update_data
+        domain_ids = update_data.get('domain_ids') or []
+        primary_domain_id = update_data.get('primary_domain_id')
         self._serialize_list_fields(update_data)
 
         try:
             updated_db_team = self.team_repo.update(db=db, db_obj=db_team, obj_in=update_data)
             db.flush()
             db.refresh(updated_db_team)
+
+            # Replace domain assignments if the caller supplied domain_ids (empty clears them)
+            if domains_provided:
+                entity_domain_repo.set_domains_for_entity(
+                    db, entity_type="team", entity_id=updated_db_team.id,
+                    domain_ids=domain_ids, primary_domain_id=primary_domain_id,
+                    assigned_by=current_user_id,
+                )
 
             # Handle tags if provided
             if tags_data is not None:  # Allow empty list to clear tags
@@ -251,6 +318,7 @@ class TeamsManager:
         read_model = self._convert_db_to_read_model(db_team, db)
 
         try:
+            entity_domain_repo.remove_all_for_entity(db, entity_type="team", entity_id=team_id)
             self.team_repo.remove(db=db, id=team_id)
             logger.info(f"Successfully deleted team '{read_model.name}' (id: {team_id})")
             return read_model

--- a/src/backend/src/controller/term_mapping/adapters/asset_adapter.py
+++ b/src/backend/src/controller/term_mapping/adapters/asset_adapter.py
@@ -45,7 +45,13 @@ class AssetAdapter:
             q = q.filter(AssetTypeDb.name == "Column")
 
         if filters.domain_ids:
-            q = q.filter(AssetDb.domain_id.in_(filters.domain_ids))
+            # Domain moved to the entity_domain_associations junction (#520); resolve
+            # asset ids assigned to any of the requested domains (empty list -> no rows).
+            from src.repositories.entity_domain_association_repository import entity_domain_repo
+            matching_ids = entity_domain_repo.find_entity_ids_by_domains(
+                db, domain_ids=list(filters.domain_ids), entity_type="asset"
+            )
+            q = q.filter(AssetDb.id.in_(matching_ids))
 
         if filters.limit:
             q = q.limit(filters.limit)

--- a/src/backend/src/controller/term_mapping/adapters/contract_adapter.py
+++ b/src/backend/src/controller/term_mapping/adapters/contract_adapter.py
@@ -100,7 +100,11 @@ class ContractAdapter:
         if filters.contract_ids:
             q = q.filter(DataContractDb.id.in_(filters.contract_ids))
         if filters.domain_ids:
-            q = q.filter(DataContractDb.domain_id.in_(filters.domain_ids))
+            from src.repositories.entity_domain_association_repository import entity_domain_repo
+            matching_ids = entity_domain_repo.find_entity_ids_by_domains(
+                db, domain_ids=list(filters.domain_ids), entity_type="data_contract"
+            )
+            q = q.filter(DataContractDb.id.in_(matching_ids or ["__none__"]))
 
         contracts = q.all()
         emitted = 0

--- a/src/backend/src/controller/term_mapping/adapters/product_adapter.py
+++ b/src/backend/src/controller/term_mapping/adapters/product_adapter.py
@@ -40,21 +40,33 @@ class ProductAdapter:
         # Look up the latest info record for the display name. The DataProductInfoDb
         # rows are versioned per-product; for our purposes the product name on
         # DataProductDb itself is good enough (kept in sync by DataProductsManager).
-        for product in q.all():
-            yield self._build(db, product)
+        products = q.all()
+        # Batch-load primary domains for all products in one query (avoids N+1) — domain
+        # moved to the entity_domain_associations junction (#520).
+        primary_by_id = self._primary_domains(db, [str(p.id) for p in products])
+        for product in products:
+            yield self._build(product, primary_by_id.get(str(product.id)))
 
     def get_target(self, db: Session, entity_id: str) -> Optional[TargetEntity]:
         product = db.query(DataProductDb).filter(DataProductDb.id == entity_id).first()
-        return self._build(db, product) if product else None
+        if not product:
+            return None
+        primary_by_id = self._primary_domains(db, [str(product.id)])
+        return self._build(product, primary_by_id.get(str(product.id)))
 
-    def _build(self, db: Session, product: DataProductDb) -> TargetEntity:
-        # Domain moved to the entity_domain_associations junction (#520); surface the
-        # primary domain name for the target's display metadata.
+    @staticmethod
+    def _primary_domains(db: Session, product_ids: List[str]) -> dict:
+        """Batch map of product_id -> primary domain name from the junction table."""
         from src.repositories.entity_domain_association_repository import entity_domain_repo
-        assigned = entity_domain_repo.get_domains_for_entity(
-            db, entity_type="data_product", entity_id=str(product.id)
+        domains_map = entity_domain_repo.get_domains_for_entities(
+            db, entity_type="data_product", entity_ids=product_ids
         )
-        primary_domain = next((a.domain_name for a in assigned if a.is_primary), None)
+        return {
+            eid: next((a.domain_name for a in assigned if a.is_primary), None)
+            for eid, assigned in domains_map.items()
+        }
+
+    def _build(self, product: DataProductDb, primary_domain: Optional[str]) -> TargetEntity:
         return TargetEntity(
             entity_type="data_product",
             entity_id=str(product.id),

--- a/src/backend/src/controller/term_mapping/adapters/product_adapter.py
+++ b/src/backend/src/controller/term_mapping/adapters/product_adapter.py
@@ -32,7 +32,7 @@ class ProductAdapter:
             matching_ids = entity_domain_repo.find_entity_ids_by_domains(
                 db, domain_ids=list(filters.domain_ids), entity_type="data_product"
             )
-            q = q.filter(DataProductDb.id.in_(matching_ids or ["__none__"]))
+            q = q.filter(DataProductDb.id.in_(matching_ids))
 
         if filters.limit:
             q = q.limit(filters.limit)
@@ -41,13 +41,20 @@ class ProductAdapter:
         # rows are versioned per-product; for our purposes the product name on
         # DataProductDb itself is good enough (kept in sync by DataProductsManager).
         for product in q.all():
-            yield self._build(product)
+            yield self._build(db, product)
 
     def get_target(self, db: Session, entity_id: str) -> Optional[TargetEntity]:
         product = db.query(DataProductDb).filter(DataProductDb.id == entity_id).first()
-        return self._build(product) if product else None
+        return self._build(db, product) if product else None
 
-    def _build(self, product: DataProductDb) -> TargetEntity:
+    def _build(self, db: Session, product: DataProductDb) -> TargetEntity:
+        # Domain moved to the entity_domain_associations junction (#520); surface the
+        # primary domain name for the target's display metadata.
+        from src.repositories.entity_domain_association_repository import entity_domain_repo
+        assigned = entity_domain_repo.get_domains_for_entity(
+            db, entity_type="data_product", entity_id=str(product.id)
+        )
+        primary_domain = next((a.domain_name for a in assigned if a.is_primary), None)
         return TargetEntity(
             entity_type="data_product",
             entity_id=str(product.id),
@@ -56,6 +63,6 @@ class ProductAdapter:
             extras={
                 "version": product.version,
                 "status": product.status,
-                "domain": product.domain,
+                "domain": primary_domain,
             },
         )

--- a/src/backend/src/controller/term_mapping/adapters/product_adapter.py
+++ b/src/backend/src/controller/term_mapping/adapters/product_adapter.py
@@ -28,7 +28,11 @@ class ProductAdapter:
         if filters.product_ids:
             q = q.filter(DataProductDb.id.in_(filters.product_ids))
         if filters.domain_ids:
-            q = q.filter(DataProductDb.domain.in_(filters.domain_ids))
+            from src.repositories.entity_domain_association_repository import entity_domain_repo
+            matching_ids = entity_domain_repo.find_entity_ids_by_domains(
+                db, domain_ids=list(filters.domain_ids), entity_type="data_product"
+            )
+            q = q.filter(DataProductDb.id.in_(matching_ids or ["__none__"]))
 
         if filters.limit:
             q = q.limit(filters.limit)

--- a/src/backend/src/db_models/__init__.py
+++ b/src/backend/src/db_models/__init__.py
@@ -16,6 +16,7 @@ from . import data_asset_reviews
 from . import data_contract_validations
 from . import data_contracts
 from . import data_domains
+from . import domain_associations
 from . import data_products
 from . import data_quality_checks
 from . import genie_spaces

--- a/src/backend/src/db_models/assets.py
+++ b/src/backend/src/db_models/assets.py
@@ -43,7 +43,8 @@ class AssetDb(Base):
     asset_type_id = Column(PG_UUID(as_uuid=True), ForeignKey("asset_types.id"), nullable=False, index=True)
     platform = Column(String, nullable=True)  # e.g., Databricks, Power BI, Salesforce
     location = Column(String, nullable=True)  # FQDN, URL, path
-    domain_id = Column(String, nullable=True, index=True)  # FK to data_domains (string ID)
+    # Domain assignment is polymorphic via entity_domain_associations (entity_type='asset');
+    # the legacy domain_id column was removed in favour of multi-domain assignment.
     properties = Column(JSON, nullable=True)  # Type-specific metadata following type's schema
     tags = Column(JSON, nullable=True)  # Quick tags/classifications
     status = Column(String, nullable=False, default="active", index=True)

--- a/src/backend/src/db_models/data_contracts.py
+++ b/src/backend/src/db_models/data_contracts.py
@@ -31,7 +31,8 @@ class DataContractDb(Base):
     owner_team_id = Column(String, ForeignKey('teams.id'), nullable=True, index=True)  # Team UUID reference
     tenant = Column(String, nullable=True)
     data_product = Column(String, nullable=True)
-    domain_id = Column(String, ForeignKey("data_domains.id"), nullable=True, index=True)
+    # Domain assignment is polymorphic via entity_domain_associations (entity_type='data_contract');
+    # the legacy domain_id column was removed in favour of multi-domain assignment.
 
     # Project relationship (nullable for backward compatibility)
     project_id = Column(String, ForeignKey('projects.id'), nullable=True, index=True)

--- a/src/backend/src/db_models/data_products.py
+++ b/src/backend/src/db_models/data_products.py
@@ -32,7 +32,8 @@ class DataProductDb(Base):
     # ==================== ODPS v1.0.0 Optional Fields ====================
     name = Column(String, nullable=True, index=True)
     version = Column(String, nullable=True, index=True)
-    domain = Column(String, nullable=True, index=True)
+    # Domain assignment is polymorphic via entity_domain_associations (entity_type='data_product');
+    # the legacy free-text `domain` column was removed in favour of multi-domain assignment.
     tenant = Column(String, nullable=True, index=True)
     product_created_ts = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 

--- a/src/backend/src/db_models/domain_associations.py
+++ b/src/backend/src/db_models/domain_associations.py
@@ -1,0 +1,64 @@
+import uuid
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    ForeignKey,
+    Index,
+    String,
+    TIMESTAMP,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.sql import func
+
+from src.common.database import Base
+
+
+class EntityDomainAssociationDb(Base):
+    """Association of a Data Domain to an entity (team, data_contract, data_product, asset).
+
+    Polymorphic junction table modeled on ``EntityTagAssociationDb``. Each entity may be
+    assigned to many domains; at most one association per ``(entity_type, entity_id)`` may
+    carry ``is_primary=True``. The primary domain feeds single-value integrations (ODCS
+    ``domain`` field, Unity Catalog ``data_domain`` tag); additional domains participate in
+    any-of search/filter/discovery and are emitted through extension fields.
+
+    Replaces the legacy single-domain columns ``teams.domain_id``,
+    ``data_contracts.domain_id``, ``assets.domain_id`` and ``data_products.domain``.
+    """
+
+    __tablename__ = "entity_domain_associations"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    domain_id = Column(String, ForeignKey("data_domains.id"), nullable=False, index=True)
+    entity_id = Column(String, nullable=False, index=True)  # ID of the domain-assigned entity
+    entity_type = Column(String, nullable=False, index=True)  # e.g. "team", "data_contract", "data_product", "asset"
+    is_primary = Column(Boolean, nullable=False, default=False, index=True)
+
+    assigned_by = Column(String, nullable=True)  # User email or ID
+    assigned_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+
+    __table_args__ = (
+        # An entity can be assigned to a given domain at most once.
+        UniqueConstraint("domain_id", "entity_type", "entity_id", name="uq_entity_domain_assignment"),
+        # At most one primary domain per entity. Partial unique index works on both
+        # PostgreSQL (production/Lakebase) and SQLite (test suite).
+        Index(
+            "uq_entity_domain_primary",
+            "entity_type",
+            "entity_id",
+            unique=True,
+            postgresql_where=text("is_primary"),
+            sqlite_where=text("is_primary = 1"),
+        ),
+        # Composite index for the common batch lookup by entity.
+        Index("ix_entity_domain_entity", "entity_type", "entity_id"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<EntityDomainAssociationDb(id={self.id}, domain_id='{self.domain_id}', "
+            f"entity_id='{self.entity_id}', entity_type='{self.entity_type}', is_primary={self.is_primary})>"
+        )

--- a/src/backend/src/db_models/teams.py
+++ b/src/backend/src/db_models/teams.py
@@ -7,7 +7,12 @@ from src.common.database import Base
 
 
 class TeamDb(Base):
-    """Team: name, title, description, optional domain_id; used for ownership and membership (TeamsManager, role resolution)."""
+    """Team: name, title, description; used for ownership and membership (TeamsManager, role resolution).
+
+    Domain assignment is polymorphic via ``entity_domain_associations``
+    (entity_type='team'); the legacy ``domain_id`` column was removed in favour of
+    multi-domain assignment.
+    """
     __tablename__ = 'teams'
 
     # Core Fields
@@ -15,10 +20,6 @@ class TeamDb(Base):
     name = Column(String, nullable=False, unique=True)
     title = Column(String, nullable=True)
     description = Column(Text, nullable=True)
-
-    # Optional parent domain relationship
-    domain_id = Column(String, ForeignKey('data_domains.id'), nullable=True)
-    domain = relationship("DataDomain", foreign_keys=[domain_id], lazy="select")
 
     # Metadata fields (stored as JSON strings)
     # tags: Moved to EntityTagAssociationDb for rich tag support

--- a/src/backend/src/file_models/data_contracts.py
+++ b/src/backend/src/file_models/data_contracts.py
@@ -42,9 +42,9 @@ class DataContractFileModel(FileModel[DataContractDb]):
         result['version'] = entity.version
         result['status'] = entity.status
         
-        # Domain and ownership
-        if entity.domain_id:
-            result['domainId'] = entity.domain_id
+        # Domain assignment is polymorphic (entity_domain_associations) and is emitted by the
+        # ODCS export path (DomainExportAdapter); it is not available on this session-less
+        # YAML serializer.
         if entity.owner_team_id:
             result['ownerTeamId'] = entity.owner_team_id
         if entity.data_product:

--- a/src/backend/src/file_models/data_products.py
+++ b/src/backend/src/file_models/data_products.py
@@ -38,9 +38,9 @@ class DataProductFileModel(FileModel[DataProductDb]):
         result['status'] = entity.status
         result['type'] = entity.type
         
-        # Domain and ownership
-        if entity.domain_id:
-            result['domainId'] = entity.domain_id
+        # Domain assignment is polymorphic (entity_domain_associations) and is emitted by the
+        # ODPS export path (DomainExportAdapter); it is not available on this session-less
+        # YAML serializer. (Previously this referenced entity.domain_id, which never existed.)
         if entity.owner_team_id:
             result['ownerTeamId'] = entity.owner_team_id
         

--- a/src/backend/src/models/assets.py
+++ b/src/backend/src/models/assets.py
@@ -677,6 +677,11 @@ class AssetSummary(BaseModel):
     location: Optional[str] = None
     tags: Optional[List[str]] = None
     status: AssetStatus
+    # Multi-domain assignment (#520): carried on summaries so list rows can show domain
+    # badges and edit dialogs (fed an AssetSummary) preserve domains on save.
+    domain_ids: List[str] = Field(default_factory=list)
+    primary_domain_id: Optional[str] = None
+    domains: List[AssignedDomain] = Field(default_factory=list)
     parent_id: Optional[UUID] = Field(None, description="ID of the parent asset (from hierarchical relationship)")
     parent_name: Optional[str] = Field(None, description="Name of the parent asset")
     updated_at: Optional[datetime] = None

--- a/src/backend/src/models/assets.py
+++ b/src/backend/src/models/assets.py
@@ -17,6 +17,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
+from src.models.domain_associations import AssignedDomain
+
 
 # ============================================================================
 # Asset Categories (Connector-level)
@@ -628,7 +630,8 @@ class AssetBase(BaseModel):
     asset_type_id: UUID = Field(..., description="ID of the persisted asset type")
     platform: Optional[str] = Field(None, description="Platform (e.g., Databricks, Power BI)")
     location: Optional[str] = Field(None, description="FQDN, URL, or path")
-    domain_id: Optional[str] = Field(None, description="Data domain ID")
+    domain_ids: List[str] = Field(default_factory=list, description="Assigned data domain IDs (primary included)")
+    primary_domain_id: Optional[str] = Field(None, description="Primary data domain ID")
     properties: Optional[Dict[str, Any]] = Field(None, description="Type-specific metadata")
     tags: Optional[List[str]] = Field(None, description="Quick tags/classifications")
     status: AssetStatus = Field(AssetStatus.ACTIVE, description="Lifecycle status")
@@ -644,7 +647,8 @@ class AssetUpdate(BaseModel):
     asset_type_id: Optional[UUID] = None
     platform: Optional[str] = None
     location: Optional[str] = None
-    domain_id: Optional[str] = None
+    domain_ids: Optional[List[str]] = None
+    primary_domain_id: Optional[str] = None
     properties: Optional[Dict[str, Any]] = None
     tags: Optional[List[str]] = None
     status: Optional[AssetStatus] = None
@@ -652,6 +656,7 @@ class AssetUpdate(BaseModel):
 
 class AssetRead(AssetBase):
     id: UUID
+    domains: List[AssignedDomain] = Field(default_factory=list, description="Assigned domains with names + primary flag")
     asset_type_name: Optional[str] = Field(None, description="Resolved asset type name")
     relationships: List[AssetRelationshipRead] = Field(default_factory=list)
     created_by: Optional[str] = None

--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -401,7 +401,9 @@ class DataContractBase(BaseModel):
     project_id: Optional[str] = None  # Project association
     kind: str = Field('DataContract')  # Required by ODCS
     apiVersion: str = Field('v3.1.0', alias='api_version')  # Required by ODCS
-    domainId: Optional[str] = Field(None, alias='domain_id')
+    domainId: Optional[str] = Field(None, alias='domain_id')  # Legacy single-domain (primary)
+    domainIds: Optional[List[str]] = Field(None, alias='domain_ids')  # Multi-domain assignment (primary included)
+    primaryDomainId: Optional[str] = Field(None, alias='primary_domain_id')
     tenant: Optional[str] = None
     dataProduct: Optional[str] = Field(None, alias='data_product')
     descriptionUsage: Optional[str] = Field(None, alias='description_usage')
@@ -473,7 +475,9 @@ class DataContractUpdate(BaseModel):
     project_id: Optional[str] = None  # Project association
     kind: Optional[str] = None
     apiVersion: Optional[str] = Field(None, alias='api_version')
-    domainId: Optional[str] = Field(None, alias='domain_id')
+    domainId: Optional[str] = Field(None, alias='domain_id')  # Legacy single-domain (primary)
+    domainIds: Optional[List[str]] = Field(None, alias='domain_ids')  # Multi-domain replace-all
+    primaryDomainId: Optional[str] = Field(None, alias='primary_domain_id')
     tenant: Optional[str] = None
     dataProduct: Optional[str] = Field(None, alias='data_product')
     description: Optional[ContractDescription] = None  # Nested description object (flattened in manager)
@@ -516,8 +520,10 @@ class DataContractRead(BaseModel):
     # Ensure JSON uses camelCase key 'apiVersion' so frontend reads it
     apiVersion: str = Field('v3.1.0', alias='apiVersion')  # Required by ODCS
     tenant: Optional[str] = None
-    domain: Optional[str] = None
-    domainId: Optional[str] = None
+    domain: Optional[str] = None  # Primary domain name
+    domainId: Optional[str] = None  # Primary domain ID
+    domainIds: List[str] = Field(default_factory=list)  # All assigned domain IDs (primary first)
+    primaryDomainId: Optional[str] = None
     dataProduct: Optional[str] = Field(None, alias='data_product')
     description: Optional[ContractDescription] = None
 
@@ -599,8 +605,10 @@ class DataContractSummary(BaseModel):
     kind: str = Field('DataContract')
     apiVersion: str = Field('v3.1.0', alias='apiVersion')
     tenant: Optional[str] = None
-    domain: Optional[str] = None
-    domainId: Optional[str] = None
+    domain: Optional[str] = None  # Primary domain name
+    domainId: Optional[str] = None  # Primary domain ID
+    domainIds: List[str] = Field(default_factory=list)  # All assigned domain IDs (primary first)
+    primaryDomainId: Optional[str] = None
     dataProduct: Optional[str] = Field(None, alias='data_product')
     description: Optional[ContractDescription] = None
     tags: Optional[List[AssignedTag]] = Field(default_factory=list)

--- a/src/backend/src/models/data_contracts_api.py
+++ b/src/backend/src/models/data_contracts_api.py
@@ -395,7 +395,9 @@ class DataContractBase(BaseModel):
     project_id: Optional[str] = None  # Project association
     kind: str = Field('DataContract')  # Required by ODCS
     apiVersion: str = Field('v3.1.0', alias='api_version')  # Required by ODCS
-    domainId: Optional[str] = Field(None, alias='domain_id')
+    domainId: Optional[str] = Field(None, alias='domain_id')  # Legacy single-domain (primary)
+    domainIds: Optional[List[str]] = Field(None, alias='domain_ids')  # Multi-domain assignment (primary included)
+    primaryDomainId: Optional[str] = Field(None, alias='primary_domain_id')
     tenant: Optional[str] = None
     dataProduct: Optional[str] = Field(None, alias='data_product')
     descriptionUsage: Optional[str] = Field(None, alias='description_usage')
@@ -467,7 +469,9 @@ class DataContractUpdate(BaseModel):
     project_id: Optional[str] = None  # Project association
     kind: Optional[str] = None
     apiVersion: Optional[str] = Field(None, alias='api_version')
-    domainId: Optional[str] = Field(None, alias='domain_id')
+    domainId: Optional[str] = Field(None, alias='domain_id')  # Legacy single-domain (primary)
+    domainIds: Optional[List[str]] = Field(None, alias='domain_ids')  # Multi-domain replace-all
+    primaryDomainId: Optional[str] = Field(None, alias='primary_domain_id')
     tenant: Optional[str] = None
     dataProduct: Optional[str] = Field(None, alias='data_product')
     description: Optional[ContractDescription] = None  # Nested description object (flattened in manager)
@@ -510,8 +514,10 @@ class DataContractRead(BaseModel):
     # Ensure JSON uses camelCase key 'apiVersion' so frontend reads it
     apiVersion: str = Field('v3.1.0', alias='apiVersion')  # Required by ODCS
     tenant: Optional[str] = None
-    domain: Optional[str] = None
-    domainId: Optional[str] = None
+    domain: Optional[str] = None  # Primary domain name
+    domainId: Optional[str] = None  # Primary domain ID
+    domainIds: List[str] = Field(default_factory=list)  # All assigned domain IDs (primary first)
+    primaryDomainId: Optional[str] = None
     dataProduct: Optional[str] = Field(None, alias='data_product')
     description: Optional[ContractDescription] = None
 
@@ -593,8 +599,10 @@ class DataContractSummary(BaseModel):
     kind: str = Field('DataContract')
     apiVersion: str = Field('v3.1.0', alias='apiVersion')
     tenant: Optional[str] = None
-    domain: Optional[str] = None
-    domainId: Optional[str] = None
+    domain: Optional[str] = None  # Primary domain name
+    domainId: Optional[str] = None  # Primary domain ID
+    domainIds: List[str] = Field(default_factory=list)  # All assigned domain IDs (primary first)
+    primaryDomainId: Optional[str] = None
     dataProduct: Optional[str] = Field(None, alias='data_product')
     description: Optional[ContractDescription] = None
     tags: Optional[List[AssignedTag]] = Field(default_factory=list)

--- a/src/backend/src/models/data_products.py
+++ b/src/backend/src/models/data_products.py
@@ -342,7 +342,9 @@ class DataProduct(BaseModel):
     # ODPS v1.0.0 optional fields
     name: Optional[str] = Field(None, description="Name of the data product")
     version: Optional[str] = Field(None, description="Version of the data product")
-    domain: Optional[str] = Field(None, description="Business domain")
+    domain: Optional[str] = Field(None, description="Primary business domain name (populated by the manager)")
+    domain_ids: List[str] = Field(default_factory=list, description="Assigned data domain IDs (primary first)")
+    primary_domain_id: Optional[str] = Field(None, description="Primary data domain ID")
     tenant: Optional[str] = Field(None, description="Organization identifier")
     owner_team_id: Optional[str] = Field(None, description="Owner team UUID")
     owner_team_name: Optional[str] = Field(None, description="Owner team name (resolved at query time)")
@@ -518,7 +520,9 @@ class DataProductCreate(BaseModel):
     # ODPS optional
     name: Optional[str] = Field(None, description="Product name")
     version: Optional[str] = Field(None, description="Product version")
-    domain: Optional[str] = Field(None, description="Domain")
+    domain: Optional[str] = Field(None, description="Legacy single domain (name or ID); prefer domain_ids")
+    domain_ids: Optional[List[str]] = Field(None, description="Assigned data domain IDs (primary included)")
+    primary_domain_id: Optional[str] = Field(None, description="Primary data domain ID")
     tenant: Optional[str] = Field(None, description="Tenant")
     owner_team_id: Optional[str] = Field(None, description="Owner team UUID")
     project_id: Optional[str] = Field(None, description="Project association")
@@ -598,6 +602,8 @@ class DataProductUpdate(BaseModel):
     version: Optional[str] = None
     status: Optional[str] = None
     domain: Optional[str] = None
+    domain_ids: Optional[List[str]] = None
+    primary_domain_id: Optional[str] = None
     tenant: Optional[str] = None
     owner_team_id: Optional[str] = None
     project_id: Optional[str] = None

--- a/src/backend/src/models/domain_associations.py
+++ b/src/backend/src/models/domain_associations.py
@@ -1,0 +1,42 @@
+"""Pydantic shapes for polymorphic entity↔domain assignments.
+
+Mirrors the tag-assignment models (``AssignedTag`` / ``AssignedTagCreate``) but for
+Data Domain assignments backed by ``EntityDomainAssociationDb``.
+"""
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class AssignedDomain(BaseModel):
+    """A Data Domain assigned to an entity, with primary flag and audit metadata."""
+
+    domain_id: str = Field(..., description="ID of the assigned data domain.")
+    domain_name: Optional[str] = Field(None, description="Name of the assigned data domain.")
+    is_primary: bool = Field(False, description="Whether this is the entity's primary (canonical) domain.")
+    assigned_by: Optional[str] = Field(None, description="User who assigned the domain.")
+    assigned_at: Optional[datetime] = Field(None, description="When the domain was assigned.")
+
+    model_config = {"from_attributes": True}
+
+
+class DomainAssignmentWrite(BaseModel):
+    """Write payload for setting an entity's domain assignments (replace-all).
+
+    ``domain_ids`` is the full set of assigned domains (including the primary).
+    ``primary_domain_id`` must be one of ``domain_ids`` when provided; when omitted
+    and ``domain_ids`` is non-empty, the repository defaults the primary to the
+    first id. An empty ``domain_ids`` leaves the entity unassigned (no primary).
+    """
+
+    domain_ids: List[str] = Field(default_factory=list, description="All assigned domain IDs, primary included.")
+    primary_domain_id: Optional[str] = Field(
+        None, description="Which domain_id is primary. Must be in domain_ids, or null when domain_ids is empty."
+    )
+
+    @model_validator(mode="after")
+    def _validate_primary_in_set(self):
+        if self.primary_domain_id is not None and self.primary_domain_id not in self.domain_ids:
+            raise ValueError("primary_domain_id must be one of domain_ids")
+        return self

--- a/src/backend/src/models/teams.py
+++ b/src/backend/src/models/teams.py
@@ -6,6 +6,7 @@ from enum import Enum
 import json
 
 from .tags import AssignedTag, AssignedTagCreate
+from .domain_associations import AssignedDomain
 
 
 class MemberType(str, Enum):
@@ -79,7 +80,8 @@ class TeamBase(BaseModel):
     name: str = Field(..., min_length=1, description="Unique name of the team")
     title: Optional[str] = Field(None, description="Display title for the team")
     description: Optional[str] = Field(None, description="Optional description of the team")
-    domain_id: Optional[str] = Field(None, description="Optional parent data domain ID")
+    domain_ids: List[str] = Field(default_factory=list, description="Assigned data domain IDs (primary included)")
+    primary_domain_id: Optional[str] = Field(None, description="Which domain_id is the primary/canonical one")
     tags: Optional[List[AssignedTagCreate]] = Field(None, description="Optional list of rich tags with metadata")
     metadata: Optional[dict] = Field(None, description="Optional metadata (links, images, etc.)")
 
@@ -94,7 +96,8 @@ class TeamUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, description="Updated name of the team")
     title: Optional[str] = Field(None, description="Updated display title")
     description: Optional[str] = Field(None, description="Updated description")
-    domain_id: Optional[str] = Field(None, description="Updated parent data domain ID")
+    domain_ids: Optional[List[str]] = Field(None, description="Updated assigned data domain IDs (replace-all; omit to leave unchanged)")
+    primary_domain_id: Optional[str] = Field(None, description="Updated primary data domain ID")
     tags: Optional[List[AssignedTagCreate]] = Field(None, description="Updated list of rich tags with metadata")
     metadata: Optional[dict] = Field(None, description="Updated metadata")
 
@@ -102,7 +105,7 @@ class TeamUpdate(BaseModel):
 class TeamRead(TeamBase):
     """Model for reading teams"""
     id: str
-    domain_name: Optional[str] = Field(None, description="Domain name for display")
+    domains: List[AssignedDomain] = Field(default_factory=list, description="Assigned domains with names + primary flag")
     created_at: datetime
     updated_at: datetime
     created_by: str
@@ -162,7 +165,8 @@ class TeamSummary(BaseModel):
     id: str
     name: str
     title: Optional[str] = None
-    domain_id: Optional[str] = None
+    domain_ids: List[str] = Field(default_factory=list, description="Assigned data domain IDs")
+    primary_domain_id: Optional[str] = Field(None, description="Primary data domain ID")
     member_count: int = Field(0, description="Number of team members")
 
     model_config = {

--- a/src/backend/src/repositories/assets_repository.py
+++ b/src/backend/src/repositories/assets_repository.py
@@ -6,6 +6,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from src.common.repository import CRUDBase
 from src.db_models.assets import AssetTypeDb, AssetDb, AssetRelationshipDb
+from src.repositories.entity_domain_association_repository import entity_domain_repo
 from src.models.assets import (
     AssetTypeCreate, AssetTypeUpdate,
     AssetCreate, AssetUpdate,
@@ -80,14 +81,17 @@ class AssetRepository(CRUDBase[AssetDb, AssetCreate, AssetUpdate]):
             db.rollback()
             raise
 
-    def _apply_filters(self, query, *, asset_type_id=None, asset_type_names=None,
-                        platform=None, domain_id=None, status=None, name=None,
+    def _apply_filters(self, query, *, db=None, asset_type_id=None, asset_type_names=None,
+                        platform=None, domain_id=None, domain_ids=None, status=None, name=None,
                         restrict_to_ids=None):
         """Apply common filter predicates to a query.
 
         ``restrict_to_ids`` is an optional iterable of asset UUIDs to scope
         results to (used for role-based DP-link scoping). An empty iterable
         intentionally yields zero results — pass None for "no restriction".
+
+        Domain filtering (``domain_id`` single and/or ``domain_ids`` list) is any-of
+        via the ``entity_domain_associations`` junction table.
         """
         if asset_type_id:
             query = query.filter(self.model.asset_type_id == asset_type_id)
@@ -97,8 +101,15 @@ class AssetRepository(CRUDBase[AssetDb, AssetCreate, AssetUpdate]):
             )
         if platform:
             query = query.filter(self.model.platform == platform)
-        if domain_id:
-            query = query.filter(self.model.domain_id == domain_id)
+        if domain_id or domain_ids:
+            wanted = list(domain_ids or [])
+            if domain_id:
+                wanted.append(domain_id)
+            session = db or query.session
+            asset_ids = entity_domain_repo.find_entity_ids_by_domains(
+                session, domain_ids=wanted, entity_type="asset"
+            )
+            query = query.filter(self.model.id.in_(asset_ids or ["__none__"]))
         if status:
             query = query.filter(self.model.status == status)
         if name:
@@ -117,6 +128,7 @@ class AssetRepository(CRUDBase[AssetDb, AssetCreate, AssetUpdate]):
         self, db: Session, *, skip: int = 0, limit: int = 100,
         asset_type_id: Optional[UUID] = None, asset_type_names: Optional[list] = None,
         platform: Optional[str] = None, domain_id: Optional[str] = None,
+        domain_ids: Optional[list] = None,
         status: Optional[str] = None, name: Optional[str] = None,
         restrict_to_ids: Optional[list] = None,
     ) -> List[AssetDb]:
@@ -132,8 +144,8 @@ class AssetRepository(CRUDBase[AssetDb, AssetCreate, AssetUpdate]):
                 .order_by(self.model.name)
             )
             query = self._apply_filters(
-                query, asset_type_id=asset_type_id, asset_type_names=asset_type_names,
-                platform=platform, domain_id=domain_id, status=status, name=name,
+                query, db=db, asset_type_id=asset_type_id, asset_type_names=asset_type_names,
+                platform=platform, domain_id=domain_id, domain_ids=domain_ids, status=status, name=name,
                 restrict_to_ids=restrict_to_ids,
             )
             return query.offset(skip).limit(limit).all()
@@ -146,6 +158,7 @@ class AssetRepository(CRUDBase[AssetDb, AssetCreate, AssetUpdate]):
         self, db: Session, *,
         asset_type_id: Optional[UUID] = None, asset_type_names: Optional[list] = None,
         platform: Optional[str] = None, domain_id: Optional[str] = None,
+        domain_ids: Optional[list] = None,
         status: Optional[str] = None, name: Optional[str] = None,
         restrict_to_ids: Optional[list] = None,
     ) -> int:
@@ -154,8 +167,8 @@ class AssetRepository(CRUDBase[AssetDb, AssetCreate, AssetUpdate]):
             from sqlalchemy import func
             query = db.query(func.count(self.model.id))
             query = self._apply_filters(
-                query, asset_type_id=asset_type_id, asset_type_names=asset_type_names,
-                platform=platform, domain_id=domain_id, status=status, name=name,
+                query, db=db, asset_type_id=asset_type_id, asset_type_names=asset_type_names,
+                platform=platform, domain_id=domain_id, domain_ids=domain_ids, status=status, name=name,
                 restrict_to_ids=restrict_to_ids,
             )
             return query.scalar() or 0

--- a/src/backend/src/repositories/assets_repository.py
+++ b/src/backend/src/repositories/assets_repository.py
@@ -109,7 +109,9 @@ class AssetRepository(CRUDBase[AssetDb, AssetCreate, AssetUpdate]):
             asset_ids = entity_domain_repo.find_entity_ids_by_domains(
                 session, domain_ids=wanted, entity_type="asset"
             )
-            query = query.filter(self.model.id.in_(asset_ids or ["__none__"]))
+            # Empty list -> SQLAlchemy renders an always-false predicate (no rows). A
+            # string sentinel would crash here because AssetDb.id is a Postgres UUID.
+            query = query.filter(self.model.id.in_(asset_ids))
         if status:
             query = query.filter(self.model.status == status)
         if name:

--- a/src/backend/src/repositories/data_products_repository.py
+++ b/src/backend/src/repositories/data_products_repository.py
@@ -11,6 +11,8 @@ from typing import Iterable, List, Optional, Any, Dict, Set, Union
 import json
 
 from src.common.repository import CRUDBase
+from src.db_models.domain_associations import EntityDomainAssociationDb
+from src.repositories.entity_domain_association_repository import entity_domain_repo
 from src.models.data_products import (
     DataProduct as DataProductApi,
     DataProductCreate,
@@ -78,7 +80,6 @@ class DataProductRepository(CRUDBase[DataProductDb, DataProductCreate, DataProdu
                 status=obj_in.status,
                 name=obj_in.name,
                 version=obj_in.version,
-                domain=obj_in.domain,
                 tenant=obj_in.tenant,
                 owner_team_id=obj_in.owner_team_id,
                 # Preserve project_id from the input schema. Historic
@@ -266,8 +267,7 @@ class DataProductRepository(CRUDBase[DataProductDb, DataProductCreate, DataProdu
                 db_obj.name = update_data['name']
             if 'version' in update_data:
                 db_obj.version = update_data['version']
-            if 'domain' in update_data:
-                db_obj.domain = update_data['domain']
+            # domain assignment handled via entity_domain_associations (see manager)
             if 'tenant' in update_data:
                 db_obj.tenant = update_data['tenant']
             if 'owner_team_id' in update_data:
@@ -658,15 +658,17 @@ class DataProductRepository(CRUDBase[DataProductDb, DataProductCreate, DataProdu
             return []
 
     def get_distinct_domains(self, db: Session) -> List[str]:
-        """Get distinct domain values from ODPS Data Products."""
-        logger.debug("Querying distinct ODPS domains...")
+        """Get distinct domain IDs assigned to Data Products (via the junction table)."""
+        logger.debug("Querying distinct data-product domain IDs...")
         try:
             result = db.execute(
-                select(distinct(self.model.domain)).where(self.model.domain.isnot(None))
+                select(distinct(EntityDomainAssociationDb.domain_id)).where(
+                    EntityDomainAssociationDb.entity_type == "data_product"
+                )
             ).scalars().all()
-            return sorted(list(result))
+            return sorted([r for r in result if r])
         except Exception as e:
-            logger.error(f"Error querying distinct ODPS domains: {e}", exc_info=True)
+            logger.error(f"Error querying distinct data-product domains: {e}", exc_info=True)
             return []
 
     def get_distinct_tenants(self, db: Session) -> List[str]:
@@ -743,17 +745,25 @@ class DataProductRepository(CRUDBase[DataProductDb, DataProductCreate, DataProdu
             raise
 
     def get_by_domain(self, db: Session, domain: str, skip: int = 0, limit: int = 100) -> List[DataProductDb]:
-        """Get ODPS Data Products filtered by domain."""
-        logger.debug(f"Fetching ODPS DataProducts for domain '{domain}' (skip: {skip}, limit: {limit})")
+        """Get Data Products assigned to a domain (primary OR additional; any-of via junction).
+
+        ``domain`` is a domain ID.
+        """
+        logger.debug(f"Fetching DataProducts for domain '{domain}' (skip: {skip}, limit: {limit})")
         try:
+            product_ids = entity_domain_repo.find_entity_ids_by_domain(
+                db, domain_id=domain, entity_type="data_product"
+            )
+            if not product_ids:
+                return []
             return db.query(self.model).options(
                 selectinload(self.model.description),
                 selectinload(self.model.input_ports),
                 selectinload(self.model.output_ports),
                 selectinload(self.model.team).selectinload(DataProductTeamDb.members)
-            ).filter(self.model.domain == domain).offset(skip).limit(limit).all()
+            ).filter(self.model.id.in_(product_ids)).offset(skip).limit(limit).all()
         except Exception as e:
-            logger.error(f"Database error fetching ODPS DataProducts by domain: {e}", exc_info=True)
+            logger.error(f"Database error fetching DataProducts by domain: {e}", exc_info=True)
             db.rollback()
             raise
 

--- a/src/backend/src/repositories/entity_domain_association_repository.py
+++ b/src/backend/src/repositories/entity_domain_association_repository.py
@@ -1,0 +1,305 @@
+"""Repository for polymorphic entity↔domain assignments.
+
+This is the deep module for multi-domain assignment. It encapsulates:
+
+* replace-all semantics for an entity's domains (``set_domains_for_entity``),
+* the at-most-one-primary-per-entity invariant,
+* batch reads for list endpoints (``get_domains_for_entities`` — avoids N+1),
+* inverse "any-of" lookups (``find_entity_ids_by_domain`` / ``find_entity_ids_by_domains``),
+* the domain-deletion blocking check (``get_entities_with_primary_domain``).
+
+Its interface mirrors ``EntityTagAssociationRepository.set_tags_for_entity``.
+"""
+from typing import Dict, List, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from src.common.logging import get_logger
+from src.common.repository import CRUDBase
+from src.db_models.data_domains import DataDomain
+from src.db_models.domain_associations import EntityDomainAssociationDb
+from src.models.domain_associations import AssignedDomain
+from pydantic import BaseModel
+
+logger = get_logger(__name__)
+
+
+class EntityDomainAssociationRepository(CRUDBase[EntityDomainAssociationDb, BaseModel, BaseModel]):
+    # ------------------------------------------------------------------ reads
+
+    def get_associations_for_entity(
+        self, db: Session, *, entity_type: str, entity_id: str
+    ) -> List[EntityDomainAssociationDb]:
+        return (
+            db.query(EntityDomainAssociationDb)
+            .filter(
+                EntityDomainAssociationDb.entity_type == entity_type,
+                EntityDomainAssociationDb.entity_id == entity_id,
+            )
+            .all()
+        )
+
+    def get_domains_for_entity(
+        self, db: Session, *, entity_type: str, entity_id: str
+    ) -> List[AssignedDomain]:
+        """Return the entity's assigned domains (primary first), with domain names."""
+        rows = (
+            db.query(
+                EntityDomainAssociationDb.domain_id,
+                DataDomain.name.label("domain_name"),
+                EntityDomainAssociationDb.is_primary,
+                EntityDomainAssociationDb.assigned_by,
+                EntityDomainAssociationDb.assigned_at,
+            )
+            .join(DataDomain, DataDomain.id == EntityDomainAssociationDb.domain_id)
+            .filter(
+                EntityDomainAssociationDb.entity_type == entity_type,
+                EntityDomainAssociationDb.entity_id == entity_id,
+            )
+            .all()
+        )
+        assigned = [
+            AssignedDomain(
+                domain_id=r.domain_id,
+                domain_name=r.domain_name,
+                is_primary=bool(r.is_primary),
+                assigned_by=r.assigned_by,
+                assigned_at=r.assigned_at,
+            )
+            for r in rows
+        ]
+        # Primary first, then by name for stable ordering.
+        assigned.sort(key=lambda d: (not d.is_primary, (d.domain_name or "").lower()))
+        return assigned
+
+    def get_domains_for_entities(
+        self, db: Session, *, entity_type: str, entity_ids: List[str]
+    ) -> Dict[str, List[AssignedDomain]]:
+        """Batch-load domains for many entities. Returns {entity_id: [AssignedDomain, ...]}."""
+        if not entity_ids:
+            return {}
+        rows = (
+            db.query(
+                EntityDomainAssociationDb.entity_id,
+                EntityDomainAssociationDb.domain_id,
+                DataDomain.name.label("domain_name"),
+                EntityDomainAssociationDb.is_primary,
+                EntityDomainAssociationDb.assigned_by,
+                EntityDomainAssociationDb.assigned_at,
+            )
+            .join(DataDomain, DataDomain.id == EntityDomainAssociationDb.domain_id)
+            .filter(
+                EntityDomainAssociationDb.entity_type == entity_type,
+                EntityDomainAssociationDb.entity_id.in_(entity_ids),
+            )
+            .all()
+        )
+        result: Dict[str, List[AssignedDomain]] = {eid: [] for eid in entity_ids}
+        for r in rows:
+            result.setdefault(r.entity_id, []).append(
+                AssignedDomain(
+                    domain_id=r.domain_id,
+                    domain_name=r.domain_name,
+                    is_primary=bool(r.is_primary),
+                    assigned_by=r.assigned_by,
+                    assigned_at=r.assigned_at,
+                )
+            )
+        for eid in result:
+            result[eid].sort(key=lambda d: (not d.is_primary, (d.domain_name or "").lower()))
+        return result
+
+    def get_primary_domain_id(
+        self, db: Session, *, entity_type: str, entity_id: str
+    ) -> Optional[str]:
+        row = (
+            db.query(EntityDomainAssociationDb.domain_id)
+            .filter(
+                EntityDomainAssociationDb.entity_type == entity_type,
+                EntityDomainAssociationDb.entity_id == entity_id,
+                EntityDomainAssociationDb.is_primary.is_(True),
+            )
+            .first()
+        )
+        return row.domain_id if row else None
+
+    # ---------------------------------------------------------------- inverse
+
+    def find_entity_ids_by_domain(
+        self, db: Session, *, domain_id: str, entity_type: str, primary_only: bool = False
+    ) -> List[str]:
+        return self.find_entity_ids_by_domains(
+            db, domain_ids=[domain_id], entity_type=entity_type, primary_only=primary_only
+        )
+
+    def find_entity_ids_by_domains(
+        self, db: Session, *, domain_ids: List[str], entity_type: str, primary_only: bool = False
+    ) -> List[str]:
+        """Entity IDs assigned to ANY of the given domains (any-of semantics)."""
+        if not domain_ids:
+            return []
+        query = (
+            db.query(EntityDomainAssociationDb.entity_id)
+            .filter(
+                EntityDomainAssociationDb.entity_type == entity_type,
+                EntityDomainAssociationDb.domain_id.in_(domain_ids),
+            )
+        )
+        if primary_only:
+            query = query.filter(EntityDomainAssociationDb.is_primary.is_(True))
+        return [row.entity_id for row in query.distinct().all()]
+
+    def find_entity_ids_with_any_domain(self, db: Session, *, entity_type: str) -> List[str]:
+        """Entity IDs that have at least one domain assignment."""
+        rows = (
+            db.query(EntityDomainAssociationDb.entity_id)
+            .filter(EntityDomainAssociationDb.entity_type == entity_type)
+            .distinct()
+            .all()
+        )
+        return [row.entity_id for row in rows]
+
+    # ------------------------------------------------------- deletion support
+
+    def get_entities_with_primary_domain(
+        self, db: Session, *, domain_id: str, entity_type: Optional[str] = None
+    ) -> List[Tuple[str, str]]:
+        """Return (entity_type, entity_id) for every entity that has this domain as PRIMARY.
+
+        Used to block domain deletion (a domain in use as a primary cannot be deleted).
+        """
+        query = db.query(
+            EntityDomainAssociationDb.entity_type, EntityDomainAssociationDb.entity_id
+        ).filter(
+            EntityDomainAssociationDb.domain_id == domain_id,
+            EntityDomainAssociationDb.is_primary.is_(True),
+        )
+        if entity_type:
+            query = query.filter(EntityDomainAssociationDb.entity_type == entity_type)
+        return [(row.entity_type, row.entity_id) for row in query.all()]
+
+    def get_assignment_counts_for_domain(self, db: Session, *, domain_id: str) -> Dict[str, Dict[str, int]]:
+        """Per-entity-type counts of primary vs additional assignments for a domain.
+
+        Returns {entity_type: {"primary": n, "additional": m}}.
+        """
+        rows = (
+            db.query(EntityDomainAssociationDb.entity_type, EntityDomainAssociationDb.is_primary)
+            .filter(EntityDomainAssociationDb.domain_id == domain_id)
+            .all()
+        )
+        counts: Dict[str, Dict[str, int]] = {}
+        for entity_type, is_primary in rows:
+            bucket = counts.setdefault(entity_type, {"primary": 0, "additional": 0})
+            bucket["primary" if is_primary else "additional"] += 1
+        return counts
+
+    def remove_all_for_domain(self, db: Session, *, domain_id: str) -> int:
+        """Delete every association row for a domain (used when deleting a domain that is
+        only ever an additional domain). Returns the number of rows removed."""
+        deleted = (
+            db.query(EntityDomainAssociationDb)
+            .filter(EntityDomainAssociationDb.domain_id == domain_id)
+            .delete(synchronize_session=False)
+        )
+        return deleted
+
+    def remove_all_for_entity(self, db: Session, *, entity_type: str, entity_id: str) -> int:
+        """Delete every domain association for an entity (used when the entity is deleted)."""
+        deleted = (
+            db.query(EntityDomainAssociationDb)
+            .filter(
+                EntityDomainAssociationDb.entity_type == entity_type,
+                EntityDomainAssociationDb.entity_id == entity_id,
+            )
+            .delete(synchronize_session=False)
+        )
+        return deleted
+
+    # ------------------------------------------------------------- write path
+
+    def set_domains_for_entity(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+        domain_ids: List[str],
+        primary_domain_id: Optional[str] = None,
+        assigned_by: Optional[str] = None,
+        validate_exist: bool = True,
+    ) -> List[AssignedDomain]:
+        """Replace all of an entity's domain assignments with the provided set.
+
+        Enforces the at-most-one-primary invariant: when ``domain_ids`` is non-empty
+        exactly one association is primary (defaults to the first id when
+        ``primary_domain_id`` is not supplied); when empty the entity is left unassigned.
+        Idempotent and safe against the partial-unique primary index (never leaves two
+        primaries visible at a flush).
+        """
+        # De-duplicate while preserving order.
+        seen = set()
+        ordered_ids: List[str] = []
+        for did in domain_ids:
+            if did not in seen:
+                seen.add(did)
+                ordered_ids.append(did)
+
+        # Resolve/validate the primary.
+        if not ordered_ids:
+            primary = None
+        elif primary_domain_id is not None:
+            if primary_domain_id not in seen:
+                raise ValueError("primary_domain_id must be one of domain_ids")
+            primary = primary_domain_id
+        else:
+            primary = ordered_ids[0]
+
+        # Optionally validate domains exist (raise on unknown to keep the API contract strict).
+        if validate_exist and ordered_ids:
+            existing = {
+                row.id
+                for row in db.query(DataDomain.id).filter(DataDomain.id.in_(ordered_ids)).all()
+            }
+            missing = [d for d in ordered_ids if d not in existing]
+            if missing:
+                raise ValueError(f"Unknown data domain id(s): {', '.join(missing)}")
+
+        current = {a.domain_id: a for a in self.get_associations_for_entity(
+            db, entity_type=entity_type, entity_id=entity_id
+        )}
+
+        # 1. Delete associations that are no longer wanted.
+        for did, assoc in list(current.items()):
+            if did not in seen:
+                db.delete(assoc)
+                del current[did]
+
+        # 2. Upsert every wanted association with is_primary=False first, so no two rows
+        #    are primary at the coming flush (protects the partial unique index).
+        for did in ordered_ids:
+            assoc = current.get(did)
+            if assoc is None:
+                assoc = EntityDomainAssociationDb(
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    domain_id=did,
+                    is_primary=False,
+                    assigned_by=assigned_by,
+                )
+                db.add(assoc)
+                current[did] = assoc
+            else:
+                assoc.is_primary = False
+        db.flush()
+
+        # 3. Promote the single primary.
+        if primary is not None:
+            current[primary].is_primary = True
+            db.flush()
+
+        return self.get_domains_for_entity(db, entity_type=entity_type, entity_id=entity_id)
+
+
+# Module-level singleton (mirrors tags_repository)
+entity_domain_repo = EntityDomainAssociationRepository(EntityDomainAssociationDb)

--- a/src/backend/src/repositories/projects_repository.py
+++ b/src/backend/src/repositories/projects_repository.py
@@ -187,13 +187,13 @@ class ProjectRepository(CRUDBase[ProjectDb, ProjectCreate, ProjectUpdate]):
         logger.debug(f"Fetching domain-related projects for user: {user_identifier}")
         try:
             from src.db_models.teams import TeamMemberDb
-            from src.db_models.data_domains import DataDomain
-            
+            from src.repositories.entity_domain_association_repository import entity_domain_repo
+
             # Get user's team IDs (case-insensitive)
             member_filters = [func.lower(TeamMemberDb.member_identifier) == user_identifier.lower()]
             for group in user_groups:
                 member_filters.append(func.lower(TeamMemberDb.member_identifier) == group.lower())
-            
+
             user_team_ids_query = (
                 db.query(TeamDb.id)
                 .join(TeamMemberDb)
@@ -201,51 +201,54 @@ class ProjectRepository(CRUDBase[ProjectDb, ProjectCreate, ProjectUpdate]):
                 .distinct()
             )
             user_team_ids = [tid[0] for tid in user_team_ids_query.all()]
-            
+
+            # Teams that carry at least one domain (via the junction table). A project whose
+            # owner team is NOT in this set has "no domain" and is treated as public.
+            teams_with_domain = set(
+                entity_domain_repo.find_entity_ids_with_any_domain(db, entity_type="team")
+            )
+
+            # Base visibility: projects with no owner team, or whose owner team is standalone.
+            public_filters = [self.model.owner_team_id.is_(None)]
+            if teams_with_domain:
+                public_filters.append(self.model.owner_team_id.notin_(teams_with_domain))
+
             if not user_team_ids:
-                # User not in any team, only show projects with no domain
+                # User not in any team → only public projects.
                 return (
                     db.query(self.model)
                     .options(selectinload(self.model.teams))
                     .options(selectinload(self.model.owner_team))
-                    .join(TeamDb, self.model.owner_team_id == TeamDb.id, isouter=True)
-                    .filter(
-                        or_(
-                            TeamDb.domain_id.is_(None),
-                            self.model.owner_team_id.is_(None)
-                        )
-                    )
+                    .filter(or_(*public_filters))
                     .distinct()
                     .order_by(self.model.name)
                     .all()
                 )
-            
-            # Get domains of user's teams
-            user_domain_ids_query = (
-                db.query(TeamDb.domain_id)
-                .filter(TeamDb.id.in_(user_team_ids))
-                .filter(TeamDb.domain_id.isnot(None))
-                .distinct()
+
+            # Union of all domains across the user's teams (primary + additional).
+            domains_map = entity_domain_repo.get_domains_for_entities(
+                db, entity_type="team", entity_ids=user_team_ids
             )
-            user_domain_ids = [did[0] for did in user_domain_ids_query.all()]
-            
-            # Build filter conditions
-            visibility_filters = [
-                # Projects with no domain (public)
-                TeamDb.domain_id.is_(None),
-                # Projects user is already a member of
-                project_team_association.c.team_id.in_(user_team_ids),
-            ]
-            
-            # Projects in same domains as user's teams
-            if user_domain_ids:
-                visibility_filters.append(TeamDb.domain_id.in_(user_domain_ids))
-            
+            user_domain_ids = {d.domain_id for assigned in domains_map.values() for d in assigned}
+
+            # Owner teams that share any of the user's domains.
+            owner_teams_sharing = (
+                set(entity_domain_repo.find_entity_ids_by_domains(
+                    db, domain_ids=list(user_domain_ids), entity_type="team"
+                ))
+                if user_domain_ids else set()
+            )
+
+            # Build visibility filters: public OR member OR owner team shares a domain.
+            visibility_filters = list(public_filters)
+            visibility_filters.append(project_team_association.c.team_id.in_(user_team_ids))
+            if owner_teams_sharing:
+                visibility_filters.append(self.model.owner_team_id.in_(owner_teams_sharing))
+
             return (
                 db.query(self.model)
                 .options(selectinload(self.model.teams))
                 .options(selectinload(self.model.owner_team))
-                .outerjoin(TeamDb, self.model.owner_team_id == TeamDb.id)
                 .outerjoin(
                     project_team_association,
                     project_team_association.c.project_id == self.model.id
@@ -255,7 +258,7 @@ class ProjectRepository(CRUDBase[ProjectDb, ProjectCreate, ProjectUpdate]):
                 .order_by(self.model.name)
                 .all()
             )
-            
+
         except SQLAlchemyError as e:
             logger.error(f"Database error fetching domain-related projects: {e}", exc_info=True)
             db.rollback()

--- a/src/backend/src/repositories/teams_repository.py
+++ b/src/backend/src/repositories/teams_repository.py
@@ -2,6 +2,7 @@ from src.common.repository import CRUDBase
 from src.db_models.teams import TeamDb, TeamMemberDb
 from src.models.teams import TeamCreate, TeamUpdate, TeamMemberCreate, TeamMemberUpdate
 from src.common.logging import get_logger
+from src.repositories.entity_domain_association_repository import entity_domain_repo
 from sqlalchemy.orm import Session, selectinload, joinedload
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy import func
@@ -9,11 +10,32 @@ from typing import List, Optional
 
 logger = get_logger(__name__)
 
+TEAM_ENTITY_TYPE = "team"
+
 
 class TeamRepository(CRUDBase[TeamDb, TeamCreate, TeamUpdate]):
     def __init__(self):
         super().__init__(TeamDb)
         logger.info("TeamRepository initialized.")
+
+    def _resolve_domain_filter(
+        self, db: Session, domain_id: Optional[str], domain_ids: Optional[List[str]]
+    ) -> Optional[List[str]]:
+        """Resolve a domain filter to the set of team IDs (any-of via the junction table).
+
+        Returns None when no domain filter is supplied (caller should not filter), or a
+        (possibly empty) list of team IDs when a filter is present.
+        """
+        ids: List[str] = []
+        if domain_ids:
+            ids.extend(domain_ids)
+        if domain_id:
+            ids.append(domain_id)
+        if not ids:
+            return None
+        return entity_domain_repo.find_entity_ids_by_domains(
+            db, domain_ids=ids, entity_type=TEAM_ENTITY_TYPE
+        )
 
     def get_with_members(self, db: Session, id: str) -> Optional[TeamDb]:
         """Gets a single team by ID, eager loading members."""
@@ -31,10 +53,16 @@ class TeamRepository(CRUDBase[TeamDb, TeamCreate, TeamUpdate]):
             raise
 
     def get_multi_with_members(
-        self, db: Session, *, skip: int = 0, limit: int = 100, domain_id: Optional[str] = None
+        self,
+        db: Session,
+        *,
+        skip: int = 0,
+        limit: int = 100,
+        domain_id: Optional[str] = None,
+        domain_ids: Optional[List[str]] = None,
     ) -> List[TeamDb]:
-        """Gets multiple teams, eager loading members. Optionally filter by domain."""
-        logger.debug(f"Fetching multiple {self.model.__name__} with members, skip={skip}, limit={limit}, domain_id={domain_id}")
+        """Gets multiple teams, eager loading members. Optionally filter by domain(s) (any-of)."""
+        logger.debug(f"Fetching multiple {self.model.__name__} with members, skip={skip}, limit={limit}, domain_id={domain_id}, domain_ids={domain_ids}")
         try:
             query = (
                 db.query(self.model)
@@ -42,8 +70,9 @@ class TeamRepository(CRUDBase[TeamDb, TeamCreate, TeamUpdate]):
                 .order_by(self.model.name)
             )
 
-            if domain_id is not None:
-                query = query.filter(self.model.domain_id == domain_id)
+            filter_ids = self._resolve_domain_filter(db, domain_id, domain_ids)
+            if filter_ids is not None:
+                query = query.filter(self.model.id.in_(filter_ids))
 
             return query.offset(skip).limit(limit).all()
         except SQLAlchemyError as e:
@@ -62,13 +91,18 @@ class TeamRepository(CRUDBase[TeamDb, TeamCreate, TeamUpdate]):
             raise
 
     def get_teams_by_domain(self, db: Session, domain_id: str) -> List[TeamDb]:
-        """Gets all teams belonging to a specific domain."""
+        """Gets all teams that include this domain (primary OR additional; any-of)."""
         logger.debug(f"Fetching teams for domain: {domain_id}")
         try:
+            team_ids = entity_domain_repo.find_entity_ids_by_domain(
+                db, domain_id=domain_id, entity_type=TEAM_ENTITY_TYPE
+            )
+            if not team_ids:
+                return []
             return (
                 db.query(self.model)
                 .options(selectinload(self.model.members))
-                .filter(self.model.domain_id == domain_id)
+                .filter(self.model.id.in_(team_ids))
                 .order_by(self.model.name)
                 .all()
             )
@@ -78,16 +112,20 @@ class TeamRepository(CRUDBase[TeamDb, TeamCreate, TeamUpdate]):
             raise
 
     def get_standalone_teams(self, db: Session) -> List[TeamDb]:
-        """Gets all standalone teams (not assigned to a domain)."""
+        """Gets all standalone teams (zero domain assignments)."""
         logger.debug("Fetching standalone teams")
         try:
-            return (
+            assigned_ids = entity_domain_repo.find_entity_ids_with_any_domain(
+                db, entity_type=TEAM_ENTITY_TYPE
+            )
+            query = (
                 db.query(self.model)
                 .options(selectinload(self.model.members))
-                .filter(self.model.domain_id.is_(None))
                 .order_by(self.model.name)
-                .all()
             )
+            if assigned_ids:
+                query = query.filter(self.model.id.notin_(assigned_ids))
+            return query.all()
         except SQLAlchemyError as e:
             logger.error(f"Database error fetching standalone teams: {e}", exc_info=True)
             db.rollback()

--- a/src/backend/src/routes/assets_routes.py
+++ b/src/backend/src/routes/assets_routes.py
@@ -306,7 +306,8 @@ def get_all_assets(
     asset_type_id: Optional[UUID] = Query(None),
     asset_type_names: Optional[str] = Query(None, description="Comma-separated asset type names"),
     platform: Optional[str] = Query(None),
-    domain_id: Optional[str] = Query(None),
+    domain_id: Optional[str] = Query(None, description="Filter by a single domain ID (any-of)"),
+    domain_ids: Optional[str] = Query(None, description="Filter by multiple domain IDs, comma-separated (any-of)"),
     asset_status: Optional[str] = Query(None, alias="status"),
     name: Optional[str] = Query(None),
 ):
@@ -345,10 +346,11 @@ def get_all_assets(
         restrict_ids = None  # unrestricted
 
     type_names_list = [t.strip() for t in asset_type_names.split(",")] if asset_type_names else None
+    domain_ids_list = [d.strip() for d in domain_ids.split(",") if d.strip()] if domain_ids else None
     return manager.get_all_assets(
         db=db, skip=skip, limit=limit,
         asset_type_id=asset_type_id, asset_type_names=type_names_list,
-        platform=platform, domain_id=domain_id, status=asset_status, name=name,
+        platform=platform, domain_id=domain_id, domain_ids=domain_ids_list, status=asset_status, name=name,
         restrict_to_ids=restrict_ids,
     )
 

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -89,6 +89,7 @@ def get_jobs_manager(request: Request):
 async def get_contracts(
     db: DBSessionDep,
     domain_id: Optional[str] = None,
+    domain_ids: Optional[str] = None,
     project_id: Optional[str] = None,
     status: Optional[str] = None,
     include_history: bool = False,
@@ -141,9 +142,11 @@ async def get_contracts(
                     "falling back to consumer visibility"
                 )
 
+        domain_ids_list = [d.strip() for d in domain_ids.split(",") if d.strip()] if domain_ids else None
         result = manager.list_contracts_from_db(
             db,
             domain_id=domain_id,
+            domain_ids=domain_ids_list,
             project_id=project_id,
             status=status,
             is_admin=is_admin,

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -89,6 +89,7 @@ def get_jobs_manager(request: Request):
 async def get_contracts(
     db: DBSessionDep,
     domain_id: Optional[str] = None,
+    domain_ids: Optional[str] = None,
     project_id: Optional[str] = None,
     include_history: bool = False,
     current_user: CurrentUserDep = None,
@@ -135,9 +136,11 @@ async def get_contracts(
                     "falling back to consumer visibility"
                 )
 
+        domain_ids_list = [d.strip() for d in domain_ids.split(",") if d.strip()] if domain_ids else None
         result = manager.list_contracts_from_db(
             db,
             domain_id=domain_id,
+            domain_ids=domain_ids_list,
             project_id=project_id,
             is_admin=is_admin,
             include_history=include_history,

--- a/src/backend/src/routes/data_domains_routes.py
+++ b/src/backend/src/routes/data_domains_routes.py
@@ -141,6 +141,25 @@ def get_data_domain(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Data domain with id '{domain_id}' not found")
     return domain
 
+@router.get(
+    "/data-domains/{domain_id}/deletion-impact",
+    dependencies=[Depends(PermissionChecker(DATA_DOMAINS_FEATURE_ID, FeatureAccessLevel.READ_ONLY))]
+)
+def get_data_domain_deletion_impact(
+    domain_id: UUID,
+    db: DBSessionDep,
+    manager: DataDomainManager = Depends(get_data_domain_manager)
+):
+    """Reports whether a domain can be deleted and which entities assign it (#520).
+
+    ``deletable`` is False when the domain (or a descendant that would cascade-delete
+    with it) is the primary domain for any entity; ``primary_assignments`` lists them.
+    """
+    try:
+        return manager.get_domain_deletion_impact(db=db, domain_id=domain_id)
+    except NotFoundError:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Data domain with id '{domain_id}' not found")
+
 @router.put(
     "/data-domains/{domain_id}",
     response_model=DataDomainRead,
@@ -258,6 +277,13 @@ def delete_data_domain(
         logger.error("Data domain not found for deletion %s: %s", domain_id, e)
         details_for_audit["exception"] = {"type": "NotFoundError", "message": str(e)}
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Data domain not found")
+    except ConflictError as e:
+        # Deletion blocked because the domain is a PRIMARY domain somewhere (#520).
+        # Pass the structured impact body through so the UI can list what to fix.
+        db.rollback()
+        logger.warning("Data domain deletion blocked %s: %s", domain_id, e.detail)
+        details_for_audit["exception"] = {"type": "ConflictError", "message": str(e.detail)}
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=e.detail)
     except Exception as e:
         db.rollback()
         logger.exception("Failed to delete data domain %s", domain_id)

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -1735,6 +1735,8 @@ async def upload_data_products(
 async def get_data_products(
     request: Request,
     project_id: Optional[str] = None,
+    domain_id: Optional[str] = None,
+    domain_ids: Optional[str] = None,
     include_history: bool = False,
     current_user: CurrentUserDep = None,
     db: DBSessionDep = None,
@@ -1808,6 +1810,14 @@ async def get_data_products(
             caller_project_ids=caller_project_ids,
             include_history=include_history,
         )
+        # Any-of domain filter (#520): a product matches when any of its assigned
+        # domains (primary or additional) is in the requested set. domain_ids are
+        # already attached to each DataProduct by the manager.
+        wanted_domains = {d.strip() for d in (domain_ids.split(",") if domain_ids else []) if d.strip()}
+        if domain_id:
+            wanted_domains.add(domain_id)
+        if wanted_domains:
+            products = [p for p in products if wanted_domains & set(getattr(p, "domain_ids", None) or [])]
         logger.info(
             f"Retrieved {len(products)} data products "
             f"(include_history={include_history})"

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -1802,7 +1802,17 @@ async def get_data_products(
                     f"caller will see only their draft-owned products"
                 )
 
-        products = manager.list_products(
+        # Any-of domain filter (#520): a product matches when any of its assigned
+        # domains (primary or additional) is in the requested set.
+        wanted_domains = {d.strip() for d in (domain_ids.split(",") if domain_ids else []) if d.strip()}
+        if domain_id:
+            wanted_domains.add(domain_id)
+
+        # The domain filter is applied in-process (domain_ids are attached per product
+        # by the manager), so a domain-filtered request must load the full candidate set
+        # rather than the default page — otherwise products assigned to the domain past
+        # the first page would be silently dropped.
+        list_kwargs = dict(
             project_id=project_id,
             is_admin=is_admin,
             caller_email=caller_email,
@@ -1810,12 +1820,10 @@ async def get_data_products(
             caller_project_ids=caller_project_ids,
             include_history=include_history,
         )
-        # Any-of domain filter (#520): a product matches when any of its assigned
-        # domains (primary or additional) is in the requested set. domain_ids are
-        # already attached to each DataProduct by the manager.
-        wanted_domains = {d.strip() for d in (domain_ids.split(",") if domain_ids else []) if d.strip()}
-        if domain_id:
-            wanted_domains.add(domain_id)
+        if wanted_domains:
+            list_kwargs["limit"] = 10000
+        products = manager.list_products(**list_kwargs)
+
         if wanted_domains:
             products = [p for p in products if wanted_domains & set(getattr(p, "domain_ids", None) or [])]
         logger.info(

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -1612,6 +1612,8 @@ async def upload_data_products(
 async def get_data_products(
     request: Request,
     project_id: Optional[str] = None,
+    domain_id: Optional[str] = None,
+    domain_ids: Optional[str] = None,
     include_history: bool = False,
     current_user: CurrentUserDep = None,
     db: DBSessionDep = None,
@@ -1685,6 +1687,14 @@ async def get_data_products(
             caller_project_ids=caller_project_ids,
             include_history=include_history,
         )
+        # Any-of domain filter (#520): a product matches when any of its assigned
+        # domains (primary or additional) is in the requested set. domain_ids are
+        # already attached to each DataProduct by the manager.
+        wanted_domains = {d.strip() for d in (domain_ids.split(",") if domain_ids else []) if d.strip()}
+        if domain_id:
+            wanted_domains.add(domain_id)
+        if wanted_domains:
+            products = [p for p in products if wanted_domains & set(getattr(p, "domain_ids", None) or [])]
         logger.info(
             f"Retrieved {len(products)} data products "
             f"(include_history={include_history})"

--- a/src/backend/src/routes/teams_routes.py
+++ b/src/backend/src/routes/teams_routes.py
@@ -57,7 +57,7 @@ def create_team(
     """Creates a new team."""
     success = False
     details_for_audit = {
-        "params": {"team_name": team_in.name, "domain_id": team_in.domain_id if hasattr(team_in, 'domain_id') else None},
+        "params": {"team_name": team_in.name, "domain_ids": team_in.domain_ids},
     }
     created_team_id = None
 
@@ -102,12 +102,16 @@ def get_all_teams(
     manager = Depends(get_teams_manager),
     skip: int = 0,
     limit: int = 100,
-    domain_id: Optional[str] = Query(None, description="Filter teams by domain ID")
+    domain_id: Optional[str] = Query(None, description="Filter teams by a single domain ID (any-of)"),
+    domain_ids: Optional[str] = Query(None, description="Filter teams by multiple domain IDs, comma-separated (any-of)")
 ):
-    """Lists all teams, optionally filtered by domain."""
-    logger.debug(f"Fetching teams (skip={skip}, limit={limit}, domain_id={domain_id})")
+    """Lists all teams, optionally filtered by domain(s) (any-of)."""
+    logger.debug(f"Fetching teams (skip={skip}, limit={limit}, domain_id={domain_id}, domain_ids={domain_ids})")
     try:
-        return manager.get_all_teams(db=db, skip=skip, limit=limit, domain_id=domain_id)
+        domain_id_list = [d for d in (domain_ids.split(",") if domain_ids else []) if d.strip()]
+        return manager.get_all_teams(
+            db=db, skip=skip, limit=limit, domain_id=domain_id, domain_ids=domain_id_list or None
+        )
     except Exception as e:
         logger.exception(f"Failed to fetch teams: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to fetch teams")
@@ -121,12 +125,14 @@ def get_all_teams(
 def get_teams_summary(
     db: DBSessionDep,
     manager = Depends(get_teams_manager),
-    domain_id: Optional[str] = Query(None, description="Filter teams by domain ID")
+    domain_id: Optional[str] = Query(None, description="Filter teams by a single domain ID (any-of)"),
+    domain_ids: Optional[str] = Query(None, description="Filter teams by multiple domain IDs, comma-separated (any-of)")
 ):
     """Gets a summary list of teams for dropdowns/selection."""
-    logger.debug(f"Fetching teams summary for domain_id={domain_id}")
+    logger.debug(f"Fetching teams summary for domain_id={domain_id}, domain_ids={domain_ids}")
     try:
-        return manager.get_teams_summary(db=db, domain_id=domain_id)
+        domain_id_list = [d for d in (domain_ids.split(",") if domain_ids else []) if d.strip()]
+        return manager.get_teams_summary(db=db, domain_id=domain_id, domain_ids=domain_id_list or None)
     except Exception as e:
         logger.exception(f"Failed to fetch teams summary: {e}")
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to fetch teams summary")

--- a/src/backend/src/tests/integration/test_l1_migration_backfill.py
+++ b/src/backend/src/tests/integration/test_l1_migration_backfill.py
@@ -1,0 +1,108 @@
+"""Integration test for the l1 multi-domain migration backfill (#520).
+
+The l1 migration (entity_domain_associations) uses Postgres-only SQL — gen_random_uuid(),
+information_schema guards, ON CONFLICT ON CONSTRAINT, a partial-unique index, and a
+uuid->varchar cast — so it cannot run on the SQLite unit suite. This test drives the REAL
+migration via `alembic upgrade head` against a throwaway schema on a live Postgres, and is
+SKIPPED unless a DSN is provided.
+
+To run it, set ONTOS_TEST_PG_DSN to a psycopg2 SQLAlchemy Postgres URL for a THROWAWAY
+database (driver ``postgresql+psycopg2``; supply host, port, db, user, the DB/OAuth token
+as the password, and ``sslmode=require`` for Lakebase), then::
+
+    hatch -e dev run pytest -p no:cacheprovider -o addopts="" \
+      backend/src/tests/integration/test_l1_migration_backfill.py
+
+For Lakebase, mint the token with ``databricks database generate-database-credential``
+(URL-encode the ``@`` in an email username as ``%40``).
+"""
+import os
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+
+DSN = os.environ.get("ONTOS_TEST_PG_DSN")
+BACKEND_DIR = Path(__file__).resolve().parents[3]  # .../src/backend
+
+pytestmark = pytest.mark.skipif(
+    not DSN, reason="ONTOS_TEST_PG_DSN not set; l1 migration backfill test needs a live Postgres."
+)
+
+PRE_L1_SETUP = """
+DROP SCHEMA IF EXISTS {schema} CASCADE;
+CREATE SCHEMA {schema};
+SET search_path TO {schema};
+CREATE TABLE data_domains (id VARCHAR PRIMARY KEY, name VARCHAR NOT NULL);
+CREATE TABLE teams (id VARCHAR PRIMARY KEY, name VARCHAR, domain_id VARCHAR);
+CREATE TABLE data_contracts (id VARCHAR PRIMARY KEY, name VARCHAR, domain_id VARCHAR);
+CREATE TABLE assets (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), name VARCHAR, domain_id VARCHAR);
+CREATE TABLE data_products (id VARCHAR PRIMARY KEY, name VARCHAR, domain VARCHAR);
+INSERT INTO data_domains (id, name) VALUES ('dom-sales','Sales'), ('dom-mkt','Marketing');
+INSERT INTO teams (id, name, domain_id) VALUES ('team-1','T1','dom-sales');
+INSERT INTO data_contracts (id, name, domain_id) VALUES ('contract-1','C1','dom-mkt');
+INSERT INTO assets (id, name, domain_id) VALUES ('11111111-1111-1111-1111-111111111111','A1','dom-sales');
+INSERT INTO data_products (id, name, domain) VALUES
+  ('prod-id','P-ById','dom-sales'), ('prod-name','P-ByName','Marketing'), ('prod-bad','P-Bad','no-such');
+CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL,
+  CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num));
+INSERT INTO alembic_version (version_num) VALUES ('k1_merge_aa1_c1_g3');
+"""
+
+
+@pytest.fixture
+def schema_name():
+    return "l1_migtest_" + uuid.uuid4().hex[:8]
+
+
+def _engine():
+    return create_engine(DSN)
+
+
+def test_l1_backfills_primary_then_drops_legacy_columns(schema_name):
+    engine = _engine()
+    try:
+        with engine.begin() as conn:
+            for stmt in PRE_L1_SETUP.format(schema=schema_name).split(";"):
+                if stmt.strip():
+                    conn.execute(text(stmt))
+
+        # Drive the REAL migration in that schema (stamped at k1 -> runs only l1).
+        env = {**os.environ, "PGSCHEMA": schema_name, "DB_USE_PASSWORD_AUTH": "true"}
+        proc = subprocess.run(
+            ["hatch", "-e", "dev", "run", "alembic", "upgrade", "head"],
+            cwd=str(BACKEND_DIR), env=env, capture_output=True, text=True, timeout=300,
+        )
+        assert proc.returncode == 0, f"alembic upgrade failed:\n{proc.stdout}\n{proc.stderr}"
+
+        with engine.connect() as conn:
+            conn.execute(text(f'SET search_path TO {schema_name}'))
+            rows = conn.execute(text(
+                "SELECT eda.entity_type, eda.entity_id, dd.name, eda.is_primary "
+                "FROM entity_domain_associations eda JOIN data_domains dd ON dd.id = eda.domain_id"
+            )).fetchall()
+            got = {(r[0], r[1]): (r[2], r[3]) for r in rows}
+
+            # Every legacy single-domain value backfilled as PRIMARY.
+            assert got[("team", "team-1")] == ("Sales", True)
+            assert got[("data_contract", "contract-1")] == ("Marketing", True)
+            assert got[("asset", "11111111-1111-1111-1111-111111111111")] == ("Sales", True)
+            assert got[("data_product", "prod-id")] == ("Sales", True)       # resolved by id
+            assert got[("data_product", "prod-name")] == ("Marketing", True)  # resolved by name
+            assert ("data_product", "prod-bad") not in got                    # unresolvable -> skipped
+            assert len(got) == 5
+
+            # Legacy columns dropped.
+            for table, col in [("teams", "domain_id"), ("data_contracts", "domain_id"),
+                               ("assets", "domain_id"), ("data_products", "domain")]:
+                exists = conn.execute(text(
+                    "SELECT 1 FROM information_schema.columns "
+                    "WHERE table_schema=:s AND table_name=:t AND column_name=:c"
+                ), {"s": schema_name, "t": table, "c": col}).scalar()
+                assert exists is None, f"{table}.{col} should have been dropped"
+    finally:
+        with engine.begin() as conn:
+            conn.execute(text(f'DROP SCHEMA IF EXISTS {schema_name} CASCADE'))
+        engine.dispose()

--- a/src/backend/src/tests/unit/test_clone_product_schema_drift.py
+++ b/src/backend/src/tests/unit/test_clone_product_schema_drift.py
@@ -45,7 +45,6 @@ def _make_active_source(db: Session, **overrides) -> DataProductDb:
         status="active",
         name="source-product",
         version="1.0.0",
-        domain="d1",
         tenant=None,
         owner_team_id=None,
         max_level_inheritance=99,

--- a/src/backend/src/tests/unit/test_data_domains_delete_block.py
+++ b/src/backend/src/tests/unit/test_data_domains_delete_block.py
@@ -1,0 +1,102 @@
+"""Unit tests for the multi-domain (#520) domain-deletion guard.
+
+A domain that is the PRIMARY domain for any entity (or for a descendant that would be
+cascade-deleted with it) cannot be deleted — the primary feeds single-value integrations.
+Domains that are only ever *additional* can be deleted, and their association rows are
+cleaned up (the junction FK has no ON DELETE CASCADE).
+"""
+import pytest
+from sqlalchemy.orm import Session
+
+from src.common.errors import ConflictError, NotFoundError
+from src.controller.data_domains_manager import DataDomainManager
+from src.models.data_domains import DataDomainCreate
+from src.repositories.data_domain_repository import data_domain_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
+
+
+@pytest.fixture
+def manager():
+    return DataDomainManager(repository=data_domain_repo)
+
+
+def _make_domain(db: Session, name: str, parent_id=None) -> str:
+    d = data_domain_repo.create(db=db, obj_in=DataDomainCreate(name=name, parent_id=parent_id))
+    db.commit()
+    return d.id
+
+
+def _assign(db: Session, entity_type: str, entity_id: str, domain_ids, primary=None):
+    entity_domain_repo.set_domains_for_entity(
+        db, entity_type=entity_type, entity_id=entity_id,
+        domain_ids=domain_ids, primary_domain_id=primary, assigned_by="tester",
+    )
+    db.commit()
+
+
+class TestDeletionImpact:
+    def test_deletable_when_no_assignments(self, db_session, manager):
+        did = _make_domain(db_session, "Sales")
+        impact = manager.get_domain_deletion_impact(db_session, did)
+        assert impact["deletable"] is True
+        assert impact["primary_assignments"] == []
+
+    def test_deletable_when_only_additional(self, db_session, manager):
+        primary = _make_domain(db_session, "Sales")
+        extra = _make_domain(db_session, "Marketing")
+        # 'extra' is only an ADDITIONAL domain for the product.
+        _assign(db_session, "data_product", "p1", [primary, extra], primary=primary)
+        impact = manager.get_domain_deletion_impact(db_session, extra)
+        assert impact["deletable"] is True
+        assert impact["assignment_counts"]["data_product"]["additional"] == 1
+        assert impact["assignment_counts"]["data_product"]["primary"] == 0
+
+    def test_not_deletable_when_primary(self, db_session, manager):
+        primary = _make_domain(db_session, "Sales")
+        _assign(db_session, "data_product", "p1", [primary], primary=primary)
+        impact = manager.get_domain_deletion_impact(db_session, primary)
+        assert impact["deletable"] is False
+        assert impact["primary_assignments"] == [{"entity_type": "data_product", "entity_id": "p1"}]
+
+    def test_missing_domain_raises(self, db_session, manager):
+        with pytest.raises(NotFoundError):
+            manager.get_domain_deletion_impact(db_session, "does-not-exist")
+
+
+class TestDeleteBlock:
+    def test_delete_blocked_when_primary(self, db_session, manager):
+        did = _make_domain(db_session, "Sales")
+        _assign(db_session, "data_contract", "c1", [did], primary=did)
+        with pytest.raises(ConflictError) as exc:
+            manager.delete_domain(db_session, did, current_user_id="tester")
+        detail = exc.value.detail
+        assert isinstance(detail, dict)
+        assert detail["code"] == "domain_primary_in_use"
+        assert {"entity_type": "data_contract", "entity_id": "c1"} in detail["primary_assignments"]
+        # The domain must still exist (nothing mutated).
+        assert data_domain_repo.get(db_session, did) is not None
+
+    def test_delete_succeeds_and_cleans_additional_rows(self, db_session, manager):
+        primary = _make_domain(db_session, "Sales")
+        extra = _make_domain(db_session, "Marketing")
+        _assign(db_session, "data_product", "p1", [primary, extra], primary=primary)
+
+        result = manager.delete_domain(db_session, extra, current_user_id="tester")
+        db_session.commit()
+        assert result is not None
+        # The domain is gone and its (additional) association row was removed.
+        assert data_domain_repo.get(db_session, extra) is None
+        remaining = entity_domain_repo.get_domains_for_entity(
+            db_session, entity_type="data_product", entity_id="p1"
+        )
+        assert [d.domain_id for d in remaining] == [primary]
+
+    def test_delete_blocked_when_descendant_is_primary(self, db_session, manager):
+        parent = _make_domain(db_session, "Commerce")
+        child = _make_domain(db_session, "Sales", parent_id=parent)
+        # The child (which cascade-deletes with the parent) is primary for a team.
+        _assign(db_session, "team", "t1", [child], primary=child)
+        with pytest.raises(ConflictError) as exc:
+            manager.delete_domain(db_session, parent, current_user_id="tester")
+        assert exc.value.detail["code"] == "domain_primary_in_use"
+        assert {"entity_type": "team", "entity_id": "t1"} in exc.value.detail["primary_assignments"]

--- a/src/backend/src/tests/unit/test_data_products_manager.py
+++ b/src/backend/src/tests/unit/test_data_products_manager.py
@@ -158,6 +158,70 @@ class TestDataProductsManager:
             manager.create_product(sample_product_data, db=db_session)
 
     # =====================================================================
+    # Domain assignment resolution (#520 multi-domain) Tests
+    # =====================================================================
+
+    def _make_domain(self, db_session, name):
+        from src.models.data_domains import DataDomainCreate
+        from src.repositories.data_domain_repository import data_domain_repo
+        d = data_domain_repo.create(db=db_session, obj_in=DataDomainCreate(name=name))
+        db_session.commit()
+        return d
+
+    def test_resolve_domains_snake_case_ids(self, manager, db_session):
+        """domain_ids + primary_domain_id (app/API form) resolve to (ids, primary)."""
+        a = self._make_domain(db_session, "Sales")
+        b = self._make_domain(db_session, "Finance")
+        ids, primary = manager._resolve_product_domain_assignment(
+            {"domain_ids": [a.id, b.id], "primary_domain_id": b.id}, db=db_session
+        )
+        assert set(ids) == {a.id, b.id}
+        assert primary == b.id
+
+    def test_resolve_domains_legacy_single_id(self, manager, db_session):
+        """Legacy single ``domain`` that is a domain ID must resolve (regression guard).
+
+        parse_odcs resolves a bare ``domain`` only by name, so the manager keeps a
+        direct ID short-circuit — without it a UUID in ``domain`` was silently dropped."""
+        a = self._make_domain(db_session, "Marketing")
+        ids, primary = manager._resolve_product_domain_assignment(
+            {"domain": a.id}, db=db_session
+        )
+        assert ids == [a.id]
+        assert primary == a.id
+
+    def test_resolve_domains_legacy_single_name(self, manager, db_session):
+        """Legacy single ``domain`` that is a domain NAME resolves via the adapter."""
+        a = self._make_domain(db_session, "Operations")
+        ids, primary = manager._resolve_product_domain_assignment(
+            {"domain": "Operations"}, db=db_session
+        )
+        assert ids == [a.id]
+        assert primary == a.id
+
+    def test_resolve_domains_odps_additional_roundtrip(self, manager, db_session):
+        """ODPS re-import: primary name + customProperties.additionalDomains reattach."""
+        a = self._make_domain(db_session, "Risk")
+        b = self._make_domain(db_session, "Compliance")
+        ids, primary = manager._resolve_product_domain_assignment(
+            {
+                "domain": "Risk",
+                "customProperties": [
+                    {"property": "additionalDomains", "value": ["Compliance"]}
+                ],
+            },
+            db=db_session,
+        )
+        assert set(ids) == {a.id, b.id}
+        assert primary == a.id
+
+    def test_resolve_domains_empty(self, manager, db_session):
+        """No domain fields → empty assignment."""
+        ids, primary = manager._resolve_product_domain_assignment({}, db=db_session)
+        assert ids == []
+        assert primary is None
+
+    # =====================================================================
     # Get Product Tests
     # =====================================================================
 

--- a/src/backend/src/tests/unit/test_domain_export_adapter.py
+++ b/src/backend/src/tests/unit/test_domain_export_adapter.py
@@ -7,7 +7,6 @@ from src.controller.domain_export_adapter import (
     DomainExportAdapter,
     ADDITIONAL_DOMAINS_PROPERTY,
     UC_DOMAIN_TAG,
-    UC_ADDITIONAL_DOMAIN_TAG,
 )
 from src.models.data_domains import DataDomainCreate
 from src.repositories.data_domain_repository import data_domain_repo
@@ -66,9 +65,11 @@ class TestUcTags:
     def test_primary_then_additional(self, db_session, adapter, domains):
         _assign(db_session, "c1", [domains["Sales"], domains["Marketing"], domains["Finance"]], domains["Marketing"])
         tags = adapter.uc_tags(db_session, ENTITY, "c1")
+        # Primary first under the canonical key, then one numbered tag per additional
+        # domain (UC holds one value per key, so additionals cannot share a key).
         assert tags[0] == (UC_DOMAIN_TAG, "Marketing")
-        additional = {v for k, v in tags if k == UC_ADDITIONAL_DOMAIN_TAG}
-        assert additional == {"Sales", "Finance"}
+        additional = {(k, v) for k, v in tags[1:]}
+        assert additional == {(f"{UC_DOMAIN_TAG}_1", "Finance"), (f"{UC_DOMAIN_TAG}_2", "Sales")}
 
     def test_empty_when_unassigned(self, db_session, adapter):
         assert adapter.uc_tags(db_session, ENTITY, "nope") == []

--- a/src/backend/src/tests/unit/test_domain_export_adapter.py
+++ b/src/backend/src/tests/unit/test_domain_export_adapter.py
@@ -1,0 +1,102 @@
+"""Unit tests for DomainExportAdapter — the single home for the primary/additional
+domain split across ODCS/ODPS export, UC tags, and import round-trip (#520)."""
+import pytest
+from sqlalchemy.orm import Session
+
+from src.controller.domain_export_adapter import (
+    DomainExportAdapter,
+    ADDITIONAL_DOMAINS_PROPERTY,
+    UC_DOMAIN_TAG,
+    UC_ADDITIONAL_DOMAIN_TAG,
+)
+from src.models.data_domains import DataDomainCreate
+from src.repositories.data_domain_repository import data_domain_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
+
+ENTITY = "data_contract"
+
+
+@pytest.fixture
+def adapter():
+    return DomainExportAdapter()
+
+
+@pytest.fixture
+def domains(db_session: Session):
+    ids = {}
+    for name in ("Sales", "Marketing", "Finance"):
+        d = data_domain_repo.create(db=db_session, obj_in=DataDomainCreate(name=name))
+        ids[name] = d.id
+    db_session.commit()
+    return ids
+
+
+def _assign(db, entity_id, domain_ids, primary):
+    entity_domain_repo.set_domains_for_entity(
+        db, entity_type=ENTITY, entity_id=entity_id,
+        domain_ids=domain_ids, primary_domain_id=primary, assigned_by="tester",
+    )
+    db.commit()
+
+
+class TestApplyOdcs:
+    def test_primary_name_and_additional_extension(self, db_session, adapter, domains):
+        _assign(db_session, "c1", [domains["Sales"], domains["Marketing"]], domains["Sales"])
+        odcs = adapter.apply_odcs({}, db_session, ENTITY, "c1")
+        assert odcs["domain"] == "Sales"  # ODCS standard single value = primary name
+        assert odcs["primaryDomainId"] == domains["Sales"]
+        assert set(odcs["domainIds"]) == {domains["Sales"], domains["Marketing"]}
+        assert odcs["domainIds"][0] == domains["Sales"]  # primary first
+        additional = [c for c in odcs["customProperties"] if c.get("property") == ADDITIONAL_DOMAINS_PROPERTY]
+        assert additional and additional[0]["value"] == ["Marketing"]
+
+    def test_no_assignment_leaves_odcs_untouched(self, db_session, adapter, domains):
+        odcs = adapter.apply_odcs({"existing": 1}, db_session, ENTITY, "unassigned")
+        assert odcs == {"existing": 1}
+
+    def test_replaces_stale_additional_domains_entry(self, db_session, adapter, domains):
+        _assign(db_session, "c1", [domains["Sales"], domains["Finance"]], domains["Sales"])
+        odcs = {"customProperties": [{"property": ADDITIONAL_DOMAINS_PROPERTY, "value": ["Stale"]}]}
+        out = adapter.apply_odcs(odcs, db_session, ENTITY, "c1")
+        entries = [c for c in out["customProperties"] if c.get("property") == ADDITIONAL_DOMAINS_PROPERTY]
+        assert len(entries) == 1 and entries[0]["value"] == ["Finance"]
+
+
+class TestUcTags:
+    def test_primary_then_additional(self, db_session, adapter, domains):
+        _assign(db_session, "c1", [domains["Sales"], domains["Marketing"], domains["Finance"]], domains["Marketing"])
+        tags = adapter.uc_tags(db_session, ENTITY, "c1")
+        assert tags[0] == (UC_DOMAIN_TAG, "Marketing")
+        additional = {v for k, v in tags if k == UC_ADDITIONAL_DOMAIN_TAG}
+        assert additional == {"Sales", "Finance"}
+
+    def test_empty_when_unassigned(self, db_session, adapter):
+        assert adapter.uc_tags(db_session, ENTITY, "nope") == []
+
+
+class TestParseOdcsRoundTrip:
+    def test_round_trips_app_keys(self, db_session, adapter, domains):
+        _assign(db_session, "c1", [domains["Sales"], domains["Marketing"]], domains["Marketing"])
+        odcs = adapter.apply_odcs({}, db_session, ENTITY, "c1")
+        domain_ids, primary = adapter.parse_odcs(odcs, db_session)
+        assert set(domain_ids) == {domains["Sales"], domains["Marketing"]}
+        assert primary == domains["Marketing"]
+
+    def test_parses_odcs_standard_names(self, db_session, adapter, domains):
+        odcs = {
+            "domain": "Sales",
+            "customProperties": [{"property": ADDITIONAL_DOMAINS_PROPERTY, "value": ["Marketing"]}],
+        }
+        domain_ids, primary = adapter.parse_odcs(odcs, db_session)
+        assert primary == domains["Sales"]
+        assert set(domain_ids) == {domains["Sales"], domains["Marketing"]}
+
+    def test_unresolvable_name_is_skipped(self, db_session, adapter, domains):
+        domain_ids, primary = adapter.parse_odcs({"domain": "Nonexistent"}, db_session)
+        assert domain_ids == [] and primary is None
+
+    def test_filters_nonexistent_ids(self, db_session, adapter, domains):
+        odcs = {"domainIds": [domains["Sales"], "ghost-id"], "primaryDomainId": "ghost-id"}
+        domain_ids, primary = adapter.parse_odcs(odcs, db_session)
+        assert domain_ids == [domains["Sales"]]
+        assert primary == domains["Sales"]  # invalid primary falls back to first existing

--- a/src/backend/src/tests/unit/test_domain_export_adapter.py
+++ b/src/backend/src/tests/unit/test_domain_export_adapter.py
@@ -61,6 +61,31 @@ class TestApplyOdcs:
         assert len(entries) == 1 and entries[0]["value"] == ["Finance"]
 
 
+class TestMergeCustomProperties:
+    """Guards the export round-trip: rebuilding customProperties must not drop the
+    additionalDomains entry apply_odcs injected (would lose additional domains on export)."""
+
+    def test_preserves_additional_domains_when_rebuilding(self, adapter):
+        applied = [{"property": ADDITIONAL_DOMAINS_PROPERTY, "value": ["Marketing", "Finance"]}]
+        rebuilt = [{"property": "sla", "value": "gold"}]
+        out = adapter.merge_custom_properties(rebuilt, applied)
+        assert {"property": "sla", "value": "gold"} in out
+        addl = [c for c in out if c.get("property") == ADDITIONAL_DOMAINS_PROPERTY]
+        assert addl and addl[0]["value"] == ["Marketing", "Finance"]
+
+    def test_no_previous_returns_rebuilt(self, adapter):
+        rebuilt = [{"property": "sla", "value": "gold"}]
+        assert adapter.merge_custom_properties(rebuilt, None) == rebuilt
+        assert adapter.merge_custom_properties(rebuilt, []) == rebuilt
+
+    def test_dedupes_stale_additional_in_rebuilt(self, adapter):
+        applied = [{"property": ADDITIONAL_DOMAINS_PROPERTY, "value": ["Fresh"]}]
+        rebuilt = [{"property": ADDITIONAL_DOMAINS_PROPERTY, "value": ["Stale"]}]
+        out = adapter.merge_custom_properties(rebuilt, applied)
+        addl = [c for c in out if c.get("property") == ADDITIONAL_DOMAINS_PROPERTY]
+        assert len(addl) == 1 and addl[0]["value"] == ["Fresh"]
+
+
 class TestUcTags:
     def test_primary_then_additional(self, db_session, adapter, domains):
         _assign(db_session, "c1", [domains["Sales"], domains["Marketing"], domains["Finance"]], domains["Marketing"])

--- a/src/backend/src/tests/unit/test_entity_domain_association_repository.py
+++ b/src/backend/src/tests/unit/test_entity_domain_association_repository.py
@@ -1,0 +1,156 @@
+"""Unit tests for EntityDomainAssociationRepository (the multi-domain deep module).
+
+Covers replace-all semantics, the at-most-one-primary invariant, idempotent upserts,
+batch reads, any-of inverse lookups, and deletion-support queries.
+"""
+import pytest
+from sqlalchemy.orm import Session
+
+from src.models.data_domains import DataDomainCreate
+from src.repositories.data_domain_repository import data_domain_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
+
+
+ENTITY = "data_product"
+
+
+@pytest.fixture
+def domains(db_session: Session):
+    """Create three domains: Sales, Marketing, Finance. Returns {name: id}."""
+    ids = {}
+    for name in ("Sales", "Marketing", "Finance"):
+        d = data_domain_repo.create(db=db_session, obj_in=DataDomainCreate(name=name))
+        ids[name] = d.id
+    db_session.commit()
+    return ids
+
+
+def _set(db, entity_id, domain_ids, primary=None):
+    return entity_domain_repo.set_domains_for_entity(
+        db, entity_type=ENTITY, entity_id=entity_id,
+        domain_ids=domain_ids, primary_domain_id=primary, assigned_by="tester",
+    )
+
+
+class TestSetDomainsForEntity:
+    def test_assign_single_defaults_primary(self, db_session, domains):
+        result = _set(db_session, "e1", [domains["Sales"]])
+        db_session.commit()
+        assert len(result) == 1
+        assert result[0].domain_id == domains["Sales"]
+        assert result[0].is_primary is True
+
+    def test_assign_multiple_first_is_primary_by_default(self, db_session, domains):
+        result = _set(db_session, "e1", [domains["Sales"], domains["Marketing"]])
+        db_session.commit()
+        primaries = [d for d in result if d.is_primary]
+        assert len(primaries) == 1
+        assert primaries[0].domain_id == domains["Sales"]
+
+    def test_explicit_primary(self, db_session, domains):
+        result = _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Marketing"])
+        db_session.commit()
+        primaries = [d for d in result if d.is_primary]
+        assert len(primaries) == 1 and primaries[0].domain_id == domains["Marketing"]
+
+    def test_replace_all_add_remove(self, db_session, domains):
+        _set(db_session, "e1", [domains["Sales"], domains["Marketing"]])
+        db_session.commit()
+        result = _set(db_session, "e1", [domains["Marketing"], domains["Finance"]], primary=domains["Finance"])
+        db_session.commit()
+        got = {d.domain_id for d in result}
+        assert got == {domains["Marketing"], domains["Finance"]}
+        assert entity_domain_repo.get_primary_domain_id(db_session, entity_type=ENTITY, entity_id="e1") == domains["Finance"]
+
+    def test_swap_primary_only(self, db_session, domains):
+        _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Sales"])
+        db_session.commit()
+        _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Marketing"])
+        db_session.commit()
+        assert entity_domain_repo.get_primary_domain_id(db_session, entity_type=ENTITY, entity_id="e1") == domains["Marketing"]
+
+    def test_remove_all_leaves_unassigned(self, db_session, domains):
+        _set(db_session, "e1", [domains["Sales"]])
+        db_session.commit()
+        result = _set(db_session, "e1", [])
+        db_session.commit()
+        assert result == []
+        assert entity_domain_repo.get_primary_domain_id(db_session, entity_type=ENTITY, entity_id="e1") is None
+
+    def test_idempotent(self, db_session, domains):
+        _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Sales"])
+        db_session.commit()
+        r2 = _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Sales"])
+        db_session.commit()
+        assert {d.domain_id for d in r2} == {domains["Sales"], domains["Marketing"]}
+        assert len([d for d in r2 if d.is_primary]) == 1
+
+    def test_dedupe_domain_ids(self, db_session, domains):
+        result = _set(db_session, "e1", [domains["Sales"], domains["Sales"], domains["Marketing"]])
+        db_session.commit()
+        assert len(result) == 2
+
+    def test_primary_not_in_set_raises(self, db_session, domains):
+        with pytest.raises(ValueError):
+            _set(db_session, "e1", [domains["Sales"]], primary=domains["Marketing"])
+
+    def test_unknown_domain_raises(self, db_session, domains):
+        with pytest.raises(ValueError):
+            _set(db_session, "e1", ["does-not-exist"])
+
+
+class TestBatchAndInverse:
+    def test_batch_reads(self, db_session, domains):
+        _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Sales"])
+        _set(db_session, "e2", [domains["Finance"]])
+        db_session.commit()
+        got = entity_domain_repo.get_domains_for_entities(db_session, entity_type=ENTITY, entity_ids=["e1", "e2", "e3"])
+        assert {d.domain_id for d in got["e1"]} == {domains["Sales"], domains["Marketing"]}
+        assert [d.domain_id for d in got["e2"]] == [domains["Finance"]]
+        assert got["e3"] == []
+        # e1 primary first
+        assert got["e1"][0].is_primary is True and got["e1"][0].domain_id == domains["Sales"]
+
+    def test_find_entity_ids_any_of(self, db_session, domains):
+        _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Sales"])
+        _set(db_session, "e2", [domains["Marketing"]])
+        _set(db_session, "e3", [domains["Finance"]])
+        db_session.commit()
+        got = set(entity_domain_repo.find_entity_ids_by_domains(
+            db_session, domain_ids=[domains["Marketing"], domains["Finance"]], entity_type=ENTITY))
+        assert got == {"e1", "e2", "e3"}
+
+    def test_find_entity_ids_primary_only(self, db_session, domains):
+        _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Sales"])
+        _set(db_session, "e2", [domains["Marketing"]])
+        db_session.commit()
+        got = set(entity_domain_repo.find_entity_ids_by_domain(
+            db_session, domain_id=domains["Marketing"], entity_type=ENTITY, primary_only=True))
+        assert got == {"e2"}  # e1 has Marketing as additional, not primary
+
+
+class TestDeletionSupport:
+    def test_entities_with_primary_domain(self, db_session, domains):
+        _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Sales"])
+        _set(db_session, "e2", [domains["Marketing"]], primary=domains["Marketing"])
+        db_session.commit()
+        blockers = entity_domain_repo.get_entities_with_primary_domain(db_session, domain_id=domains["Marketing"])
+        assert (ENTITY, "e2") in blockers
+        assert (ENTITY, "e1") not in blockers  # Marketing is additional for e1
+
+    def test_remove_all_for_domain(self, db_session, domains):
+        _set(db_session, "e1", [domains["Sales"], domains["Marketing"]], primary=domains["Sales"])
+        db_session.commit()
+        removed = entity_domain_repo.remove_all_for_domain(db_session, domain_id=domains["Marketing"])
+        db_session.commit()
+        assert removed == 1
+        remaining = entity_domain_repo.get_domains_for_entity(db_session, entity_type=ENTITY, entity_id="e1")
+        assert {d.domain_id for d in remaining} == {domains["Sales"]}
+
+    def test_assignment_counts(self, db_session, domains):
+        _set(db_session, "e1", [domains["Marketing"]], primary=domains["Marketing"])
+        _set(db_session, "e2", [domains["Sales"], domains["Marketing"]], primary=domains["Sales"])
+        db_session.commit()
+        counts = entity_domain_repo.get_assignment_counts_for_domain(db_session, domain_id=domains["Marketing"])
+        assert counts[ENTITY]["primary"] == 1
+        assert counts[ENTITY]["additional"] == 1

--- a/src/backend/src/tests/unit/test_teams_manager.py
+++ b/src/backend/src/tests/unit/test_teams_manager.py
@@ -91,6 +91,25 @@ class TestTeamsManager:
         assert result.primary_domain_id == domain_id
         assert len(result.domains) == 1 and result.domains[0].is_primary
 
+    def test_create_team_primary_not_in_domain_ids_is_clamped(self, manager, db_session):
+        """A primary_domain_id outside domain_ids must be clamped to the first id, not
+        propagated to set_domains_for_entity (which would raise ValueError -> HTTP 500)."""
+        a = _make_domain(db_session, "Alpha")
+        b = _make_domain(db_session, "Beta")
+        team_data = TeamCreate(
+            name="Clamp Team",
+            description="primary not in set",
+            domain_ids=[a, b],
+            primary_domain_id="not-a-member",
+        )
+
+        # Act — should not raise; primary falls back to the first domain id.
+        result = manager.create_team(db_session, team_data, current_user_id="user1")
+
+        # Assert
+        assert set(result.domain_ids) == {a, b}
+        assert result.primary_domain_id == a
+
     # =====================================================================
     # Get Team Tests
     # =====================================================================

--- a/src/backend/src/tests/unit/test_teams_manager.py
+++ b/src/backend/src/tests/unit/test_teams_manager.py
@@ -14,6 +14,16 @@ from sqlalchemy.orm import Session
 from src.controller.teams_manager import TeamsManager
 from src.models.teams import TeamCreate, TeamUpdate, TeamMemberCreate, TeamMemberUpdate
 from src.db_models.teams import TeamDb, TeamMemberDb
+from src.models.data_domains import DataDomainCreate
+from src.repositories.data_domain_repository import data_domain_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
+
+
+def _make_domain(db_session, name: str) -> str:
+    """Create a real data domain and return its id (needed for FK-backed assignments)."""
+    d = data_domain_repo.create(db=db_session, obj_in=DataDomainCreate(name=name))
+    db_session.commit()
+    return d.id
 
 
 class TestTeamsManager:
@@ -63,19 +73,23 @@ class TestTeamsManager:
         assert result.description == sample_team_data.description
 
     def test_create_team_with_domain(self, manager, db_session):
-        """Test creating team with domain association."""
+        """Test creating team with (multi-)domain association."""
         # Arrange
+        domain_id = _make_domain(db_session, "Domain 123")
         team_data = TeamCreate(
             name="Domain Team",
             description="Team with domain",
-            domain_id="domain-123",
+            domain_ids=[domain_id],
+            primary_domain_id=domain_id,
         )
 
         # Act
         result = manager.create_team(db_session, team_data, current_user_id="user1")
 
         # Assert
-        assert result.domain_id == "domain-123"
+        assert result.domain_ids == [domain_id]
+        assert result.primary_domain_id == domain_id
+        assert len(result.domains) == 1 and result.domains[0].is_primary
 
     # =====================================================================
     # Get Team Tests
@@ -133,12 +147,12 @@ class TestTeamsManager:
         assert len(result) == 3
 
     def test_get_teams_by_domain(self, manager, db_session):
-        """Test filtering teams by domain."""
+        """Test filtering teams by domain (any-of via junction)."""
         # Arrange - Create teams with and without domain
+        domain_id = _make_domain(db_session, "Domain 123")
         team_with_domain = TeamDb(
             id=str(uuid.uuid4()),
             name="Domain Team",
-            domain_id="domain-123",
             created_by="test-user",
             updated_by="test-user",
             extra_metadata='{}',
@@ -153,21 +167,25 @@ class TestTeamsManager:
         db_session.add(team_with_domain)
         db_session.add(team_without_domain)
         db_session.commit()
+        entity_domain_repo.set_domains_for_entity(
+            db_session, entity_type="team", entity_id=team_with_domain.id, domain_ids=[domain_id]
+        )
+        db_session.commit()
 
         # Act
-        result = manager.get_teams_by_domain(db_session, "domain-123")
+        result = manager.get_teams_by_domain(db_session, domain_id)
 
         # Assert
         assert len(result) == 1
         assert result[0].name == "Domain Team"
 
     def test_get_standalone_teams(self, manager, db_session):
-        """Test getting teams without domain."""
+        """Test getting teams without any domain assignment."""
         # Arrange
+        domain_id = _make_domain(db_session, "Domain 123")
         standalone_team = TeamDb(
             id=str(uuid.uuid4()),
             name="Standalone Team",
-            domain_id=None,
             created_by="test-user",
             updated_by="test-user",
             extra_metadata='{}',
@@ -175,13 +193,16 @@ class TestTeamsManager:
         domain_team = TeamDb(
             id=str(uuid.uuid4()),
             name="Domain Team",
-            domain_id="domain-123",
             created_by="test-user",
             updated_by="test-user",
             extra_metadata='{}',
         )
         db_session.add(standalone_team)
         db_session.add(domain_team)
+        db_session.commit()
+        entity_domain_repo.set_domains_for_entity(
+            db_session, entity_type="team", entity_id=domain_team.id, domain_ids=[domain_id]
+        )
         db_session.commit()
 
         # Act

--- a/src/backend/src/tests/unit/test_teams_repository.py
+++ b/src/backend/src/tests/unit/test_teams_repository.py
@@ -12,6 +12,9 @@ import uuid
 from src.repositories.teams_repository import TeamRepository
 from src.models.teams import TeamCreate
 from src.db_models.teams import TeamDb
+from src.models.data_domains import DataDomainCreate
+from src.repositories.data_domain_repository import data_domain_repo
+from src.repositories.entity_domain_association_repository import entity_domain_repo
 
 
 class TestTeamRepository:
@@ -173,12 +176,13 @@ class TestTeamRepository:
     # =====================================================================
 
     def test_get_teams_by_domain(self, repository, db_session):
-        """Test filtering teams by domain."""
+        """Test filtering teams by domain (any-of via junction)."""
         # Arrange
+        domain = data_domain_repo.create(db=db_session, obj_in=DataDomainCreate(name="Domain 123"))
+        db_session.commit()
         team_with_domain = TeamDb(
             id=str(uuid.uuid4()),
             name="Domain Team",
-            domain_id="domain-123",
             created_by="test-user",
             updated_by="test-user",
             extra_metadata='{}',
@@ -193,9 +197,13 @@ class TestTeamRepository:
         db_session.add(team_with_domain)
         db_session.add(team_without_domain)
         db_session.commit()
+        entity_domain_repo.set_domains_for_entity(
+            db_session, entity_type="team", entity_id=team_with_domain.id, domain_ids=[domain.id]
+        )
+        db_session.commit()
 
         # Act
-        domain_teams = repository.get_teams_by_domain(db_session, domain_id="domain-123")
+        domain_teams = repository.get_teams_by_domain(db_session, domain_id=domain.id)
 
         # Assert
         assert len(domain_teams) == 1

--- a/src/backend/src/tests/unit/test_term_mapping_adapters_get_target.py
+++ b/src/backend/src/tests/unit/test_term_mapping_adapters_get_target.py
@@ -314,6 +314,8 @@ def test_product_adapter_get_target_returns_none_when_missing():
 
 def test_product_adapter_get_target_builds_entity():
     from src.controller.term_mapping.adapters.product_adapter import ProductAdapter
+    from src.models.domain_associations import AssignedDomain
+    import src.repositories.entity_domain_association_repository as edar
 
     product_id = str(uuid.uuid4())
     product = SimpleNamespace(
@@ -321,12 +323,17 @@ def test_product_adapter_get_target_builds_entity():
         name="Customer 360",
         version="2.1.0",
         status="released",
-        domain="customer",
     )
     db = MagicMock()
     db.query.return_value.filter.return_value.first.return_value = product
 
-    target = ProductAdapter().get_target(db, product_id)
+    # Domain now comes from the entity_domain_associations junction (#520): the
+    # adapter surfaces the primary domain name.
+    with patch.object(
+        edar.entity_domain_repo, "get_domains_for_entity",
+        return_value=[AssignedDomain(domain_id="dom-1", domain_name="customer", is_primary=True)],
+    ):
+        target = ProductAdapter().get_target(db, product_id)
     assert target is not None
     assert target.entity_type == "data_product"
     assert target.entity_id == product_id

--- a/src/backend/src/tests/unit/test_term_mapping_adapters_get_target.py
+++ b/src/backend/src/tests/unit/test_term_mapping_adapters_get_target.py
@@ -330,8 +330,8 @@ def test_product_adapter_get_target_builds_entity():
     # Domain now comes from the entity_domain_associations junction (#520): the
     # adapter surfaces the primary domain name.
     with patch.object(
-        edar.entity_domain_repo, "get_domains_for_entity",
-        return_value=[AssignedDomain(domain_id="dom-1", domain_name="customer", is_primary=True)],
+        edar.entity_domain_repo, "get_domains_for_entities",
+        return_value={product_id: [AssignedDomain(domain_id="dom-1", domain_name="customer", is_primary=True)]},
     ):
         target = ProductAdapter().get_target(db, product_id)
     assert target is not None

--- a/src/backend/src/tools/data_contracts.py
+++ b/src/backend/src/tools/data_contracts.py
@@ -49,25 +49,40 @@ class SearchDataContractsTool(BaseTool):
         
         try:
             from src.db_models.data_contracts import DataContractDb
-            
+            from src.repositories.entity_domain_association_repository import entity_domain_repo
+
             contracts_db = ctx.db.query(DataContractDb).limit(500).all()
             logger.debug(f"[search_data_contracts] Found {len(contracts_db)} total contracts in database")
-            
+
             if not contracts_db:
                 return ToolResult(
                     success=True,
                     data={"contracts": [], "total_found": 0, "message": "No data contracts found"}
                 )
-            
+
+            # Batch-load domain assignments (domain moved to the junction table).
+            domains_map = entity_domain_repo.get_domains_for_entities(
+                ctx.db, entity_type="data_contract", entity_ids=[str(c.id) for c in contracts_db]
+            )
+            contract_domain_names: Dict[str, List[str]] = {
+                cid: [a.domain_name for a in assigned if a.domain_name]
+                for cid, assigned in domains_map.items()
+            }
+            contract_primary_domain: Dict[str, Optional[str]] = {
+                cid: next((a.domain_name for a in assigned if a.is_primary), None)
+                for cid, assigned in domains_map.items()
+            }
+
             query_lower = query.lower() if query and query != '*' else ''
             filtered = []
-            
+
             for c in contracts_db:
+                c_domain_names = contract_domain_names.get(str(c.id), [])
                 if not query_lower:
                     include = True
                 else:
                     name_match = query_lower in (c.name or "").lower()
-                    
+
                     desc_match = False
                     if c.description:
                         try:
@@ -79,16 +94,16 @@ class SearchDataContractsTool(BaseTool):
                                 desc_match = query_lower in desc_dict.lower()
                         except Exception:
                             pass
-                    
-                    domain_match = query_lower in (c.domain or "").lower()
+
+                    domain_match = any(query_lower in (n or "").lower() for n in c_domain_names)
                     include = name_match or desc_match or domain_match
-                
+
                 if include:
-                    if domain and c.domain and c.domain.lower() != domain.lower():
+                    if domain and not any(n.lower() == domain.lower() for n in c_domain_names):
                         continue
                     if status and c.status != status:
                         continue
-                    
+
                     desc_purpose = None
                     if c.description:
                         try:
@@ -97,11 +112,11 @@ class SearchDataContractsTool(BaseTool):
                                 desc_purpose = desc_dict.get('purpose')
                         except Exception:
                             pass
-                    
+
                     filtered.append({
                         "id": str(c.id),
                         "name": c.name,
-                        "domain": c.domain,
+                        "domain": contract_primary_domain.get(str(c.id)),
                         "description": desc_purpose,
                         "status": c.status,
                         "version": c.version
@@ -146,15 +161,22 @@ class GetDataContractTool(BaseTool):
         
         try:
             from src.db_models.data_contracts import DataContractDb
-            
+            from src.repositories.entity_domain_association_repository import entity_domain_repo
+
             contract = ctx.db.query(DataContractDb).filter(DataContractDb.id == contract_id).first()
-            
+
             if not contract:
                 return ToolResult(
                     success=False,
                     error=f"Data contract '{contract_id}' not found"
                 )
-            
+
+            # Domain now lives in the entity_domain_associations junction; use the primary.
+            assigned = entity_domain_repo.get_domains_for_entity(
+                ctx.db, entity_type="data_contract", entity_id=str(contract.id)
+            )
+            primary_domain = next((a.domain_name for a in assigned if a.is_primary), None)
+
             desc_purpose = None
             if contract.description:
                 try:
@@ -163,14 +185,14 @@ class GetDataContractTool(BaseTool):
                         desc_purpose = desc_dict.get('purpose')
                 except Exception:
                     pass
-            
+
             logger.info(f"[get_data_contract] SUCCESS: Found contract {contract_id}")
             return ToolResult(
                 success=True,
                 data={
                     "id": str(contract.id),
                     "name": contract.name,
-                    "domain": contract.domain,
+                    "domain": primary_domain,
                     "description": desc_purpose,
                     "status": contract.status,
                     "version": contract.version,

--- a/src/backend/src/tools/data_products.py
+++ b/src/backend/src/tools/data_products.py
@@ -39,15 +39,22 @@ class GetDataProductTool(BaseTool):
         
         try:
             from src.db_models.data_products import DataProductDb
-            
+            from src.repositories.entity_domain_association_repository import entity_domain_repo
+
             product = ctx.db.query(DataProductDb).filter(DataProductDb.id == product_id).first()
-            
+
             if not product:
                 return ToolResult(
                     success=False,
                     error=f"Data product '{product_id}' not found"
                 )
-            
+
+            # Domain now lives in the entity_domain_associations junction; use the primary.
+            assigned = entity_domain_repo.get_domains_for_entity(
+                ctx.db, entity_type="data_product", entity_id=str(product.id)
+            )
+            primary_domain = next((a.domain_name for a in assigned if a.is_primary), None)
+
             # Extract description purpose from JSON
             desc_purpose = None
             if product.description:
@@ -76,7 +83,7 @@ class GetDataProductTool(BaseTool):
                 data={
                     "id": str(product.id),
                     "name": product.name,
-                    "domain": product.domain,
+                    "domain": primary_domain,
                     "description": desc_purpose,
                     "status": product.status,
                     "version": product.version,
@@ -182,16 +189,31 @@ class SearchDataProductsTool(BaseTool):
             # Query database directly using the session
             from src.db_models.data_products import DataProductDb
             from src.db_models.semantic_links import EntitySemanticLinkDb
-            
+            from src.repositories.entity_domain_association_repository import entity_domain_repo
+
             products_db = ctx.db.query(DataProductDb).limit(500).all()
             logger.debug(f"[search_data_products] Found {len(products_db)} total products in database")
-            
+
             if not products_db:
                 logger.info(f"[search_data_products] No products found in database")
                 return ToolResult(
                     success=True,
                     data={"products": [], "total_found": 0, "message": "No data products found"}
                 )
+
+            # Batch-load domain assignments (domain moved to the junction table).
+            # {product_id: [domain names]} with the primary name tracked separately.
+            domains_map = entity_domain_repo.get_domains_for_entities(
+                ctx.db, entity_type="data_product", entity_ids=[str(p.id) for p in products_db]
+            )
+            product_domain_names: Dict[str, List[str]] = {
+                pid: [a.domain_name for a in assigned if a.domain_name]
+                for pid, assigned in domains_map.items()
+            }
+            product_primary_domain: Dict[str, Optional[str]] = {
+                pid: next((a.domain_name for a in assigned if a.is_primary), None)
+                for pid, assigned in domains_map.items()
+            }
             
             # Filter by query (name, description, domain)
             query_lower = query.lower() if query and query != '*' else ''
@@ -215,13 +237,14 @@ class SearchDataProductsTool(BaseTool):
                     logger.warning(f"[search_data_products] Semantic link lookup failed: {e}")
             
             for p in products_db:
+                p_domain_names = product_domain_names.get(str(p.id), [])
                 # If query is empty or '*', include all products
                 if not query_lower:
                     include = True
                 else:
                     # Match on name
                     name_match = query_lower in (p.name or "").lower()
-                    
+
                     # Match on description (stored as JSON)
                     desc_match = False
                     if p.description:
@@ -232,18 +255,18 @@ class SearchDataProductsTool(BaseTool):
                                 desc_match = query_lower in desc_text.lower()
                         except Exception:
                             pass
-                    
-                    # Match on domain
-                    domain_match = query_lower in (p.domain or "").lower()
-                    
+
+                    # Match on domain (any assigned domain — primary or additional)
+                    domain_match = any(query_lower in (n or "").lower() for n in p_domain_names)
+
                     # Match via semantic links (ontology concepts)
                     semantic_match = str(p.id) in semantic_product_ids
-                    
+
                     include = name_match or desc_match or domain_match or semantic_match
-                
+
                 if include:
-                    # Apply filters
-                    if domain and p.domain and p.domain.lower() != domain.lower():
+                    # Apply filters (any-of over assigned domains)
+                    if domain and not any(n.lower() == domain.lower() for n in p_domain_names):
                         continue
                     if status and p.status != status:
                         continue
@@ -273,7 +296,7 @@ class SearchDataProductsTool(BaseTool):
                     filtered.append({
                         "id": str(p.id),
                         "name": p.name,
-                        "domain": p.domain,
+                        "domain": product_primary_domain.get(str(p.id)),
                         "description": desc_purpose,
                         "status": p.status,
                         "output_tables": output_tables[:5],  # Limit for response size

--- a/src/backend/src/tools/teams.py
+++ b/src/backend/src/tools/teams.py
@@ -7,6 +7,7 @@ Tools for searching, creating, updating, and deleting teams.
 from typing import Any, Dict, List, Optional
 
 from src.common.logging import get_logger
+from src.repositories.entity_domain_association_repository import entity_domain_repo
 from src.tools.base import BaseTool, ToolContext, ToolResult
 
 logger = get_logger(__name__)
@@ -42,11 +43,15 @@ class SearchTeamsTool(BaseTool):
         
         try:
             from src.db_models.teams import TeamDb
-            
+            from src.repositories.entity_domain_association_repository import entity_domain_repo
+
             db_query = ctx.db.query(TeamDb)
             if domain_id:
-                db_query = db_query.filter(TeamDb.domain_id == domain_id)
-            
+                team_ids = entity_domain_repo.find_entity_ids_by_domain(
+                    ctx.db, domain_id=domain_id, entity_type="team"
+                )
+                db_query = db_query.filter(TeamDb.id.in_(team_ids or ["__none__"]))
+
             teams_db = db_query.limit(500).all()
             logger.debug(f"[search_teams] Found {len(teams_db)} total teams in database")
             
@@ -74,7 +79,11 @@ class SearchTeamsTool(BaseTool):
                         "name": t.name,
                         "title": t.title,
                         "description": t.description,
-                        "domain_id": str(t.domain_id) if t.domain_id else None,
+                        "domain_ids": [
+                            d.domain_id for d in entity_domain_repo.get_domains_for_entity(
+                                ctx.db, entity_type="team", entity_id=str(t.id)
+                            )
+                        ],
                         "member_count": len(t.members) if t.members else 0
                     })
             
@@ -142,8 +151,12 @@ class GetTeamTool(BaseTool):
                     "name": team.name,
                     "title": team.title,
                     "description": team.description,
-                    "domain_id": str(team.domain_id) if team.domain_id else None,
-                    "domain_name": team.domain_name,
+                    "domains": [
+                        {"domain_id": d.domain_id, "domain_name": d.domain_name, "is_primary": d.is_primary}
+                        for d in entity_domain_repo.get_domains_for_entity(
+                            ctx.db, entity_type="team", entity_id=str(team.id)
+                        )
+                    ],
                     "member_count": len(team.members) if team.members else 0,
                     "members": members,
                     "created_at": team.created_at.isoformat() if team.created_at else None
@@ -201,7 +214,8 @@ class CreateTeamTool(BaseTool):
                 name=name,
                 title=title,
                 description=description or "",
-                domain_id=domain_id
+                domain_ids=[domain_id] if domain_id else [],
+                primary_domain_id=domain_id or None,
             )
             
             created = teams_manager.create_team(
@@ -285,8 +299,10 @@ class UpdateTeamTool(BaseTool):
             if description is not None:
                 update_data["description"] = description
             if domain_id is not None:
-                update_data["domain_id"] = domain_id if domain_id else None
-            
+                # Single-domain tool contract maps onto multi-domain replace-all.
+                update_data["domain_ids"] = [domain_id] if domain_id else []
+                update_data["primary_domain_id"] = domain_id or None
+
             if not update_data:
                 return ToolResult(
                     success=False,

--- a/src/backend/src/utils/contract_cloner.py
+++ b/src/backend/src/utils/contract_cloner.py
@@ -75,7 +75,7 @@ class ContractCloner:
             'owner_team_id': source_contract_db.owner_team_id,
             'tenant': source_contract_db.tenant,
             'data_product': source_contract_db.data_product,
-            'domain_id': source_contract_db.domain_id,
+            # domain assignment is copied separately via entity_domain_associations
             'project_id': source_contract_db.project_id,
 
             # Copy descriptions

--- a/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
+++ b/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
@@ -165,8 +165,9 @@ class DatasetTagInfo:
     product_status: Optional[str]
     # Domain metadata: primary domain (prefer contract, fallback to product).
     # With multi-domain assignment the primary feeds the single-value ``data_domain``
-    # tag; ``additional_domain_names`` carries the non-primary domains (emitted as a
-    # companion ``data_domain_additional`` tag). See DomainExportAdapter.uc_tags.
+    # tag; ``additional_domain_names`` carries the non-primary domains, each emitted as
+    # its own numbered tag (``data_domain_1``, ``data_domain_2``, ...) since a UC
+    # securable holds one value per tag key. See DomainExportAdapter.uc_tags.
     domain_id: Optional[str]
     domain_name: Optional[str]
     # Semantic links
@@ -794,13 +795,15 @@ def build_desired_for_dataset(d: DatasetTagInfo, tag_sync_configs: List[Dict[str
                     tag_key = sanitize_tag_key(tag_key)
                     desired[tag_key] = tag_value
 
-                    # Additional (non-primary) domains ride on a companion tag key.
-                    # For the default ``data_domain`` key this yields
-                    # ``data_domain_additional`` (see DomainExportAdapter.uc_tags);
-                    # UC allows one value per key, so the names are comma-joined.
-                    if d.additional_domain_names:
-                        additional_key = sanitize_tag_key(f"{tag_key}_additional")
-                        desired[additional_key] = ",".join(d.additional_domain_names)
+                    # Additional (non-primary) domains are emitted as separate UC
+                    # tags, one per assignment (PRD story 26). A UC securable holds
+                    # one value per tag key, so each additional domain gets its own
+                    # numbered key derived from the primary key (``data_domain_1``,
+                    # ``data_domain_2``, ...) written after the primary. Names are
+                    # sorted for deterministic key assignment.
+                    for idx, name in enumerate(sorted(d.additional_domain_names), start=1):
+                        additional_key = sanitize_tag_key(f"{tag_key}_{idx}")
+                        desired[additional_key] = name
 
         elif entity_type == "data_contract":
             if d.contract_name:

--- a/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
+++ b/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
@@ -505,14 +505,20 @@ def merge_dataset_tag_infos(contract_datasets: List[DatasetTagInfo], asset_datas
             existing.product_status = existing.product_status or d.product_status
             existing.asset_id = existing.asset_id or d.asset_id
             existing.asset_type_name = existing.asset_type_name or d.asset_type_name
-            # Domain: the primary and its additional domains belong to the SAME source, so
-            # adopt them together. Only take d's domain (+ its additionals) when `existing`
-            # had no primary yet — otherwise we'd tag existing's primary with additionals
-            # that belong to a different source's primary.
+            # Domain: a primary and its additional domains belong to the SAME source.
+            # - existing has no primary yet  -> adopt d's primary + its additionals.
+            # - both sources share the same primary -> union the additionals (both are
+            #   legitimate additional domains for this FQN).
+            # - primaries differ -> keep existing's; do NOT attach d's additionals to a
+            #   different source's primary.
             if not existing.domain_name and d.domain_name:
                 existing.domain_id = d.domain_id
                 existing.domain_name = d.domain_name
                 existing.additional_domain_names = list(d.additional_domain_names)
+            elif existing.domain_name and d.domain_name == existing.domain_name:
+                for name in d.additional_domain_names:
+                    if name not in existing.additional_domain_names:
+                        existing.additional_domain_names.append(name)
             # Union semantic links
             existing_iris = {link.iri for link in existing.semantic_links}
             for link in d.semantic_links:

--- a/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
+++ b/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
@@ -503,14 +503,16 @@ def merge_dataset_tag_infos(contract_datasets: List[DatasetTagInfo], asset_datas
             existing.product_name = existing.product_name or d.product_name
             existing.product_version = existing.product_version or d.product_version
             existing.product_status = existing.product_status or d.product_status
-            existing.domain_id = existing.domain_id or d.domain_id
-            existing.domain_name = existing.domain_name or d.domain_name
             existing.asset_id = existing.asset_id or d.asset_id
             existing.asset_type_name = existing.asset_type_name or d.asset_type_name
-            # Union additional domains (preserve order, dedupe)
-            for name in d.additional_domain_names:
-                if name not in existing.additional_domain_names:
-                    existing.additional_domain_names.append(name)
+            # Domain: the primary and its additional domains belong to the SAME source, so
+            # adopt them together. Only take d's domain (+ its additionals) when `existing`
+            # had no primary yet — otherwise we'd tag existing's primary with additionals
+            # that belong to a different source's primary.
+            if not existing.domain_name and d.domain_name:
+                existing.domain_id = d.domain_id
+                existing.domain_name = d.domain_name
+                existing.additional_domain_names = list(d.additional_domain_names)
             # Union semantic links
             existing_iris = {link.iri for link in existing.semantic_links}
             for link in d.semantic_links:

--- a/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
+++ b/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
@@ -4,7 +4,7 @@ import re
 import sys
 import argparse
 from typing import Any, Dict, Iterable, List, Optional, Tuple
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from uuid import uuid4
 
 from sqlalchemy import create_engine, text
@@ -163,7 +163,10 @@ class DatasetTagInfo:
     product_name: Optional[str]
     product_version: Optional[str]
     product_status: Optional[str]
-    # Domain metadata (prefer contract domain, fallback to product domain)
+    # Domain metadata: primary domain (prefer contract, fallback to product).
+    # With multi-domain assignment the primary feeds the single-value ``data_domain``
+    # tag; ``additional_domain_names`` carries the non-primary domains (emitted as a
+    # companion ``data_domain_additional`` tag). See DomainExportAdapter.uc_tags.
     domain_id: Optional[str]
     domain_name: Optional[str]
     # Semantic links
@@ -171,6 +174,8 @@ class DatasetTagInfo:
     # Asset metadata (populated when sourced from assets table)
     asset_id: Optional[str] = None
     asset_type_name: Optional[str] = None
+    # Additional (non-primary) domain names for the chosen domain source.
+    additional_domain_names: List[str] = field(default_factory=list)
 
 
 def read_contracts_and_links(engine: Engine, limit: Optional[int] = None) -> List[Dict[str, Any]]:
@@ -181,7 +186,6 @@ def read_contracts_and_links(engine: Engine, limit: Optional[int] = None) -> Lis
                c.version AS contract_version,
                c.status AS contract_status,
                c.data_product AS product_name_from_contract,
-               c.domain_id AS contract_domain_id,
                o.id   AS object_id,
                o.name AS schema_name,
                o.physical_name,
@@ -189,19 +193,40 @@ def read_contracts_and_links(engine: Engine, limit: Optional[int] = None) -> Lis
                el.label AS schema_semantic_label,
                d.id AS domain_id,
                d.name AS domain_name,
+               (SELECT array_agg(dd.name ORDER BY dd.name)
+                  FROM entity_domain_associations eda2
+                  JOIN data_domains dd ON dd.id = eda2.domain_id
+                 WHERE eda2.entity_type = 'data_contract'
+                   AND eda2.entity_id = c.id
+                   AND eda2.is_primary = FALSE) AS contract_additional_domains,
                p.id AS product_id,
                p.name AS product_name,
                p.version AS product_version,
                p.status AS product_status,
-               p.domain AS product_domain
+               pd.name AS product_domain,
+               (SELECT array_agg(dd.name ORDER BY dd.name)
+                  FROM entity_domain_associations eda3
+                  JOIN data_domains dd ON dd.id = eda3.domain_id
+                 WHERE eda3.entity_type = 'data_product'
+                   AND eda3.entity_id = p.id
+                   AND eda3.is_primary = FALSE) AS product_additional_domains
         FROM data_contracts c
         JOIN data_contract_schema_objects o ON o.contract_id = c.id
         LEFT JOIN entity_semantic_links el
           ON el.entity_type = 'data_contract_schema'
          AND el.entity_id = c.id || '#' || o.name
-        LEFT JOIN data_domains d ON c.domain_id = d.id
+        LEFT JOIN entity_domain_associations eda
+          ON eda.entity_type = 'data_contract'
+         AND eda.entity_id = c.id
+         AND eda.is_primary = TRUE
+        LEFT JOIN data_domains d ON d.id = eda.domain_id
         LEFT JOIN data_product_output_ports op ON op.contract_id = c.id AND op.asset_identifier = o.physical_name
         LEFT JOIN data_products p ON op.product_id = p.id
+        LEFT JOIN entity_domain_associations pda
+          ON pda.entity_type = 'data_product'
+         AND pda.entity_id = p.id
+         AND pda.is_primary = TRUE
+        LEFT JOIN data_domains pd ON pd.id = pda.domain_id
         """
         + (" LIMIT :limit" if limit else "")
     )
@@ -230,7 +255,9 @@ def build_dataset_tag_infos(rows: List[Dict[str, Any]], default_catalog: Optiona
                 "product_status": r.get("product_status"),
                 "domain_id": r.get("domain_id"),
                 "domain_name": r.get("domain_name"),
+                "contract_additional_domains": r.get("contract_additional_domains") or [],
                 "product_domain": r.get("product_domain"),
+                "product_additional_domains": r.get("product_additional_domains") or [],
                 "semantic_links": [],
             },
         )
@@ -258,12 +285,14 @@ def build_dataset_tag_infos(rows: List[Dict[str, Any]], default_catalog: Optiona
             continue
         cat, sch, tbl = parts
 
-        # Prefer contract domain, fallback to product domain (string field)
+        # Prefer contract domain, fallback to product domain. Additional (non-primary)
+        # domains follow whichever source supplied the primary domain.
         domain_id = data.get("domain_id")
         domain_name = data.get("domain_name")
+        additional_domains = list(data.get("contract_additional_domains") or [])
         if not domain_name and data.get("product_domain"):
-            # Product domain is a string field, not FK
             domain_name = data.get("product_domain")
+            additional_domains = list(data.get("product_additional_domains") or [])
 
         semantic_links = [
             SemanticLink(iri=link["iri"], label=link["label"], slug=link["slug"])
@@ -287,6 +316,7 @@ def build_dataset_tag_infos(rows: List[Dict[str, Any]], default_catalog: Optiona
                 domain_id=str(domain_id) if domain_id else None,
                 domain_name=str(domain_name) if domain_name else None,
                 semantic_links=semantic_links,
+                additional_domain_names=[str(n) for n in additional_domains if n],
             )
         )
     return out
@@ -300,9 +330,14 @@ def read_assets_and_links(engine: Engine, limit: Optional[int] = None) -> List[D
                a.name        AS asset_name,
                a.location    AS physical_name,
                at.name       AS asset_type_name,
-               a.domain_id   AS asset_domain_id,
                d.id          AS domain_id,
                d.name        AS domain_name,
+               (SELECT array_agg(dd.name ORDER BY dd.name)
+                  FROM entity_domain_associations eda2
+                  JOIN data_domains dd ON dd.id = eda2.domain_id
+                 WHERE eda2.entity_type = 'asset'
+                   AND eda2.entity_id = a.id::text
+                   AND eda2.is_primary = FALSE) AS asset_additional_domains,
                er.target_id  AS contract_id,
                c.name        AS contract_name,
                c.version     AS contract_version,
@@ -311,12 +346,22 @@ def read_assets_and_links(engine: Engine, limit: Optional[int] = None) -> List[D
                p.name        AS product_name,
                p.version     AS product_version,
                p.status      AS product_status,
-               p.domain      AS product_domain,
+               pd.name       AS product_domain,
+               (SELECT array_agg(dd.name ORDER BY dd.name)
+                  FROM entity_domain_associations eda3
+                  JOIN data_domains dd ON dd.id = eda3.domain_id
+                 WHERE eda3.entity_type = 'data_product'
+                   AND eda3.entity_id = p.id
+                   AND eda3.is_primary = FALSE) AS product_additional_domains,
                esl.iri       AS asset_semantic_iri,
                esl.label     AS asset_semantic_label
         FROM assets a
         JOIN asset_types at ON a.asset_type_id = at.id
-        LEFT JOIN data_domains d ON a.domain_id = d.id
+        LEFT JOIN entity_domain_associations ada
+          ON ada.entity_type = 'asset'
+         AND ada.entity_id = a.id::text
+         AND ada.is_primary = TRUE
+        LEFT JOIN data_domains d ON d.id = ada.domain_id
         LEFT JOIN entity_relationships er
           ON er.source_id = a.id::text
          AND er.source_type IN ('Table', 'View')
@@ -327,6 +372,11 @@ def read_assets_and_links(engine: Engine, limit: Optional[int] = None) -> List[D
           ON op.contract_id = c.id
          AND op.asset_identifier = a.location
         LEFT JOIN data_products p ON op.product_id = p.id
+        LEFT JOIN entity_domain_associations pda
+          ON pda.entity_type = 'data_product'
+         AND pda.entity_id = p.id
+         AND pda.is_primary = TRUE
+        LEFT JOIN data_domains pd ON pd.id = pda.domain_id
         LEFT JOIN entity_semantic_links esl
           ON esl.entity_id = a.id::text
          AND esl.entity_type = 'asset'
@@ -363,7 +413,9 @@ def build_asset_tag_infos(rows: List[Dict[str, Any]], default_catalog: Optional[
                 "product_status": r.get("product_status"),
                 "domain_id": r.get("domain_id"),
                 "domain_name": r.get("domain_name"),
+                "asset_additional_domains": r.get("asset_additional_domains") or [],
                 "product_domain": r.get("product_domain"),
+                "product_additional_domains": r.get("product_additional_domains") or [],
                 "semantic_links": [],
             },
         )
@@ -391,8 +443,10 @@ def build_asset_tag_infos(rows: List[Dict[str, Any]], default_catalog: Optional[
 
         domain_id = data.get("domain_id")
         domain_name = data.get("domain_name")
+        additional_domains = list(data.get("asset_additional_domains") or [])
         if not domain_name and data.get("product_domain"):
             domain_name = data.get("product_domain")
+            additional_domains = list(data.get("product_additional_domains") or [])
 
         semantic_links = [
             SemanticLink(iri=link["iri"], label=link["label"], slug=link["slug"])
@@ -418,6 +472,7 @@ def build_asset_tag_infos(rows: List[Dict[str, Any]], default_catalog: Optional[
                 semantic_links=semantic_links,
                 asset_id=str(data.get("asset_id") or "") or None,
                 asset_type_name=str(data.get("asset_type_name") or "") or None,
+                additional_domain_names=[str(n) for n in additional_domains if n],
             )
         )
     return out
@@ -452,6 +507,10 @@ def merge_dataset_tag_infos(contract_datasets: List[DatasetTagInfo], asset_datas
             existing.domain_name = existing.domain_name or d.domain_name
             existing.asset_id = existing.asset_id or d.asset_id
             existing.asset_type_name = existing.asset_type_name or d.asset_type_name
+            # Union additional domains (preserve order, dedupe)
+            for name in d.additional_domain_names:
+                if name not in existing.additional_domain_names:
+                    existing.additional_domain_names.append(name)
             # Union semantic links
             existing_iris = {link.iri for link in existing.semantic_links}
             for link in d.semantic_links:
@@ -726,6 +785,14 @@ def build_desired_for_dataset(d: DatasetTagInfo, tag_sync_configs: List[Dict[str
                 if tag_key and tag_value:
                     tag_key = sanitize_tag_key(tag_key)
                     desired[tag_key] = tag_value
+
+                    # Additional (non-primary) domains ride on a companion tag key.
+                    # For the default ``data_domain`` key this yields
+                    # ``data_domain_additional`` (see DomainExportAdapter.uc_tags);
+                    # UC allows one value per key, so the names are comma-joined.
+                    if d.additional_domain_names:
+                        additional_key = sanitize_tag_key(f"{tag_key}_additional")
+                        desired[additional_key] = ",".join(d.additional_domain_names)
 
         elif entity_type == "data_contract":
             if d.contract_name:

--- a/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
+++ b/src/backend/src/workflows/uc_tag_sync/uc_tag_sync.py
@@ -800,10 +800,18 @@ def build_desired_for_dataset(d: DatasetTagInfo, tag_sync_configs: List[Dict[str
                     # one value per tag key, so each additional domain gets its own
                     # numbered key derived from the primary key (``data_domain_1``,
                     # ``data_domain_2``, ...) written after the primary. Names are
-                    # sorted for deterministic key assignment.
-                    for idx, name in enumerate(sorted(d.additional_domain_names), start=1):
+                    # sorted for deterministic key assignment. The running index skips
+                    # any key already present in ``desired`` (e.g. one produced by
+                    # another tag-sync config) so a numbered key never silently
+                    # clobbers an unrelated tag.
+                    idx = 1
+                    for name in sorted(d.additional_domain_names):
                         additional_key = sanitize_tag_key(f"{tag_key}_{idx}")
+                        while additional_key in desired:
+                            idx += 1
+                            additional_key = sanitize_tag_key(f"{tag_key}_{idx}")
                         desired[additional_key] = name
+                        idx += 1
 
         elif entity_type == "data_contract":
             if d.contract_name:

--- a/src/frontend/src/components/common/asset-form-dialog.tsx
+++ b/src/frontend/src/components/common/asset-form-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Separator } from '@/components/ui/separator';
+import DomainMultiSelector from '@/components/ui/domain-multi-selector';
 import { AssetRead, AssetCreate, AssetUpdate } from '@/types/asset';
 import { EntityFieldDefinition, EntityTypeSchema } from '@/types/ontology-schema';
 import { useTranslation } from 'react-i18next';
@@ -121,6 +122,12 @@ export function AssetFormDialog({
       defaults.status = asset.status || 'draft';
       defaults.platform = asset.platform || '';
       defaults.location = asset.location || '';
+      defaults.domain_ids = (asset.domains && asset.domains.length > 0)
+        ? asset.domains.map(d => d.domain_id)
+        : (asset.domain_id ? [asset.domain_id] : []);
+      defaults.primary_domain_id = asset.primary_domain_id
+        ?? asset.domains?.find(d => d.is_primary)?.domain_id
+        ?? asset.domain_id ?? null;
       const props = asset.properties || {};
       if (schema?.fields) {
         for (const f of schema.fields) {
@@ -134,6 +141,8 @@ export function AssetFormDialog({
       defaults.status = 'draft';
       defaults.platform = '';
       defaults.location = '';
+      defaults.domain_ids = [];
+      defaults.primary_domain_id = null;
       if (schema?.fields) {
         for (const f of schema.fields) {
           if (TOP_LEVEL_FIELDS.has(f.name) || SYSTEM_FIELDS.has(f.name)) continue;
@@ -172,6 +181,8 @@ export function AssetFormDialog({
           status: values.status || null,
           platform: values.platform || null,
           location: values.location || null,
+          domain_ids: values.domain_ids || [],
+          primary_domain_id: values.primary_domain_id ?? null,
           properties: Object.keys(properties).length > 0 ? properties : null,
         };
         const response = await apiPut<AssetRead>(`/api/assets/${asset.id}`, payload);
@@ -186,6 +197,8 @@ export function AssetFormDialog({
           status: values.status || 'draft',
           platform: values.platform || null,
           location: values.location || null,
+          domain_ids: values.domain_ids || [],
+          primary_domain_id: values.primary_domain_id ?? null,
           properties: Object.keys(properties).length > 0 ? properties : null,
         };
         const response = await apiPost<AssetRead>('/api/assets', payload);
@@ -301,6 +314,27 @@ export function AssetFormDialog({
                       <FormLabel>Location</FormLabel>
                       <FormControl>
                         <Input placeholder="e.g. catalog.schema.table" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="domain_ids"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Domains</FormLabel>
+                      <FormControl>
+                        <DomainMultiSelector
+                          value={field.value || []}
+                          primaryDomainId={form.watch('primary_domain_id')}
+                          onChange={(domainIds, primaryDomainId) => {
+                            field.onChange(domainIds);
+                            form.setValue('primary_domain_id', primaryDomainId);
+                          }}
+                          placeholder="Select domains..."
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>

--- a/src/frontend/src/components/data-contracts/create-contract-inline-dialog.tsx
+++ b/src/frontend/src/components/data-contracts/create-contract-inline-dialog.tsx
@@ -5,12 +5,14 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/hooks/use-toast';
-import { useDomains } from '@/hooks/use-domains';
+import DomainMultiSelector from '@/components/ui/domain-multi-selector';
 import { Loader2 } from 'lucide-react';
 
 type PrefillData = {
   domain?: string;
   domainId?: string;
+  domainIds?: string[];
+  primaryDomainId?: string | null;
   tenant?: string;
   owner_team_id?: string;
 };
@@ -29,14 +31,14 @@ export default function CreateContractInlineDialog({
   prefillData
 }: CreateContractInlineDialogProps) {
   const { toast } = useToast();
-  const { domains } = useDomains();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  
+
   const [name, setName] = useState('');
   const [version, setVersion] = useState('1.0.0');
   const [status, setStatus] = useState('draft');
   const [ownerTeamId, setOwnerTeamId] = useState('');
-  const [domainId, setDomainId] = useState('');
+  const [domainIds, setDomainIds] = useState<string[]>([]);
+  const [primaryDomainId, setPrimaryDomainId] = useState<string | null>(null);
   const [tenant, setTenant] = useState('');
 
   useEffect(() => {
@@ -46,7 +48,8 @@ export default function CreateContractInlineDialog({
       setVersion('1.0.0');
       setStatus('draft');
       setOwnerTeamId(prefillData?.owner_team_id || '');
-      setDomainId(prefillData?.domainId || '');
+      setDomainIds(prefillData?.domainIds || (prefillData?.domainId ? [prefillData.domainId] : []));
+      setPrimaryDomainId(prefillData?.primaryDomainId ?? prefillData?.domainId ?? null);
       setTenant(prefillData?.tenant || '');
     }
   }, [isOpen, prefillData]);
@@ -82,7 +85,10 @@ export default function CreateContractInlineDialog({
 
       // Add optional fields if provided
       if (ownerTeamId.trim()) payload.owner_team_id = ownerTeamId.trim();
-      if (domainId) payload.domainId = domainId;
+      if (domainIds.length > 0) {
+        payload.domainIds = domainIds;
+        payload.primaryDomainId = primaryDomainId;
+      }
       if (tenant.trim()) payload.tenant = tenant.trim();
 
       const response = await fetch('/api/data-contracts', {
@@ -169,24 +175,18 @@ export default function CreateContractInlineDialog({
             </Select>
           </div>
 
-          {domains && domains.length > 0 && (
-            <div className="space-y-2">
-              <Label htmlFor="domain">Domain</Label>
-              <Select value={domainId || "_none"} onValueChange={(v) => setDomainId(v === "_none" ? "" : v)}>
-                <SelectTrigger id="domain">
-                  <SelectValue placeholder="Select domain (optional)" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="_none">None</SelectItem>
-                  {domains.map((domain) => (
-                    <SelectItem key={domain.id} value={domain.id}>
-                      {domain.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
+          <div className="space-y-2">
+            <Label htmlFor="domain">Domains</Label>
+            <DomainMultiSelector
+              value={domainIds}
+              primaryDomainId={primaryDomainId}
+              onChange={(nextIds, nextPrimary) => {
+                setDomainIds(nextIds);
+                setPrimaryDomainId(nextPrimary);
+              }}
+              placeholder="Select domains (optional)"
+            />
+          </div>
 
           <div className="space-y-2">
             <Label htmlFor="tenant">Tenant</Label>

--- a/src/frontend/src/components/data-contracts/data-contract-basic-form-dialog.tsx
+++ b/src/frontend/src/components/data-contracts/data-contract-basic-form-dialog.tsx
@@ -15,7 +15,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
-import { useDomains } from '@/hooks/use-domains'
+import DomainMultiSelector from '@/components/ui/domain-multi-selector'
 import { useToast } from '@/hooks/use-toast'
 import type { DataContractCreate } from '@/types/data-contract'
 import type { TeamSummary } from '@/types/team'
@@ -34,6 +34,8 @@ type BasicFormProps = {
     owner_team_id?: string
     project_id?: string
     domain?: string
+    domainIds?: string[]
+    primaryDomainId?: string | null
     tenant?: string
     descriptionUsage?: string
     descriptionPurpose?: string
@@ -45,7 +47,6 @@ type BasicFormProps = {
 const statuses = ['draft', 'active', 'deprecated', 'archived']
 
 export default function DataContractBasicFormDialog({ isOpen, onOpenChange, onSubmit, initial }: BasicFormProps) {
-  const { domains, loading: domainsLoading } = useDomains()
   const { toast } = useToast()
   const { currentProject, availableProjects, fetchUserProjects, isLoading: projectsLoading } = useProjectContext()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -57,7 +58,8 @@ export default function DataContractBasicFormDialog({ isOpen, onOpenChange, onSu
   const [status, setStatus] = useState('draft')
   const [ownerTeamId, setOwnerTeamId] = useState('')
   const [projectId, setProjectId] = useState('')
-  const [domain, setDomain] = useState('')
+  const [domainIds, setDomainIds] = useState<string[]>([])
+  const [primaryDomainId, setPrimaryDomainId] = useState<string | null>(null)
   const [tenant, setTenant] = useState('')
   const [descriptionUsage, setDescriptionUsage] = useState('')
   const [descriptionPurpose, setDescriptionPurpose] = useState('')
@@ -100,7 +102,8 @@ export default function DataContractBasicFormDialog({ isOpen, onOpenChange, onSu
       status: initial.status || 'draft',
       ownerTeamId: initial.owner_team_id || '',
       projectId: initial.project_id || '',
-      domain: initial.domain || '',
+      domainIds: initial.domainIds || (initial.domain ? [initial.domain] : []),
+      primaryDomainId: initial.primaryDomainId ?? initial.domain ?? null,
       tenant: initial.tenant || '',
       descriptionUsage: initial.descriptionUsage || '',
       descriptionPurpose: initial.descriptionPurpose || '',
@@ -112,7 +115,8 @@ export default function DataContractBasicFormDialog({ isOpen, onOpenChange, onSu
       status: 'draft',
       ownerTeamId: '',
       projectId: currentProject?.id || '',
-      domain: '',
+      domainIds: [],
+      primaryDomainId: null,
       tenant: '',
       descriptionUsage: '',
       descriptionPurpose: '',
@@ -125,7 +129,8 @@ export default function DataContractBasicFormDialog({ isOpen, onOpenChange, onSu
     setStatus(initValues.status)
     setOwnerTeamId(initValues.ownerTeamId)
     setProjectId(initValues.projectId)
-    setDomain(initValues.domain)
+    setDomainIds(initValues.domainIds)
+    setPrimaryDomainId(initValues.primaryDomainId)
     setTenant(initValues.tenant)
     setDescriptionUsage(initValues.descriptionUsage)
     setDescriptionPurpose(initValues.descriptionPurpose)
@@ -150,14 +155,15 @@ export default function DataContractBasicFormDialog({ isOpen, onOpenChange, onSu
       status !== initialFormValues.status ||
       ownerTeamId !== initialFormValues.ownerTeamId ||
       projectId !== initialFormValues.projectId ||
-      domain !== initialFormValues.domain ||
+      domainIds.join(',') !== (initialFormValues.domainIds || []).join(',') ||
+      (primaryDomainId || '') !== (initialFormValues.primaryDomainId || '') ||
       tenant !== initialFormValues.tenant ||
       descriptionUsage !== initialFormValues.descriptionUsage ||
       descriptionPurpose !== initialFormValues.descriptionPurpose ||
       descriptionLimitations !== initialFormValues.descriptionLimitations ||
       currentTagsNormalized !== initialTagsNormalized
     )
-  }, [initialFormValues, name, version, status, ownerTeamId, projectId, domain, tenant, descriptionUsage, descriptionPurpose, descriptionLimitations, tags])
+  }, [initialFormValues, name, version, status, ownerTeamId, projectId, domainIds, primaryDomainId, tenant, descriptionUsage, descriptionPurpose, descriptionLimitations, tags])
 
   const handleCloseAttempt = () => {
     if (isFormDirty && !isSubmitting) {
@@ -181,7 +187,7 @@ export default function DataContractBasicFormDialog({ isOpen, onOpenChange, onSu
 
     console.log('[DEBUG FORM] State values before submit:')
     console.log('  - projectId:', projectId)
-    console.log('  - domain:', domain)
+    console.log('  - domainIds:', domainIds)
     console.log('  - ownerTeamId:', ownerTeamId)
     
     setIsSubmitting(true)
@@ -202,7 +208,8 @@ export default function DataContractBasicFormDialog({ isOpen, onOpenChange, onSu
         project_id: projectId && projectId !== '__none__' ? projectId : undefined,
         kind: 'DataContract',
         apiVersion: 'v3.1.0',
-        domainId: domain && domain !== '__none__' ? domain : undefined,
+        domainIds: domainIds,
+        primaryDomainId: primaryDomainId,
         tenant: tenant.trim() || undefined,
         tags: normalizedTags.length > 0 ? normalizedTags as any : undefined,
         description: {
@@ -342,29 +349,18 @@ export default function DataContractBasicFormDialog({ isOpen, onOpenChange, onSu
         </p>
       </div>
 
-      {/* Domain */}
+      {/* Domains */}
       <div className="space-y-2">
-        <Label htmlFor="domain">Domain</Label>
-        <Select 
-          value={domain || '__none__'} 
-          onValueChange={(value) => {
-            console.log('[DEBUG] Domain onValueChange fired:', value);
-            setDomain(value === '__none__' ? '' : value);
-          }} 
-          disabled={domainsLoading}
-        >
-          <SelectTrigger id="domain">
-            <SelectValue placeholder="Select a domain (optional)" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="__none__">None</SelectItem>
-            {domains.map((d) => (
-              <SelectItem key={d.id} value={d.id}>
-                {d.name}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Label htmlFor="domain">Domains</Label>
+        <DomainMultiSelector
+          value={domainIds}
+          primaryDomainId={primaryDomainId}
+          onChange={(nextIds, nextPrimary) => {
+            setDomainIds(nextIds)
+            setPrimaryDomainId(nextPrimary)
+          }}
+          placeholder="Select domains (optional)"
+        />
       </div>
 
           {/* Tenant */}

--- a/src/frontend/src/components/data-contracts/data-contract-wizard-dialog.tsx
+++ b/src/frontend/src/components/data-contracts/data-contract-wizard-dialog.tsx
@@ -10,6 +10,7 @@ import type { InferredSchemaObject } from './infer-from-asset-dialog'
 import BusinessConceptsDisplay from '@/components/business-concepts/business-concepts-display'
 import { PrincipalPicker } from '@/components/common/principal-picker'
 import { useDomains } from '@/hooks/use-domains'
+import DomainMultiSelector from '@/components/ui/domain-multi-selector'
 import { useToast } from '@/hooks/use-toast'
 
 type WizardProps = {
@@ -57,7 +58,7 @@ const ENVIRONMENTS = ['production', 'staging', 'development', 'test']
 const PHYSICAL_TYPES = ['table', 'view', 'materialized_view', 'external_table', 'managed_table', 'streaming_table']
 
 export default function DataContractWizardDialog({ isOpen, onOpenChange, onSubmit, initial }: WizardProps) {
-  const { domains, loading: domainsLoading, refetch: refetchDomains } = useDomains()
+  const { refetch: refetchDomains } = useDomains()
   const { toast } = useToast()
 
   // Helper function to handle domain-related errors
@@ -73,7 +74,8 @@ export default function DataContractWizardDialog({ isOpen, onOpenChange, onSubmi
       })
 
       // Clear the invalid domain selection
-      setDomain('')
+      setDomainIds([])
+      setPrimaryDomainId(null)
 
       // Refetch domains to get the latest list
       try {
@@ -102,7 +104,12 @@ export default function DataContractWizardDialog({ isOpen, onOpenChange, onSubmi
   const [version, setVersion] = useState(initial?.version || '1.0.0')
   const [status, setStatus] = useState(initial?.status || 'draft')
   const [owner, setOwner] = useState(initial?.owner || '')
-  const [domain, setDomain] = useState(initial?.domain || '')
+  const [domainIds, setDomainIds] = useState<string[]>(
+    initial?.domainIds || (initial?.domainId ? [initial.domainId] : (initial?.domain ? [initial.domain] : []))
+  )
+  const [primaryDomainId, setPrimaryDomainId] = useState<string | null>(
+    initial?.primaryDomainId ?? initial?.domainId ?? initial?.domain ?? null
+  )
   const [tenant, setTenant] = useState(initial?.tenant || '')
   const [dataProduct, setDataProduct] = useState(initial?.dataProduct || '')
   const [descriptionUsage, setDescriptionUsage] = useState(initial?.descriptionUsage || '')
@@ -228,7 +235,8 @@ export default function DataContractWizardDialog({ isOpen, onOpenChange, onSubmi
         setVersion('1.0.0')
         setStatus('draft')
         setOwner('')
-        setDomain('')
+        setDomainIds([])
+        setPrimaryDomainId(null)
         setTenant('')
         setDataProduct('')
         setDescriptionUsage('')
@@ -253,7 +261,8 @@ export default function DataContractWizardDialog({ isOpen, onOpenChange, onSubmi
         setVersion(initial.version || '1.0.0')
         setStatus(initial.status || 'draft')
         setOwner(initial.owner || '')
-        setDomain(initial.domain || '')
+        setDomainIds(initial.domainIds || (initial.domainId ? [initial.domainId] : (initial.domain ? [initial.domain] : [])))
+        setPrimaryDomainId(initial.primaryDomainId ?? initial.domainId ?? initial.domain ?? null)
         setTenant(initial.tenant || '')
         setDataProduct(initial.dataProduct || '')
         setDescriptionUsage(initial.descriptionUsage || '')
@@ -388,7 +397,8 @@ export default function DataContractWizardDialog({ isOpen, onOpenChange, onSubmi
         version,
         status: status, // Use user-selected status
         owner,
-        domainId: domain, // Send as domainId since domain variable contains the ID
+        domainIds: domainIds, // Multi-domain assignment (primary included)
+        primaryDomainId: primaryDomainId,
         tenant,
         dataProduct,
         description: { usage: descriptionUsage, purpose: descriptionPurpose, limitations: descriptionLimitations },
@@ -475,7 +485,8 @@ export default function DataContractWizardDialog({ isOpen, onOpenChange, onSubmi
         version,
         status: 'draft', // Draft status for partial saves
         owner,
-        domainId: domain, // Send as domainId since domain variable contains the ID
+        domainIds: domainIds, // Multi-domain assignment (primary included)
+        primaryDomainId: primaryDomainId,
         tenant,
         dataProduct,
         description: { usage: descriptionUsage, purpose: descriptionPurpose, limitations: descriptionLimitations },
@@ -647,22 +658,17 @@ export default function DataContractWizardDialog({ isOpen, onOpenChange, onSubmi
               {/* Metadata Panel */}
               <div className="space-y-4">
                 <div>
-                  <Label className="text-sm font-medium">Domain</Label>
-                  <Select value={domain} onValueChange={setDomain} disabled={domainsLoading}>
-                    <SelectTrigger className="mt-1">
-                      <SelectValue placeholder={domainsLoading ? "Loading domains..." : "Select a data domain"} />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {domains.length === 0 && !domainsLoading && (
-                        <SelectItem value="no-domains" disabled>No domains available</SelectItem>
-                      )}
-                      {domains.map((domainOption) => (
-                        <SelectItem key={domainOption.id} value={domainOption.id}>
-                          {domainOption.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  <Label className="text-sm font-medium">Domains</Label>
+                  <DomainMultiSelector
+                    className="mt-1"
+                    value={domainIds}
+                    primaryDomainId={primaryDomainId}
+                    onChange={(nextIds, nextPrimary) => {
+                      setDomainIds(nextIds)
+                      setPrimaryDomainId(nextPrimary)
+                    }}
+                    placeholder="Select data domains"
+                  />
                 </div>
                 <div>
                   <Label className="text-sm font-medium">Tenant</Label>

--- a/src/frontend/src/components/data-products/data-product-create-dialog.tsx
+++ b/src/frontend/src/components/data-products/data-product-create-dialog.tsx
@@ -28,7 +28,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useToast } from '@/hooks/use-toast';
 import { Loader2 } from 'lucide-react';
 import { ConsumerPrincipal, DataProduct, DataProductStatus } from '@/types/data-product';
-import { useDomains } from '@/hooks/use-domains';
+import DomainMultiSelector from '@/components/ui/domain-multi-selector';
 import { useTeams } from '@/hooks/use-teams';
 import TagSelector from '@/components/ui/tag-selector';
 import { ConsumerGroupsPicker } from '@/components/data-products/consumer-groups-picker';
@@ -50,7 +50,8 @@ const dataProductCreateSchema = z.object({
   productType: z.enum(productTypes).optional(),
   ownerTeamId: z.string().optional(),
   projectId: z.string().optional(),
-  domain: z.string().optional(),
+  domain_ids: z.array(z.string()).optional(),
+  primary_domain_id: z.string().nullable().optional(),
   tenant: z.string().optional(),
   purpose: z.string().optional(),
   limitations: z.string().optional(),
@@ -79,7 +80,6 @@ export default function DataProductCreateDialog({
   mode = 'create',
 }: DataProductCreateDialogProps) {
   const { toast } = useToast();
-  const { domains, loading: domainsLoading } = useDomains();
   const { teams, loading: teamsLoading } = useTeams();
   const { currentProject, availableProjects, isLoading: projectsLoading, fetchUserProjects } = useProjectContext();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -94,7 +94,8 @@ export default function DataProductCreateDialog({
       productType: undefined,
       ownerTeamId: '',
       projectId: '',
-      domain: '',
+      domain_ids: [],
+      primary_domain_id: null,
       tenant: '',
       purpose: '',
       limitations: '',
@@ -124,7 +125,8 @@ export default function DataProductCreateDialog({
           productType: productType || undefined,
           ownerTeamId: product.owner_team_id || '',
           projectId: product.project_id || '',
-          domain: product.domain || '',
+          domain_ids: product.domain_ids || [],
+          primary_domain_id: product.primary_domain_id ?? null,
           tenant: product.tenant || '',
           purpose: product.description?.purpose || '',
           limitations: product.description?.limitations || '',
@@ -141,7 +143,8 @@ export default function DataProductCreateDialog({
           productType: undefined,
           ownerTeamId: '',
           projectId: currentProject?.id || '',
-          domain: '',
+          domain_ids: [],
+          primary_domain_id: null,
           tenant: '',
           purpose: '',
           limitations: '',
@@ -189,7 +192,8 @@ export default function DataProductCreateDialog({
           name: data.name,
           version: data.version,
           status: data.status,
-          domain: data.domain || undefined,
+          domain_ids: data.domain_ids || [],
+          primary_domain_id: data.primary_domain_id ?? null,
           tenant: data.tenant || undefined,
           owner_team_id: data.ownerTeamId || undefined,
           project_id: data.projectId || undefined,
@@ -252,7 +256,8 @@ export default function DataProductCreateDialog({
           name: data.name,
           version: data.version,
           status: data.status,
-          domain: data.domain || undefined,
+          domain_ids: data.domain_ids || [],
+          primary_domain_id: data.primary_domain_id ?? null,
           tenant: data.tenant || undefined,
           owner_team_id: data.ownerTeamId || undefined,
           project_id: data.projectId || undefined,
@@ -478,28 +483,16 @@ export default function DataProductCreateDialog({
           {/* Optional Fields */}
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
-              <Label htmlFor="domain">Domain</Label>
-              <Select
-                value={form.watch('domain') || undefined}
-                onValueChange={(value) => form.setValue('domain', value)}
-              >
-                <SelectTrigger id="domain">
-                  <SelectValue placeholder="Select domain..." />
-                </SelectTrigger>
-                <SelectContent>
-                  {domainsLoading ? (
-                    <SelectItem value="loading" disabled>
-                      Loading...
-                    </SelectItem>
-                  ) : (
-                    domains.map((domain) => (
-                      <SelectItem key={domain.id} value={domain.id}>
-                        {domain.name}
-                      </SelectItem>
-                    ))
-                  )}
-                </SelectContent>
-              </Select>
+              <Label htmlFor="domain">Domains</Label>
+              <DomainMultiSelector
+                value={form.watch('domain_ids') || []}
+                primaryDomainId={form.watch('primary_domain_id')}
+                onChange={(domainIds, primaryDomainId) => {
+                  form.setValue('domain_ids', domainIds);
+                  form.setValue('primary_domain_id', primaryDomainId);
+                }}
+                placeholder="Select domains..."
+              />
             </div>
 
             <div className="space-y-2">

--- a/src/frontend/src/components/data-products/data-product-form-dialog.tsx
+++ b/src/frontend/src/components/data-products/data-product-form-dialog.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/accordion"
 import { useApi } from '@/hooks/use-api';
 import TagSelector from '@/components/ui/tag-selector';
+import DomainMultiSelector from '@/components/ui/domain-multi-selector';
 import { ConsumerGroupsPicker } from '@/components/data-products/consumer-groups-picker';
 
 // --- Prop Types --- 
@@ -348,6 +349,13 @@ const DataProductFormDialog: React.FC<DataProductFormDialogProps> = ({
   const [jsonParseError, setJsonParseError] = useState<string | null>(null);
 
   // State for Schema Validation
+  // Domain assignment (#520) is kept in LOCAL state — NOT in the RHF form data — so it is
+  // never part of the payload validated against the ODPS schema (which is
+  // additionalProperties:false and would reject top-level domain_ids). It is injected into
+  // the payload after schema validation, just before the API call.
+  const [domainIds, setDomainIds] = useState<string[]>([]);
+  const [primaryDomainId, setPrimaryDomainId] = useState<string | null>(null);
+
   const [dataProductSchema, setDataProductSchema] = useState<object | null>(null);
   const [schemaValidator, setSchemaValidator] = useState<ValidateFunction | null>(null);
   const [validationStatusMessage, setValidationStatusMessage] = useState<string | null>(null);
@@ -444,7 +452,15 @@ const DataProductFormDialog: React.FC<DataProductFormDialogProps> = ({
           delete formData.created_at; // Keep this for optional field
           // delete formData.updated_at; // REMOVE: updated_at is required in type
 
-          reset(formData); 
+          // Domains (#520) live in local state, not RHF — strip them from the form data so
+          // they never enter the ODPS-schema-validated payload.
+          setDomainIds((productData as any).domain_ids || []);
+          setPrimaryDomainId((productData as any).primary_domain_id ?? null);
+          delete (formData as any).domain_ids;
+          delete (formData as any).primary_domain_id;
+          delete (formData as any).domain;
+
+          reset(formData);
 
           // Populate state arrays for custom editors *after* reset
           setLinksArray(linksObjectToArray(formData.links));
@@ -470,8 +486,10 @@ const DataProductFormDialog: React.FC<DataProductFormDialogProps> = ({
         }
       } else if (isOpen && !isEditMode) {
           // Reset form for CREATE mode when dialog opens
+          setDomainIds([]);
+          setPrimaryDomainId(null);
           const defaultValues = createDefaultProduct();
-          reset(defaultValues); 
+          reset(defaultValues);
           setLinksArray(linksObjectToArray(defaultValues.links));
           setCustomArray(objectToArray(defaultValues.custom));
           setJsonString(JSON.stringify(cleanEmptyOptionalStrings(defaultValues), null, 2));
@@ -729,9 +747,14 @@ const DataProductFormDialog: React.FC<DataProductFormDialogProps> = ({
         toast({ title: "Validation Error", description: "Please fix validation errors before saving.", variant: "destructive" });
         setActiveTab('json'); // Switch to JSON tab to show errors easily
         // Update jsonString state to reflect the *cleaned* payload causing validation errors
-        setJsonString(JSON.stringify(payload, null, 2)); 
+        setJsonString(JSON.stringify(payload, null, 2));
         return; // Stop submission
     }
+
+    // Inject domain assignments AFTER schema validation (#520): domain_ids/primary_domain_id
+    // are app extension fields not in the ODPS schema, so they must not be validated.
+    (payload as any).domain_ids = domainIds;
+    (payload as any).primary_domain_id = primaryDomainId;
 
     try {
         let response;
@@ -962,9 +985,16 @@ const DataProductFormDialog: React.FC<DataProductFormDialogProps> = ({
                               </div>
                               <div className="grid grid-cols-2 gap-4">
                                   <div>
-                                    <Label htmlFor="info.domain">Domain</Label>
-                                    <Input id="info.domain" {...register("info.domain")} />
-                                    {errors.info?.domain && <p className="text-sm text-red-600 mt-1">{errors.info.domain.message}</p>}
+                                    <Label htmlFor="domain_ids">Domains</Label>
+                                    <DomainMultiSelector
+                                      value={domainIds}
+                                      primaryDomainId={primaryDomainId}
+                                      onChange={(ids, primary) => {
+                                        setDomainIds(ids);
+                                        setPrimaryDomainId(primary);
+                                      }}
+                                      placeholder="Select domains..."
+                                    />
                                   </div>
                                   <div>
                                     <Label htmlFor="info.archetype">Archetype</Label>

--- a/src/frontend/src/components/data-products/data-product-form-dialog.tsx
+++ b/src/frontend/src/components/data-products/data-product-form-dialog.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import DomainMultiSelector from '@/components/ui/domain-multi-selector';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Plus, AlertCircle, X, Loader2, Check, ChevronsUpDown } from 'lucide-react';
@@ -963,16 +962,9 @@ const DataProductFormDialog: React.FC<DataProductFormDialogProps> = ({
                               </div>
                               <div className="grid grid-cols-2 gap-4">
                                   <div>
-                                    <Label htmlFor="domain_ids">Domains</Label>
-                                    <DomainMultiSelector
-                                      value={_watch('domain_ids') || []}
-                                      primaryDomainId={_watch('primary_domain_id')}
-                                      onChange={(domainIds, primaryDomainId) => {
-                                        setValue('domain_ids', domainIds, { shouldDirty: true });
-                                        setValue('primary_domain_id', primaryDomainId, { shouldDirty: true });
-                                      }}
-                                      placeholder="Select domains..."
-                                    />
+                                    <Label htmlFor="info.domain">Domain</Label>
+                                    <Input id="info.domain" {...register("info.domain")} />
+                                    {errors.info?.domain && <p className="text-sm text-red-600 mt-1">{errors.info.domain.message}</p>}
                                   </div>
                                   <div>
                                     <Label htmlFor="info.archetype">Archetype</Label>

--- a/src/frontend/src/components/data-products/data-product-form-dialog.tsx
+++ b/src/frontend/src/components/data-products/data-product-form-dialog.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import DomainMultiSelector from '@/components/ui/domain-multi-selector';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Plus, AlertCircle, X, Loader2, Check, ChevronsUpDown } from 'lucide-react';
@@ -962,9 +963,16 @@ const DataProductFormDialog: React.FC<DataProductFormDialogProps> = ({
                               </div>
                               <div className="grid grid-cols-2 gap-4">
                                   <div>
-                                    <Label htmlFor="info.domain">Domain</Label>
-                                    <Input id="info.domain" {...register("info.domain")} />
-                                    {errors.info?.domain && <p className="text-sm text-red-600 mt-1">{errors.info.domain.message}</p>}
+                                    <Label htmlFor="domain_ids">Domains</Label>
+                                    <DomainMultiSelector
+                                      value={_watch('domain_ids') || []}
+                                      primaryDomainId={_watch('primary_domain_id')}
+                                      onChange={(domainIds, primaryDomainId) => {
+                                        setValue('domain_ids', domainIds, { shouldDirty: true });
+                                        setValue('primary_domain_id', primaryDomainId, { shouldDirty: true });
+                                      }}
+                                      placeholder="Select domains..."
+                                    />
                                   </div>
                                   <div>
                                     <Label htmlFor="info.archetype">Archetype</Label>

--- a/src/frontend/src/components/data-products/output-port-form-dialog.tsx
+++ b/src/frontend/src/components/data-products/output-port-form-dialog.tsx
@@ -428,8 +428,8 @@ export default function OutputPortFormDialog({ isOpen, onOpenChange, onSubmit, i
       onOpenChange={setIsCreateContractOpen}
       onSuccess={handleContractCreated}
       prefillData={{
-        domain: product?.domain,
-        domainId: product?.domain,
+        domainIds: product?.domain_ids,
+        primaryDomainId: product?.primary_domain_id,
         tenant: product?.tenant,
         owner_team_id: product?.owner_team_id
       }}

--- a/src/frontend/src/components/home/marketplace-view.tsx
+++ b/src/frontend/src/components/home/marketplace-view.tsx
@@ -328,6 +328,14 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
     );
   }, []);
 
+  // Add a domain to the filter (idempotent). Used by the graph view, where a node
+  // click both focuses the graph and includes that domain in the filter — adding
+  // (not toggling) so navigating back to an already-selected node never silently
+  // removes it from the filter.
+  const addDomainToFilter = useCallback((domainId: string) => {
+    setSelectedDomainIds(prev => (prev.includes(domainId) ? prev : [...prev, domainId]));
+  }, []);
+
   // Handle product card click
   const handleProductClick = async (product: DataProduct) => {
     setSelectedProduct(product);
@@ -626,10 +634,11 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
             <div className={`transition-opacity duration-300 ${graphFadeIn ? 'opacity-100' : 'opacity-0'}`}>
               <DataDomainMiniGraph
                 currentDomain={selectedDomainDetails}
-                // Node click navigates the graph (focus only). Filtering is an
-                // explicit action via the pills view so browsing the graph doesn't
-                // silently mutate the multi-select filter (see graphFocusId note).
-                onNodeClick={(id) => setGraphFocusId(id)}
+                // Node click focuses the graph AND includes that domain in the filter.
+                // We add (never remove) so re-visiting a node during navigation can't
+                // silently drop it from the filter; clearing is done via the pills view
+                // or the "clear filters" control.
+                onNodeClick={(id) => { setGraphFocusId(id); addDomainToFilter(id); }}
               />
             </div>
           ) : (

--- a/src/frontend/src/components/home/marketplace-view.tsx
+++ b/src/frontend/src/components/home/marketplace-view.tsx
@@ -51,7 +51,12 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
   
   // Search and filter state
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedDomainId, setSelectedDomainId] = useState<string | null>(null);
+  // Multi-domain filter (#520 story 10): the marketplace filters by one or MORE
+  // domains and shows entities matching ANY of them (union). Empty = all domains.
+  const [selectedDomainIds, setSelectedDomainIds] = useState<string[]>([]);
+  // Graph view focuses a single domain for the mini-graph; kept separate from the
+  // multi-select filter so browsing the graph doesn't collapse the filter to one.
+  const [graphFocusId, setGraphFocusId] = useState<string | null>(null);
   const [scopeFilter, setScopeFilter] = useState<string>('all');
   const [certificationLevels, setCertificationLevels] = useState<CertificationLevel[]>([]);
   
@@ -169,18 +174,18 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
     }
   }, []);
 
-  // Load domain details when switching to graph mode or changing selection
+  // Load domain details when switching to graph mode or changing the graph focus.
   useEffect(() => {
-    if (domainBrowserStyle === 'graph' && selectedDomainId) {
-      loadDomainDetails(selectedDomainId);
-    } else if (domainBrowserStyle === 'graph' && !selectedDomainId && domains.length > 0) {
-      // Auto-select first root domain for graph view
+    if (domainBrowserStyle === 'graph' && graphFocusId) {
+      loadDomainDetails(graphFocusId);
+    } else if (domainBrowserStyle === 'graph' && !graphFocusId && domains.length > 0) {
+      // Auto-focus first root domain for graph view (focus only; does not filter).
       const rootDomain = domains.find(d => !d.parent_id) || domains[0];
       if (rootDomain) {
-        setSelectedDomainId(rootDomain.id);
+        setGraphFocusId(rootDomain.id);
       }
     }
-  }, [domainBrowserStyle, selectedDomainId, domains, loadDomainDetails]);
+  }, [domainBrowserStyle, graphFocusId, domains, loadDomainDetails]);
 
   // Fade-in effect for graph when domain changes
   useEffect(() => {
@@ -223,42 +228,16 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
     return result;
   }, [domains]);
 
-  // Build match sets based on exact/children selection
-  // Uses the already-loaded domains array to walk the tree client-side (no API calls needed)
+  // Build match sets from the selected domains (union / any-of, #520 story 10).
+  // Uses the already-loaded domains array to walk the tree client-side (no API calls needed).
+  // "Include children" (default) unions each selected domain with its descendants (story 11).
   useEffect(() => {
-    if (!selectedDomainId) { 
-      setMatchSets(null); 
-      return; 
-    }
-    
-    const selected = domains.find(d => d.id === selectedDomainId);
-    if (!selected) {
-      // Domain not found in our list - try matching by name in case selectedDomainId is a name
-      const byName = domains.find(d => d.name.toLowerCase() === selectedDomainId.toLowerCase());
-      if (byName) {
-        // Use the found domain
-        const ids = new Set<string>([byName.id]);
-        const namesLower = new Set<string>([byName.name.toLowerCase()]);
-        setMatchSets({ ids, namesLower });
-      } else {
-        setMatchSets({ ids: new Set([selectedDomainId]), namesLower: new Set([selectedDomainId.toLowerCase()]) });
-      }
+    if (selectedDomainIds.length === 0) {
+      setMatchSets(null);
       return;
     }
-    
-    // Exact match: only the selected domain
-    if (exactMatchesOnly) {
-      const ids = new Set<string>([String(selectedDomainId)]);
-      const namesLower = new Set<string>([selected.name.toLowerCase()]);
-      setMatchSets({ ids, namesLower });
-      return;
-    }
-    
-    // Include children: walk all descendants using the domains array (client-side)
-    const ids = new Set<string>();
-    const namesLower = new Set<string>();
-    
-    // Build a map of parent_id -> children for efficient lookup
+
+    // Build a map of parent_id -> children once for descendant walks.
     const childrenByParentId = new Map<string, DataDomain[]>();
     domains.forEach(d => {
       if (d.parent_id) {
@@ -268,28 +247,47 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
         childrenByParentId.get(d.parent_id)!.push(d);
       }
     });
-    
-    // Walk the tree from the selected domain
-    const queue: DataDomain[] = [selected];
-    while (queue.length > 0) {
-      const domain = queue.shift()!;
-      ids.add(domain.id);
-      namesLower.add(domain.name.toLowerCase());
-      
-      // Add children to queue
-      const children = childrenByParentId.get(domain.id) || [];
-      queue.push(...children);
+
+    const ids = new Set<string>();
+    const namesLower = new Set<string>();
+
+    for (const selectedId of selectedDomainIds) {
+      const selected =
+        domains.find(d => d.id === selectedId) ||
+        domains.find(d => d.name.toLowerCase() === selectedId.toLowerCase());
+
+      if (!selected) {
+        // Unknown id/name: match it literally so a stale selection still filters.
+        ids.add(selectedId);
+        namesLower.add(selectedId.toLowerCase());
+        continue;
+      }
+
+      if (exactMatchesOnly) {
+        ids.add(selected.id);
+        namesLower.add(selected.name.toLowerCase());
+        continue;
+      }
+
+      // Include children: walk all descendants from this selected domain.
+      const queue: DataDomain[] = [selected];
+      while (queue.length > 0) {
+        const domain = queue.shift()!;
+        ids.add(domain.id);
+        namesLower.add(domain.name.toLowerCase());
+        queue.push(...(childrenByParentId.get(domain.id) || []));
+      }
     }
-    
+
     setMatchSets({ ids, namesLower });
-  }, [selectedDomainId, exactMatchesOnly, domains]);
+  }, [selectedDomainIds, exactMatchesOnly, domains]);
 
   // Filter products based on search and domain
   const filteredProducts = useMemo(() => {
     let filtered = allProducts;
     
     // Filter by domain using matchSets
-    if (selectedDomainId) {
+    if (selectedDomainIds.length > 0) {
       if (!matchSets) return []; // Still loading match sets
       filtered = filtered.filter(p => {
         // Any-of semantics (#520 story 9/10): match when ANY of the product's assigned
@@ -321,7 +319,14 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
     }
 
     return filtered;
-  }, [allProducts, selectedDomainId, searchQuery, matchSets]);
+  }, [allProducts, selectedDomainIds, searchQuery, matchSets]);
+
+  // Toggle a domain in the multi-select filter (add if absent, remove if present).
+  const toggleDomain = useCallback((domainId: string) => {
+    setSelectedDomainIds(prev =>
+      prev.includes(domainId) ? prev.filter(id => id !== domainId) : [...prev, domainId]
+    );
+  }, []);
 
   // Handle product card click
   const handleProductClick = async (product: DataProduct) => {
@@ -518,8 +523,8 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
         <div className="flex items-center justify-between mb-2">
           <div className="text-sm font-medium">{t('marketplace.browseDataDomains')}</div>
           <div className="flex items-center gap-4">
-            {/* Exact match toggle - only show when a domain is selected */}
-            {selectedDomainId && (
+            {/* Exact match toggle - only show when at least one domain is selected */}
+            {selectedDomainIds.length > 0 && (
               <div className="flex items-center gap-2">
                 <span className="text-xs text-muted-foreground">{t('marketplace.exactMatchOnly')}</span>
                 <Switch 
@@ -563,9 +568,9 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
           /* Pills View */
           <div className="flex flex-wrap gap-2">
             <Button
-              variant={selectedDomainId === null ? "default" : "outline"}
+              variant={selectedDomainIds.length === 0 ? "default" : "outline"}
               size="sm"
-              onClick={() => setSelectedDomainId(null)}
+              onClick={() => setSelectedDomainIds([])}
               className="rounded-full"
             >
               {t('marketplace.allDomains')}
@@ -578,9 +583,9 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
                 <HoverCard key={domain.id} openDelay={300} closeDelay={100}>
                   <HoverCardTrigger asChild>
                     <Button
-                      variant={selectedDomainId === domain.id ? "default" : "outline"}
+                      variant={selectedDomainIds.includes(domain.id) ? "default" : "outline"}
                       size="sm"
-                      onClick={() => setSelectedDomainId(domain.id)}
+                      onClick={() => toggleDomain(domain.id)}
                       className="rounded-full"
                     >
                       {domain.name}
@@ -621,7 +626,10 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
             <div className={`transition-opacity duration-300 ${graphFadeIn ? 'opacity-100' : 'opacity-0'}`}>
               <DataDomainMiniGraph
                 currentDomain={selectedDomainDetails}
-                onNodeClick={(id) => setSelectedDomainId(id)}
+                // Node click navigates the graph (focus only). Filtering is an
+                // explicit action via the pills view so browsing the graph doesn't
+                // silently mutate the multi-select filter (see graphFocusId note).
+                onNodeClick={(id) => setGraphFocusId(id)}
               />
             </div>
           ) : (
@@ -683,7 +691,7 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
             <div className="text-center py-12 text-muted-foreground">
               <Package className="h-12 w-12 mx-auto mb-4 opacity-30" />
               <p>{t('marketplace.products.noProducts')}</p>
-              {(searchQuery || selectedDomainId || scopeFilter !== 'all') && (
+              {(searchQuery || selectedDomainIds.length > 0 || scopeFilter !== 'all') && (
                 <p className="text-sm mt-1">{t('marketplace.products.adjustFilters')}</p>
               )}
             </div>

--- a/src/frontend/src/components/home/marketplace-view.tsx
+++ b/src/frontend/src/components/home/marketplace-view.tsx
@@ -292,12 +292,20 @@ export default function MarketplaceView({ className }: MarketplaceViewProps) {
     if (selectedDomainId) {
       if (!matchSets) return []; // Still loading match sets
       filtered = filtered.filter(p => {
+        // Any-of semantics (#520 story 9/10): match when ANY of the product's assigned
+        // domains (primary OR additional) falls in the selected domain (+descendants) set,
+        // not just the primary. domain_ids carries all assignments; fall back to the
+        // legacy primary `domain` id/name for products not yet re-indexed.
+        const assignedIds = (p as any)?.domain_ids as string[] | undefined;
+        if (assignedIds && assignedIds.length > 0) {
+          if (assignedIds.some(id => matchSets.ids.has(String(id)))) return true;
+        }
         const productDomainRaw = p?.domain;
         const productDomainIdLike = productDomainRaw != null ? String(productDomainRaw) : '';
         const productDomainLower = productDomainIdLike.toLowerCase();
         if (!productDomainLower) return false;
-        if (matchSets.ids.has(productDomainIdLike)) return true; // Match by id
-        if (matchSets.namesLower.has(productDomainLower)) return true; // Match by name
+        if (matchSets.ids.has(productDomainIdLike)) return true; // Match by id (primary)
+        if (matchSets.namesLower.has(productDomainLower)) return true; // Match by name (primary)
         return false;
       });
     }

--- a/src/frontend/src/components/teams/team-form-dialog.tsx
+++ b/src/frontend/src/components/teams/team-form-dialog.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import TagSelector from '@/components/ui/tag-selector';
+import DomainMultiSelector from '@/components/ui/domain-multi-selector';
 import { PrincipalPicker } from '@/components/common/principal-picker';
 import { principalAcceptsForMemberType } from '@/lib/team-members';
 import {
@@ -37,7 +38,6 @@ import { useTranslation } from 'react-i18next';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from '@/hooks/use-toast';
 import { TeamRead, TeamCreate, TeamUpdate, TeamMember } from '@/types/team';
-import { DataDomain } from '@/types/data-domain';
 
 // Form schema
 const teamMemberSchema = z.object({
@@ -50,7 +50,8 @@ const teamFormSchema = z.object({
   name: z.string().min(1, 'Team name is required'),
   title: z.string().optional(),
   description: z.string().optional(),
-  domain_id: z.string().optional(),
+  domain_ids: z.array(z.string()).optional(),
+  primary_domain_id: z.string().nullable().optional(),
   tags: z.array(z.any()).optional(),
   members: z.array(teamMemberSchema).optional(),
 });
@@ -72,7 +73,6 @@ export function TeamFormDialog({
   onSubmitSuccess,
   initialDomainId,
 }: TeamFormDialogProps) {
-  const [domains, setDomains] = useState<DataDomain[]>([]);
   const [availableRoles, setAvailableRoles] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -86,7 +86,8 @@ export function TeamFormDialog({
       name: '',
       title: '',
       description: '',
-      domain_id: 'none',
+      domain_ids: [],
+      primary_domain_id: null,
       tags: [],
       members: [],
     },
@@ -100,7 +101,6 @@ export function TeamFormDialog({
   // Fetch data when dialog opens
   useEffect(() => {
     if (isOpen) {
-      fetchDomains();
       fetchAvailableRoles();
 
       if (team) {
@@ -109,7 +109,8 @@ export function TeamFormDialog({
           name: team.name,
           title: team.title || '',
           description: team.description || '',
-          domain_id: team.domain_id || 'none',
+          domain_ids: team.domain_ids || (team.domain_id ? [team.domain_id] : []),
+          primary_domain_id: team.primary_domain_id ?? team.domain_id ?? null,
           tags: team.tags || [],
           members: team.members?.map(member => ({
             member_type: member.member_type,
@@ -123,24 +124,14 @@ export function TeamFormDialog({
           name: '',
           title: '',
           description: '',
-          domain_id: initialDomainId || 'none',
+          domain_ids: initialDomainId ? [initialDomainId] : [],
+          primary_domain_id: initialDomainId || null,
           tags: [],
           members: [],
         });
       }
     }
   }, [isOpen, team, form, initialDomainId]);
-
-  const fetchDomains = async () => {
-    try {
-      const response = await apiGet<DataDomain[]>('/api/data-domains');
-      if (response.data && !response.error) {
-        setDomains(Array.isArray(response.data) ? response.data : []);
-      }
-    } catch (error) {
-      console.error('Failed to fetch domains:', error);
-    }
-  };
 
   const fetchAvailableRoles = async () => {
     try {
@@ -167,9 +158,15 @@ export function TeamFormDialog({
     setIsSubmitting(true);
     try {
       // Filter out empty members and clean up data
+      const domainIds = data.domain_ids || [];
+      const primaryDomainId =
+        data.primary_domain_id && domainIds.includes(data.primary_domain_id)
+          ? data.primary_domain_id
+          : domainIds[0] ?? null;
       const cleanedData = {
         ...data,
-        domain_id: data.domain_id === 'none' ? undefined : data.domain_id,
+        domain_ids: domainIds,
+        primary_domain_id: primaryDomainId,
         tags: data.tags || [],
         members: data.members?.filter(member => member.member_identifier.trim() !== '').map(member => ({
           ...member,
@@ -184,7 +181,8 @@ export function TeamFormDialog({
           name: cleanedData.name,
           title: cleanedData.title || undefined,
           description: cleanedData.description || undefined,
-          domain_id: cleanedData.domain_id || undefined,
+          domain_ids: cleanedData.domain_ids,
+          primary_domain_id: cleanedData.primary_domain_id,
           tags: cleanedData.tags,
           metadata: undefined,
         };
@@ -226,7 +224,8 @@ export function TeamFormDialog({
           name: cleanedData.name,
           title: cleanedData.title || undefined,
           description: cleanedData.description || undefined,
-          domain_id: cleanedData.domain_id || undefined,
+          domain_ids: cleanedData.domain_ids,
+          primary_domain_id: cleanedData.primary_domain_id,
           tags: cleanedData.tags,
           metadata: undefined,
         };
@@ -335,25 +334,21 @@ export function TeamFormDialog({
 
               <FormField
                 control={form.control}
-                name="domain_id"
+                name="domain_ids"
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>{t('teams:form.labels.domain')}</FormLabel>
-                    <Select onValueChange={field.onChange} value={field.value}>
-                      <FormControl>
-                        <SelectTrigger>
-                          <SelectValue placeholder={t('teams:form.placeholders.selectDomain')} />
-                        </SelectTrigger>
-                      </FormControl>
-                      <SelectContent>
-                        <SelectItem value="none">No domain</SelectItem>
-                        {domains.map((domain) => (
-                          <SelectItem key={domain.id} value={domain.id}>
-                            {domain.name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
+                    <FormControl>
+                      <DomainMultiSelector
+                        value={field.value || []}
+                        primaryDomainId={form.watch('primary_domain_id')}
+                        onChange={(domainIds, primaryDomainId) => {
+                          field.onChange(domainIds);
+                          form.setValue('primary_domain_id', primaryDomainId);
+                        }}
+                        placeholder={t('teams:form.placeholders.selectDomain')}
+                      />
+                    </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/src/frontend/src/components/ui/domain-badge-list.tsx
+++ b/src/frontend/src/components/ui/domain-badge-list.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { Star } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { useDomains } from '@/hooks/use-domains';
+import { AssignedDomain } from '@/types/data-domain';
+
+export interface DomainBadgeListProps {
+  /** Assigned domain IDs (any order). The primary is rendered first with a star. */
+  domainIds?: (string | null | undefined)[] | null;
+  /** Which domain id is primary. */
+  primaryDomainId?: string | null;
+  /** Pre-resolved assigned domains (preferred when available — avoids a name lookup). */
+  domains?: AssignedDomain[] | null;
+  /** Optional click handler (e.g. navigate to the domain). */
+  onDomainClick?: (domainId: string) => void;
+  className?: string;
+}
+
+/**
+ * Renders an entity's assigned data domains as badges, with the primary distinguished
+ * (accent + star) and listed first (issue #520 story 12). Resolves names from the shared
+ * `useDomains` cache when only IDs are supplied.
+ */
+const DomainBadgeList: React.FC<DomainBadgeListProps> = ({
+  domainIds,
+  primaryDomainId,
+  domains,
+  onDomainClick,
+  className,
+}) => {
+  const { getDomainName } = useDomains();
+
+  // Build a normalized [{id, name, isPrimary}] list, primary first.
+  let entries: { id: string; name: string; isPrimary: boolean }[] = [];
+  if (domains && domains.length > 0) {
+    entries = domains
+      .filter(d => d.domain_id)
+      .map(d => ({
+        id: d.domain_id,
+        name: d.domain_name || getDomainName(d.domain_id) || d.domain_id,
+        isPrimary: d.is_primary,
+      }));
+  } else if (domainIds && domainIds.length > 0) {
+    entries = domainIds
+      .filter((id): id is string => Boolean(id))
+      .map(id => ({ id, name: getDomainName(id) || id, isPrimary: id === primaryDomainId }));
+  }
+  if (entries.length === 0) return null;
+
+  // Primary first, then stable by name.
+  entries.sort((a, b) => (a.isPrimary === b.isPrimary ? a.name.localeCompare(b.name) : a.isPrimary ? -1 : 1));
+
+  return (
+    <div className={cn('flex flex-wrap gap-1', className)}>
+      {entries.map(({ id, name, isPrimary }) => (
+        <Badge
+          key={id}
+          variant={isPrimary ? 'default' : 'secondary'}
+          className={cn('gap-1', onDomainClick && 'cursor-pointer hover:opacity-80')}
+          title={isPrimary ? `${name} (primary domain)` : name}
+          onClick={onDomainClick ? (e) => { e.stopPropagation(); onDomainClick(id); } : undefined}
+        >
+          {isPrimary && <Star className="h-3 w-3 fill-current" />}
+          <span className="truncate max-w-[10rem]">{name}</span>
+        </Badge>
+      ))}
+    </div>
+  );
+};
+
+export default DomainBadgeList;

--- a/src/frontend/src/components/ui/domain-multi-selector.test.ts
+++ b/src/frontend/src/components/ui/domain-multi-selector.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the DomainMultiSelector selection logic (#520 multi-domain).
+ *
+ * We test the exported pure helpers rather than rendering the component, because
+ * the underlying Radix <Popover>/<Command> hangs in jsdom (see trigger-picker /
+ * role-form-dialog tests for the same convention).
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  addDomainToSelection,
+  removeDomainFromSelection,
+  resolveEffectivePrimary,
+} from './domain-multi-selector';
+
+describe('resolveEffectivePrimary', () => {
+  it('returns null for an empty selection', () => {
+    expect(resolveEffectivePrimary([], null)).toBeNull();
+  });
+
+  it('falls back to the first selected domain when no primary is set', () => {
+    expect(resolveEffectivePrimary(['a', 'b'], null)).toBe('a');
+  });
+
+  it('keeps the explicit primary when it is still selected', () => {
+    expect(resolveEffectivePrimary(['a', 'b'], 'b')).toBe('b');
+  });
+
+  it('falls back to the first when the explicit primary is no longer selected', () => {
+    expect(resolveEffectivePrimary(['a', 'b'], 'z')).toBe('a');
+  });
+});
+
+describe('addDomainToSelection', () => {
+  it('makes the first added domain the primary', () => {
+    expect(addDomainToSelection([], null, 'a')).toEqual({ domainIds: ['a'], primaryDomainId: 'a' });
+  });
+
+  it('appends without changing the existing primary', () => {
+    expect(addDomainToSelection(['a'], 'a', 'b')).toEqual({ domainIds: ['a', 'b'], primaryDomainId: 'a' });
+  });
+
+  it('is a no-op when the domain is already selected', () => {
+    expect(addDomainToSelection(['a', 'b'], 'a', 'b')).toEqual({ domainIds: ['a', 'b'], primaryDomainId: 'a' });
+  });
+
+  it('respects maxDomains', () => {
+    expect(addDomainToSelection(['a'], 'a', 'b', 1)).toEqual({ domainIds: ['a'], primaryDomainId: 'a' });
+  });
+});
+
+describe('removeDomainFromSelection', () => {
+  it('removes a non-primary domain and keeps the primary', () => {
+    expect(removeDomainFromSelection(['a', 'b'], 'a', 'b')).toEqual({ domainIds: ['a'], primaryDomainId: 'a' });
+  });
+
+  it('promotes the first remaining domain when the primary is removed', () => {
+    expect(removeDomainFromSelection(['a', 'b'], 'a', 'a')).toEqual({ domainIds: ['b'], primaryDomainId: 'b' });
+  });
+
+  it('leaves no primary when the last domain is removed', () => {
+    expect(removeDomainFromSelection(['a'], 'a', 'a')).toEqual({ domainIds: [], primaryDomainId: null });
+  });
+});

--- a/src/frontend/src/components/ui/domain-multi-selector.tsx
+++ b/src/frontend/src/components/ui/domain-multi-selector.tsx
@@ -1,0 +1,257 @@
+import React, { useState } from 'react';
+import { Check, ChevronsUpDown, Star, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { useDomains } from '@/hooks/use-domains';
+
+/** The domain selection state emitted by the selector. */
+export interface DomainSelection {
+  domainIds: string[];
+  primaryDomainId: string | null;
+}
+
+/**
+ * Resolve the effective primary: the explicit primary if it is still selected,
+ * otherwise the first selected domain (or null when nothing is selected).
+ * Pure — exported for testing.
+ */
+export function resolveEffectivePrimary(value: string[], primaryDomainId: string | null | undefined): string | null {
+  if (primaryDomainId && value.includes(primaryDomainId)) return primaryDomainId;
+  return value[0] ?? null;
+}
+
+/** Add a domain (no-op if already present or over max); first added becomes primary. Pure. */
+export function addDomainToSelection(
+  value: string[],
+  primaryDomainId: string | null | undefined,
+  domainId: string,
+  maxDomains?: number,
+): DomainSelection {
+  const effective = resolveEffectivePrimary(value, primaryDomainId);
+  if (value.includes(domainId) || (maxDomains !== undefined && value.length >= maxDomains)) {
+    return { domainIds: value, primaryDomainId: effective };
+  }
+  const domainIds = [...value, domainId];
+  return { domainIds, primaryDomainId: effective ?? domainId };
+}
+
+/** Remove a domain; if it was primary, the first remaining becomes primary. Pure. */
+export function removeDomainFromSelection(
+  value: string[],
+  primaryDomainId: string | null | undefined,
+  domainId: string,
+): DomainSelection {
+  const effective = resolveEffectivePrimary(value, primaryDomainId);
+  const domainIds = value.filter(id => id !== domainId);
+  const nextPrimary = domainId === effective ? domainIds[0] ?? null : effective;
+  return { domainIds, primaryDomainId: nextPrimary };
+}
+
+export interface DomainMultiSelectorProps {
+  /** Currently selected domain IDs */
+  value: string[];
+  /** Which selected domain is the primary (feeds single-value integrations) */
+  primaryDomainId?: string | null;
+  /**
+   * Callback when the selection or primary changes. Emits the full domain-ID list
+   * and the primary domain ID (or null when nothing is selected).
+   */
+  onChange: (domainIds: string[], primaryDomainId: string | null) => void;
+  /** Placeholder text */
+  placeholder?: string;
+  /** Whether the selector is disabled */
+  disabled?: boolean;
+  /** Maximum number of domains that can be selected */
+  maxDomains?: number;
+  /** Label for the selector */
+  label?: string;
+  /** Additional CSS classes */
+  className?: string;
+}
+
+/**
+ * Multi-select for assigning one or more data domains to an entity, with exactly one
+ * marked as *primary*. Mirrors the tag-selector UX; domains are read from the shared
+ * `useDomains` cache (domains are created/managed elsewhere, so there is no "create").
+ */
+const DomainMultiSelector: React.FC<DomainMultiSelectorProps> = ({
+  value,
+  primaryDomainId,
+  onChange,
+  placeholder = 'Select domains...',
+  disabled = false,
+  maxDomains,
+  label,
+  className,
+}) => {
+  const [open, setOpen] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
+  const { domains, loading, getDomainName } = useDomains();
+
+  // Resolve the effective primary: the explicit one if still selected, else the first.
+  const effectivePrimary = resolveEffectivePrimary(value, primaryDomainId);
+
+  const isSelected = (domainId: string): boolean => value.includes(domainId);
+
+  const addDomain = (domainId: string) => {
+    const next = addDomainToSelection(value, primaryDomainId, domainId, maxDomains);
+    onChange(next.domainIds, next.primaryDomainId);
+    setSearchValue('');
+  };
+
+  const removeDomain = (domainId: string) => {
+    const next = removeDomainFromSelection(value, primaryDomainId, domainId);
+    onChange(next.domainIds, next.primaryDomainId);
+  };
+
+  const setPrimary = (domainId: string) => {
+    if (!isSelected(domainId)) return;
+    onChange(value, domainId);
+  };
+
+  const filteredDomains = domains.filter(domain =>
+    (domain.name?.toLowerCase() || '').includes(searchValue.toLowerCase())
+  );
+
+  return (
+    <div className={cn('space-y-2', className)}>
+      {label && <Label>{label}</Label>}
+
+      {/* Selected domains display */}
+      {value.length > 0 && (
+        <div className="flex flex-wrap gap-1 p-2 border rounded-md bg-background">
+          {value.map((domainId) => {
+            const isPrimary = domainId === effectivePrimary;
+            return (
+              <Badge
+                key={domainId}
+                variant={isPrimary ? 'default' : 'secondary'}
+                className="flex items-center gap-1"
+              >
+                {!disabled && (
+                  <button
+                    type="button"
+                    onClick={() => setPrimary(domainId)}
+                    title={isPrimary ? 'Primary domain' : 'Set as primary domain'}
+                    className="focus:outline-none"
+                    aria-label={isPrimary ? 'Primary domain' : 'Set as primary domain'}
+                  >
+                    <Star className={cn('h-3 w-3', isPrimary ? 'fill-current' : 'opacity-40')} />
+                  </button>
+                )}
+                <span className="truncate max-w-[12rem]">
+                  {getDomainName(domainId) || domainId}
+                </span>
+                {!disabled && (
+                  <button
+                    type="button"
+                    onClick={() => removeDomain(domainId)}
+                    title="Remove domain"
+                    className="focus:outline-none"
+                    aria-label="Remove domain"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                )}
+              </Badge>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Domain selector */}
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className={cn(
+              'w-full justify-between',
+              value.length === 0 && 'text-muted-foreground'
+            )}
+            disabled={disabled || (maxDomains ? value.length >= maxDomains : false)}
+          >
+            {value.length > 0 ? (
+              <span className="truncate">
+                {value.length === 1 ? '1 domain selected' : `${value.length} domains selected`}
+              </span>
+            ) : (
+              placeholder
+            )}
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-full p-0" align="start">
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="Search domains..."
+              value={searchValue}
+              onValueChange={setSearchValue}
+            />
+            <div
+              className="max-h-60 overflow-y-auto"
+              onWheel={(e) => e.stopPropagation()}
+            >
+              <CommandList>
+                {loading ? (
+                  <CommandEmpty>Loading domains...</CommandEmpty>
+                ) : filteredDomains.length === 0 ? (
+                  <CommandEmpty>No domains found.</CommandEmpty>
+                ) : (
+                  <CommandGroup>
+                    {filteredDomains.map((domain) => (
+                      <CommandItem
+                        key={domain.id}
+                        value={domain.name}
+                        onSelect={() => (isSelected(domain.id) ? removeDomain(domain.id) : addDomain(domain.id))}
+                      >
+                        <Check
+                          className={cn(
+                            'mr-2 h-4 w-4',
+                            isSelected(domain.id) ? 'opacity-100' : 'opacity-0'
+                          )}
+                        />
+                        <div className="flex-1 min-w-0">
+                          <span className="font-medium truncate">{domain.name}</span>
+                          {domain.description && (
+                            <div className="text-sm text-muted-foreground truncate">
+                              {domain.description}
+                            </div>
+                          )}
+                        </div>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+              </CommandList>
+            </div>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {maxDomains && (
+        <p className="text-sm text-muted-foreground">
+          {value.length} of {maxDomains} domains selected
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default DomainMultiSelector;

--- a/src/frontend/src/hooks/use-domains.test.ts
+++ b/src/frontend/src/hooks/use-domains.test.ts
@@ -51,9 +51,31 @@ describe('useDomains Hook', () => {
       const { result } = renderHook(() => useDomains());
 
       expect(typeof result.current.getDomainName).toBe('function');
+      expect(typeof result.current.getDomainNames).toBe('function');
       expect(typeof result.current.getDomainById).toBe('function');
       expect(typeof result.current.getDomainIdByName).toBe('function');
       expect(typeof result.current.refetch).toBe('function');
+    });
+
+    it('getDomainNames resolves a list of IDs to names, skipping unknowns (#520)', async () => {
+      (global.fetch as any).mockImplementation((url: string) => {
+        if (url === '/api/data-domains') {
+          return Promise.resolve({ ok: true, json: async () => mockDomains });
+        }
+        if (url === '/api/cache-version') {
+          return Promise.resolve({ ok: true, json: async () => ({ version: 1 }) });
+        }
+        return Promise.reject(new Error('Unknown URL'));
+      });
+
+      const { result } = renderHook(() => useDomains());
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.getDomainNames(['domain-1', 'domain-3'])).toEqual(['Finance', 'Sales']);
+      // Unknown IDs are skipped; order preserved.
+      expect(result.current.getDomainNames(['domain-2', 'ghost', 'domain-1'])).toEqual(['Marketing', 'Finance']);
+      expect(result.current.getDomainNames([])).toEqual([]);
+      expect(result.current.getDomainNames(null)).toEqual([]);
     });
 
     it('fetches domains on mount', async () => {

--- a/src/frontend/src/hooks/use-domains.ts
+++ b/src/frontend/src/hooks/use-domains.ts
@@ -222,6 +222,19 @@ export const useDomains = () => {
     }
   }, [state.domains])
 
+  // Memoized helper: resolve a list of domain IDs to their names (issue #520).
+  // Unknown IDs are skipped; input order is preserved.
+  const getDomainNames = useMemo(() => {
+    const domainMap = new Map(state.domains.map(domain => [domain.id, domain.name]))
+
+    return (domainIds: (string | null | undefined)[] | undefined | null): string[] => {
+      if (!domainIds) return []
+      return domainIds
+        .map(id => (id ? domainMap.get(id) : undefined))
+        .filter((name): name is string => Boolean(name))
+    }
+  }, [state.domains])
+
   // Memoized domain ID lookup by name function
   const getDomainIdByName = useMemo(() => {
     const domainNameMap = new Map(state.domains.map(domain => [domain.name.toLowerCase(), domain.id]))
@@ -237,6 +250,7 @@ export const useDomains = () => {
     loading: state.loading,
     error: state.error,
     getDomainName,
+    getDomainNames,
     getDomainById,
     getDomainIdByName,
     refetch: loadDomains,

--- a/src/frontend/src/types/asset.ts
+++ b/src/frontend/src/types/asset.ts
@@ -1,3 +1,5 @@
+import { AssignedDomain } from '@/types/data-domain';
+
 // --- Asset Types ---
 export type AssetTypeCategory = 'data' | 'analytics' | 'integration' | 'system' | 'custom';
 // Must match backend AssetTypeCategory enum: data, analytics, integration, system, custom
@@ -65,7 +67,10 @@ export interface AssetRead {
   asset_type_name?: string | null;
   platform?: string | null;
   location?: string | null;
-  domain_id?: string | null;
+  domain_id?: string | null; // Legacy single-domain (primary); prefer domain_ids
+  domain_ids?: string[]; // Multi-domain assignment (primary included)
+  primary_domain_id?: string | null;
+  domains?: AssignedDomain[]; // Assigned domains with names + primary flag
   properties?: Record<string, any> | null;
   tags?: string[] | null;
   status: AssetStatus;
@@ -89,7 +94,8 @@ export interface AssetCreate {
   asset_type_id: string;
   platform?: string | null;
   location?: string | null;
-  domain_id?: string | null;
+  domain_ids?: string[]; // Multi-domain assignment (primary included)
+  primary_domain_id?: string | null;
   properties?: Record<string, any> | null;
   tags?: string[] | null;
   status?: AssetStatus;
@@ -101,7 +107,8 @@ export interface AssetUpdate {
   asset_type_id?: string | null;
   platform?: string | null;
   location?: string | null;
-  domain_id?: string | null;
+  domain_ids?: string[]; // Replace-all; omit to leave unchanged
+  primary_domain_id?: string | null;
   properties?: Record<string, any> | null;
   tags?: string[] | null;
   status?: AssetStatus | null;

--- a/src/frontend/src/types/data-contract.ts
+++ b/src/frontend/src/types/data-contract.ts
@@ -30,8 +30,10 @@ export type DataContractListItem = {
   // Summary field from list endpoint
   schemaObjectCount?: number
   // Fields returned by summary endpoint for compatibility
-  domain?: string
-  domainId?: string
+  domain?: string // Primary domain name
+  domainId?: string // Legacy single-domain (primary) id
+  domainIds?: string[] // Multi-domain assignment (primary first)
+  primaryDomainId?: string | null
   kind?: string
   apiVersion?: string
   tenant?: string
@@ -257,8 +259,10 @@ export interface DataContract {
   status: string
   name: string
   tenant?: string
-  domain?: string // Legacy field (domain name)
-  domainId?: string // Domain ID for backend API
+  domain?: string // Primary domain name
+  domainId?: string // Legacy single-domain (primary) id
+  domainIds?: string[] // Multi-domain assignment (primary first)
+  primaryDomainId?: string | null
   dataProduct?: string
   owner_team_id?: string // UUID of the owning team
   owner_team_name?: string // Display name of the owning team
@@ -405,6 +409,8 @@ export type DataContractCreate = {
   apiVersion?: string
   domain?: string
   domainId?: string
+  domainIds?: string[] // Multi-domain assignment (primary included)
+  primaryDomainId?: string | null
   tenant?: string
   dataProduct?: string
   description?: ContractDescription

--- a/src/frontend/src/types/data-domain.ts
+++ b/src/frontend/src/types/data-domain.ts
@@ -5,6 +5,31 @@ export interface DataDomainBasicInfo {
   name: string;
 }
 
+/**
+ * Result of `GET /api/data-domains/{id}/deletion-impact` (#520). A domain that is the
+ * primary domain for any entity (or a descendant that would cascade-delete with it)
+ * cannot be deleted; `primary_assignments` lists what to reassign first.
+ */
+export interface DomainDeletionImpact {
+  domain_id: string;
+  domain_name: string;
+  deletable: boolean;
+  primary_assignments: { entity_type: string; entity_id: string }[];
+  assignment_counts: Record<string, { primary: number; additional: number }>;
+}
+
+/**
+ * A data domain assigned to an entity (team, data contract, data product, asset),
+ * with the primary flag. Mirrors the backend `AssignedDomain` model (#520 multi-domain).
+ */
+export interface AssignedDomain {
+  domain_id: string;
+  domain_name?: string | null;
+  is_primary: boolean;
+  assigned_by?: string | null;
+  assigned_at?: string | null;
+}
+
 export interface DataDomain {
   id: string;
   name: string;

--- a/src/frontend/src/types/data-product.ts
+++ b/src/frontend/src/types/data-product.ts
@@ -1,4 +1,5 @@
 import { AssignedTag } from '@/components/ui/tag-chip';
+import { AssignedDomain } from '@/types/data-domain';
 
 /**
  * ODPS v1.0.0 (Open Data Product Standard) TypeScript Types
@@ -253,7 +254,10 @@ export interface DataProduct {
   // ODPS v1.0.0 optional fields
   name?: string;
   version?: string;
-  domain?: string;
+  domain?: string; // Primary domain name (populated by backend); prefer domain_ids
+  domain_ids?: string[]; // Multi-domain assignment (primary included)
+  primary_domain_id?: string | null;
+  domains?: AssignedDomain[]; // Assigned domains with names + primary flag
   tenant?: string;
   authoritativeDefinitions?: AuthoritativeDefinition[];
   description?: Description;

--- a/src/frontend/src/types/team.ts
+++ b/src/frontend/src/types/team.ts
@@ -1,4 +1,5 @@
 import { AssignedTag } from '@/components/ui/tag-chip';
+import { AssignedDomain } from '@/types/data-domain';
 
 export enum MemberType {
   USER = "user",
@@ -33,8 +34,11 @@ export interface Team {
   name: string;
   title?: string | null;
   description?: string | null;
-  domain_id?: string | null;
+  domain_id?: string | null; // Legacy single-domain (primary); prefer domain_ids
   domain_name?: string | null; // For display
+  domain_ids?: string[]; // Multi-domain assignment (primary included)
+  primary_domain_id?: string | null;
+  domains?: AssignedDomain[]; // Assigned domains with names + primary flag
   tags?: AssignedTag[] | null;
   metadata?: Record<string, any> | null;
   created_at: string;
@@ -51,7 +55,8 @@ export interface TeamCreate {
   name: string;
   title?: string | null;
   description?: string | null;
-  domain_id?: string | null;
+  domain_ids?: string[]; // Multi-domain assignment (primary included)
+  primary_domain_id?: string | null;
   tags?: (string | AssignedTag)[] | null;
   metadata?: Record<string, any> | null;
 }
@@ -60,7 +65,8 @@ export interface TeamUpdate {
   name?: string;
   title?: string | null;
   description?: string | null;
-  domain_id?: string | null;
+  domain_ids?: string[]; // Replace-all; omit to leave unchanged
+  primary_domain_id?: string | null;
   tags?: (string | AssignedTag)[] | null;
   metadata?: Record<string, any> | null;
 }
@@ -69,6 +75,7 @@ export interface TeamSummary {
   id: string;
   name: string;
   title?: string | null;
-  domain_id?: string | null;
+  domain_ids?: string[];
+  primary_domain_id?: string | null;
   member_count: number;
 }

--- a/src/frontend/src/views/asset-detail.tsx
+++ b/src/frontend/src/views/asset-detail.tsx
@@ -13,6 +13,7 @@ import { Label } from '@/components/ui/label';
 import { TabsDetailSkeleton } from '@/components/common/list-view-skeleton';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { AssetDeleteDialog } from '@/components/assets/asset-delete-dialog';
+import DomainBadgeList from '@/components/ui/domain-badge-list';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AssetRead } from '@/types/asset';
 import { EntityTypeDefinition } from '@/types/ontology-schema';
@@ -355,13 +356,14 @@ export default function AssetDetailView() {
                     <Label className="text-xs text-muted-foreground">
                       {asset.domains && asset.domains.length > 1 ? 'Domains' : 'Domain'}
                     </Label>
-                    <p className="text-sm mt-1">
-                      {asset.domains && asset.domains.length > 0
-                        ? asset.domains
-                            .map(d => (d.is_primary ? `${d.domain_name} (primary)` : d.domain_name))
-                            .join(', ')
-                        : asset.domain_id}
-                    </p>
+                    <div className="mt-1">
+                      <DomainBadgeList
+                        domains={asset.domains}
+                        domainIds={asset.domain_id ? [asset.domain_id] : []}
+                        primaryDomainId={asset.primary_domain_id ?? asset.domain_id}
+                        onDomainClick={(id) => navigate(`/settings/data-domains/${id}`)}
+                      />
+                    </div>
                   </div>
                 )}
                 {asset.created_by && (

--- a/src/frontend/src/views/asset-detail.tsx
+++ b/src/frontend/src/views/asset-detail.tsx
@@ -350,10 +350,18 @@ export default function AssetDetailView() {
                     <p className="text-sm mt-1">{asset.platform}</p>
                   </div>
                 )}
-                {asset.domain_id && (
+                {((asset.domains && asset.domains.length > 0) || asset.domain_id) && (
                   <div>
-                    <Label className="text-xs text-muted-foreground">Domain</Label>
-                    <p className="text-sm mt-1">{asset.domain_id}</p>
+                    <Label className="text-xs text-muted-foreground">
+                      {asset.domains && asset.domains.length > 1 ? 'Domains' : 'Domain'}
+                    </Label>
+                    <p className="text-sm mt-1">
+                      {asset.domains && asset.domains.length > 0
+                        ? asset.domains
+                            .map(d => (d.is_primary ? `${d.domain_name} (primary)` : d.domain_name))
+                            .join(', ')
+                        : asset.domain_id}
+                    </p>
                   </div>
                 )}
                 {asset.created_by && (

--- a/src/frontend/src/views/data-contracts.tsx
+++ b/src/frontend/src/views/data-contracts.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { DataContractListItem, DataContractCreate } from '@/types/data-contract';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom'
-import { useDomains } from '@/hooks/use-domains'
+import DomainBadgeList from '@/components/ui/domain-badge-list'
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
@@ -33,7 +33,6 @@ import { FeatureAccessLevel } from '@/types/settings';
 export default function DataContracts() {
   const { t } = useTranslation(['data-contracts', 'common']);
   const { toast } = useToast();
-  const { getDomainName } = useDomains();
   const [contracts, setContracts] = useState<DataContractListItem[]>([]);
   const [loading, setLoading] = useState(true);
   // "Show all versions" toggle — flips the family-collapse on the backend.
@@ -330,26 +329,19 @@ export default function DataContracts() {
         );
       },
       cell: ({ row }) => {
-        const contract = row.original;
-        const primaryId = (contract as any).primaryDomainId || (contract as any).domain_id || (contract as any).domainId;
-        const domainName = (contract as any).domain || getDomainName(primaryId);
-        // Multi-domain (#520): show a +N indicator for additional (non-primary) domains.
-        const totalDomains = (contract as any).domainIds?.length ?? (primaryId ? 1 : 0);
-        const additionalCount = Math.max(0, totalDomains - 1);
+        const contract = row.original as any;
+        // Multi-domain (#520): render each assigned domain as a badge (primary starred).
+        const domainIds: string[] = contract.domainIds
+          ?? (contract.domainId ? [contract.domainId] : (contract.domain_id ? [contract.domain_id] : []));
+        const primaryId = contract.primaryDomainId || contract.domainId || contract.domain_id || domainIds[0] || null;
         return (
-          <div>
+          <div className="space-y-1">
             <div className="font-medium">{row.getValue("name")}</div>
-            {domainName && primaryId && (
-              <div
-                className="text-xs text-muted-foreground cursor-pointer hover:underline"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  navigate(`/settings/data-domains/${primaryId}`);
-                }}
-              >
-                ↳ Domain: {domainName}{additionalCount > 0 && ` +${additionalCount}`}
-              </div>
-            )}
+            <DomainBadgeList
+              domainIds={domainIds}
+              primaryDomainId={primaryId}
+              onDomainClick={(id) => navigate(`/settings/data-domains/${id}`)}
+            />
           </div>
         );
       },

--- a/src/frontend/src/views/data-contracts.tsx
+++ b/src/frontend/src/views/data-contracts.tsx
@@ -331,20 +331,23 @@ export default function DataContracts() {
       },
       cell: ({ row }) => {
         const contract = row.original;
-        const domainId = (contract as any).domain_id || (contract as any).domainId;
-        const domainName = getDomainName(domainId);
+        const primaryId = (contract as any).primaryDomainId || (contract as any).domain_id || (contract as any).domainId;
+        const domainName = (contract as any).domain || getDomainName(primaryId);
+        // Multi-domain (#520): show a +N indicator for additional (non-primary) domains.
+        const totalDomains = (contract as any).domainIds?.length ?? (primaryId ? 1 : 0);
+        const additionalCount = Math.max(0, totalDomains - 1);
         return (
           <div>
             <div className="font-medium">{row.getValue("name")}</div>
-            {domainName && domainId && (
+            {domainName && primaryId && (
               <div
                 className="text-xs text-muted-foreground cursor-pointer hover:underline"
                 onClick={(e) => {
                   e.stopPropagation();
-                  navigate(`/settings/data-domains/${domainId}`);
+                  navigate(`/settings/data-domains/${primaryId}`);
                 }}
               >
-                ↳ Domain: {domainName}
+                ↳ Domain: {domainName}{additionalCount > 0 && ` +${additionalCount}`}
               </div>
             )}
           </div>

--- a/src/frontend/src/views/data-contracts.tsx
+++ b/src/frontend/src/views/data-contracts.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { DataContractListItem, DataContractCreate } from '@/types/data-contract';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom'
-import { useDomains } from '@/hooks/use-domains'
+import DomainBadgeList from '@/components/ui/domain-badge-list'
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
@@ -31,7 +31,6 @@ import { useApi } from '@/hooks/use-api';
 export default function DataContracts() {
   const { t } = useTranslation(['data-contracts', 'common']);
   const { toast } = useToast();
-  const { getDomainName } = useDomains();
   const [contracts, setContracts] = useState<DataContractListItem[]>([]);
   const [loading, setLoading] = useState(true);
   // "Show all versions" toggle — flips the family-collapse on the backend.
@@ -320,26 +319,19 @@ export default function DataContracts() {
         );
       },
       cell: ({ row }) => {
-        const contract = row.original;
-        const primaryId = (contract as any).primaryDomainId || (contract as any).domain_id || (contract as any).domainId;
-        const domainName = (contract as any).domain || getDomainName(primaryId);
-        // Multi-domain (#520): show a +N indicator for additional (non-primary) domains.
-        const totalDomains = (contract as any).domainIds?.length ?? (primaryId ? 1 : 0);
-        const additionalCount = Math.max(0, totalDomains - 1);
+        const contract = row.original as any;
+        // Multi-domain (#520): render each assigned domain as a badge (primary starred).
+        const domainIds: string[] = contract.domainIds
+          ?? (contract.domainId ? [contract.domainId] : (contract.domain_id ? [contract.domain_id] : []));
+        const primaryId = contract.primaryDomainId || contract.domainId || contract.domain_id || domainIds[0] || null;
         return (
-          <div>
+          <div className="space-y-1">
             <div className="font-medium">{row.getValue("name")}</div>
-            {domainName && primaryId && (
-              <div
-                className="text-xs text-muted-foreground cursor-pointer hover:underline"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  navigate(`/settings/data-domains/${primaryId}`);
-                }}
-              >
-                ↳ Domain: {domainName}{additionalCount > 0 && ` +${additionalCount}`}
-              </div>
-            )}
+            <DomainBadgeList
+              domainIds={domainIds}
+              primaryDomainId={primaryId}
+              onDomainClick={(id) => navigate(`/settings/data-domains/${id}`)}
+            />
           </div>
         );
       },

--- a/src/frontend/src/views/data-contracts.tsx
+++ b/src/frontend/src/views/data-contracts.tsx
@@ -321,20 +321,23 @@ export default function DataContracts() {
       },
       cell: ({ row }) => {
         const contract = row.original;
-        const domainId = (contract as any).domain_id || (contract as any).domainId;
-        const domainName = getDomainName(domainId);
+        const primaryId = (contract as any).primaryDomainId || (contract as any).domain_id || (contract as any).domainId;
+        const domainName = (contract as any).domain || getDomainName(primaryId);
+        // Multi-domain (#520): show a +N indicator for additional (non-primary) domains.
+        const totalDomains = (contract as any).domainIds?.length ?? (primaryId ? 1 : 0);
+        const additionalCount = Math.max(0, totalDomains - 1);
         return (
           <div>
             <div className="font-medium">{row.getValue("name")}</div>
-            {domainName && domainId && (
+            {domainName && primaryId && (
               <div
                 className="text-xs text-muted-foreground cursor-pointer hover:underline"
                 onClick={(e) => {
                   e.stopPropagation();
-                  navigate(`/settings/data-domains/${domainId}`);
+                  navigate(`/settings/data-domains/${primaryId}`);
                 }}
               >
-                ↳ Domain: {domainName}
+                ↳ Domain: {domainName}{additionalCount > 0 && ` +${additionalCount}`}
               </div>
             )}
           </div>

--- a/src/frontend/src/views/data-domain-details.tsx
+++ b/src/frontend/src/views/data-domain-details.tsx
@@ -501,7 +501,7 @@ export default function DataDomainDetailsView() {
     await Promise.all([
       load(`/api/data-products?domain_id=${domainId}`, setDomainProducts),
       load(`/api/data-contracts?domain_id=${domainId}`, setDomainContracts),
-      load(`/api/assets?domain_id=${domainId}&limit=200`, setDomainAssets),
+      load(`/api/assets?domain_id=${domainId}&limit=1000`, setDomainAssets),
     ]);
   }, [get]);
 

--- a/src/frontend/src/views/data-domain-details.tsx
+++ b/src/frontend/src/views/data-domain-details.tsx
@@ -14,7 +14,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import TagChip from '@/components/ui/tag-chip';
 import { Separator } from '@/components/ui/separator';
-import { ArrowLeft, Edit3, Users, Tag, Hash, CalendarDays, UserCircle, ListTree, ChevronsUpDown, Plus } from 'lucide-react';
+import { ArrowLeft, Edit3, Users, Tag, Hash, CalendarDays, UserCircle, ListTree, ChevronsUpDown, Plus, Star } from 'lucide-react';
 import ConceptSelectDialog from '@/components/semantic/concept-select-dialog';
 import LinkedConceptChips from '@/components/semantic/linked-concept-chips';
 import type { EntitySemanticLink } from '@/types/semantic-link';
@@ -249,6 +249,10 @@ export default function DataDomainDetailsView() {
   const [hierarchyConceptIris, setHierarchyConceptIris] = useState<string[]>([]);
   const [linkedAssets, setLinkedAssets] = useState<any[]>([]);
   const [domainTeams, setDomainTeams] = useState<TeamSummary[]>([]);
+  // Entities (products/contracts/assets) assigned to this domain — primary OR additional (#520 story 9/29).
+  const [domainProducts, setDomainProducts] = useState<any[]>([]);
+  const [domainContracts, setDomainContracts] = useState<any[]>([]);
+  const [domainAssets, setDomainAssets] = useState<any[]>([]);
   const [teamDialogOpen, setTeamDialogOpen] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
@@ -482,6 +486,25 @@ export default function DataDomainDetailsView() {
     }
   }, [get]);
 
+  const fetchDomainEntities = useCallback(async (domainId: string) => {
+    // Any-of domain filter (primary OR additional) via the list endpoints (#520).
+    const load = async (url: string, set: (v: any[]) => void) => {
+      try {
+        const resp = await get<any>(url);
+        const data = resp.data;
+        const items = Array.isArray(data) ? data : (data?.items ?? []);
+        set(!resp.error && Array.isArray(items) ? items : []);
+      } catch {
+        set([]);
+      }
+    };
+    await Promise.all([
+      load(`/api/data-products?domain_id=${domainId}`, setDomainProducts),
+      load(`/api/data-contracts?domain_id=${domainId}`, setDomainContracts),
+      load(`/api/assets?domain_id=${domainId}&limit=200`, setDomainAssets),
+    ]);
+  }, [get]);
+
   const handleTeamDialogSuccess = (_team: Team) => {
     // Refresh domain teams after successful team operation
     if (domainId) {
@@ -526,6 +549,7 @@ export default function DataDomainDetailsView() {
       fetchDomainDetails(domainId);
       fetchMetadata(domainId);
       fetchDomainTeams(domainId);
+      fetchDomainEntities(domainId);
     } else {
       setError("No Domain ID provided.");
       setDynamicTitle("Invalid Domain");
@@ -750,6 +774,52 @@ export default function DataDomainDetailsView() {
               </Button>
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      {/* Assigned entities (#520 story 9/29): products/contracts/assets in this domain,
+          primary OR additional, with the primary distinguished. */}
+      <Card className="mb-6">
+        <CardHeader>
+          <CardTitle className="text-xl flex items-center">
+            <Tag className="mr-2 h-5 w-5 text-primary"/>
+            Assigned Entities
+          </CardTitle>
+          <CardDescription>
+            Data products, contracts, and assets assigned to this domain (primary or additional).
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {([
+            { label: 'Data Products', items: domainProducts, path: (i: any) => `/data-products/${i.id}`, primaryKey: 'primary_domain_id' },
+            { label: 'Data Contracts', items: domainContracts, path: (i: any) => `/data-contracts/${i.id}`, primaryKey: 'primaryDomainId' },
+            { label: 'Assets', items: domainAssets, path: (i: any) => `/governance/assets/${i.id}`, primaryKey: 'primary_domain_id' },
+          ] as const).map(({ label, items, path, primaryKey }) => (
+            <div key={label}>
+              <h4 className="text-sm font-semibold text-muted-foreground mb-2">{label} ({items.length})</h4>
+              {items.length > 0 ? (
+                <div className="flex flex-wrap gap-2">
+                  {items.map((it: any) => {
+                    const isPrimary = (it as any)[primaryKey] === domainId;
+                    return (
+                      <Badge
+                        key={it.id}
+                        variant={isPrimary ? 'default' : 'secondary'}
+                        className="cursor-pointer hover:opacity-80 gap-1"
+                        onClick={() => navigate(path(it))}
+                        title={isPrimary ? 'Primary domain' : 'Additional domain'}
+                      >
+                        {isPrimary && <Star className="h-3 w-3 fill-current" />}
+                        {it.name || it.id}
+                      </Badge>
+                    );
+                  })}
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">None assigned.</p>
+              )}
+            </div>
+          ))}
         </CardContent>
       </Card>
 

--- a/src/frontend/src/views/data-domains.tsx
+++ b/src/frontend/src/views/data-domains.tsx
@@ -4,7 +4,7 @@ import { MoreHorizontal, PlusCircle, AlertCircle, BoxSelect, TableIcon, Workflow
 import { ListViewSkeleton } from '@/components/common/list-view-skeleton';
 import { Button } from "@/components/ui/button";
 import { DataTable } from "@/components/ui/data-table";
-import { DataDomain } from '@/types/data-domain';
+import { DataDomain, DomainDeletionImpact } from '@/types/data-domain';
 import { useApi } from '@/hooks/use-api';
 import { useToast } from "@/hooks/use-toast";
 import { DataDomainFormDialog } from '@/components/data-domains/data-domain-form-dialog';
@@ -55,6 +55,7 @@ export default function DataDomainsView() {
   const [editingDomain, setEditingDomain] = useState<DataDomain | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [deletingDomainId, setDeletingDomainId] = useState<string | null>(null);
+  const [deletionImpact, setDeletionImpact] = useState<DomainDeletionImpact | null>(null);
   const [componentError, setComponentError] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'table' | 'graph'>('table');
   const [previewDomainId, setPreviewDomainId] = useState<string | null>(null);
@@ -134,7 +135,15 @@ export default function DataDomainsView() {
          return;
     }
     setDeletingDomainId(domainId);
+    setDeletionImpact(null);
     setIsDeleteDialogOpen(true);
+    // Pre-check whether the domain can be deleted (#520): blocked if it (or a
+    // descendant that cascade-deletes with it) is any entity's primary domain.
+    apiGet<DomainDeletionImpact>(`/api/data-domains/${domainId}/deletion-impact`)
+      .then((resp) => {
+        if (resp.data && !resp.error) setDeletionImpact(resp.data);
+      })
+      .catch((e) => console.error('Failed to load domain deletion impact:', e));
   };
 
   const handleDeleteConfirm = async () => {
@@ -143,8 +152,14 @@ export default function DataDomainsView() {
       const response = await apiDelete(`/api/data-domains/${deletingDomainId}`);
       if (response.error) {
         let errorMessage = response.error;
-        if (response.data && typeof response.data === 'object' && response.data !== null && 'detail' in response.data && typeof (response.data as { detail: string }).detail === 'string') {
-            errorMessage = (response.data as { detail: string }).detail;
+        // The delete-block 409 (#520) returns a structured `detail` object; surface its message.
+        if (response.data && typeof response.data === 'object' && response.data !== null && 'detail' in response.data) {
+            const detail = (response.data as { detail: unknown }).detail;
+            if (typeof detail === 'string') {
+                errorMessage = detail;
+            } else if (detail && typeof detail === 'object' && 'message' in detail && typeof (detail as { message: string }).message === 'string') {
+                errorMessage = (detail as { message: string }).message;
+            }
         }
         throw new Error(errorMessage || 'Failed to delete domain.');
       }
@@ -365,9 +380,31 @@ export default function DataDomainsView() {
               {t('deleteDialog.description')}
             </AlertDialogDescription>
           </AlertDialogHeader>
+          {deletionImpact && !deletionImpact.deletable && (
+            <div className="rounded-md border border-red-300 bg-red-50 dark:bg-red-950/30 p-3 text-sm text-red-800 dark:text-red-300">
+              <p className="font-medium">This domain can't be deleted.</p>
+              <p className="mt-1">
+                It is the primary domain for {deletionImpact.primary_assignments.length} entity assignment(s):
+              </p>
+              <ul className="mt-1 list-disc list-inside">
+                {Object.entries(deletionImpact.assignment_counts)
+                  .filter(([, counts]) => counts.primary > 0)
+                  .map(([entityType, counts]) => (
+                    <li key={entityType}>
+                      {counts.primary} {entityType.replace(/_/g, ' ')}(s)
+                    </li>
+                  ))}
+              </ul>
+              <p className="mt-1">Reassign those to a different primary domain first.</p>
+            </div>
+          )}
           <AlertDialogFooter>
-            <AlertDialogCancel onClick={() => setDeletingDomainId(null)}>{t('deleteDialog.cancel')}</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDeleteConfirm} className="bg-red-600 hover:bg-red-700" disabled={apiIsLoading || permissionsLoading}>
+            <AlertDialogCancel onClick={() => { setDeletingDomainId(null); setDeletionImpact(null); }}>{t('deleteDialog.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              className="bg-red-600 hover:bg-red-700"
+              disabled={apiIsLoading || permissionsLoading || (deletionImpact !== null && !deletionImpact.deletable)}
+            >
                {(apiIsLoading || permissionsLoading) ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null} {t('deleteDialog.delete')}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/frontend/src/views/data-products.tsx
+++ b/src/frontend/src/views/data-products.tsx
@@ -27,6 +27,7 @@ import { useNotificationsStore } from '@/stores/notifications-store';
 import DataProductGraphView from '@/components/data-products/data-product-graph-view';
 import useBreadcrumbStore from '@/stores/breadcrumb-store';
 import { useDomains } from '@/hooks/use-domains';
+import DomainBadgeList from '@/components/ui/domain-badge-list';
 import { useProjectContext } from '@/stores/project-store';
 import CertificationBadge from '@/components/common/certification-badge';
 import PublicationBadge from '@/components/common/publication-badge';
@@ -538,25 +539,18 @@ export default function DataProducts() {
       ),
       cell: ({ row }) => {
         const product = row.original;
-        const domainName = product.domain;
-        const domainId = product.primary_domain_id || getDomainIdByName(domainName);
-        // Multi-domain (#520): show a +N indicator for additional (non-primary) domains.
-        const totalDomains = product.domain_ids?.length ?? (domainId ? 1 : 0);
-        const additionalCount = Math.max(0, totalDomains - 1);
+        // Multi-domain (#520): render each assigned domain as a badge (primary starred).
+        const domainIds = product.domain_ids ?? [];
+        const primaryId = product.primary_domain_id || getDomainIdByName(product.domain) || domainIds[0] || null;
         return (
-          <div>
+          <div className="space-y-1">
             <div className="font-medium">{product.name || 'Unnamed Product'}</div>
-            {domainName && domainId && (
-              <div
-                className="text-xs text-muted-foreground cursor-pointer hover:underline"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  navigate(`/settings/data-domains/${domainId}`);
-                }}
-              >
-                ↳ Domain: {domainName}{additionalCount > 0 && ` +${additionalCount}`}
-              </div>
-            )}
+            <DomainBadgeList
+              domains={product.domains}
+              domainIds={domainIds}
+              primaryDomainId={primaryId}
+              onDomainClick={(id) => navigate(`/settings/data-domains/${id}`)}
+            />
           </div>
         );
       },

--- a/src/frontend/src/views/data-products.tsx
+++ b/src/frontend/src/views/data-products.tsx
@@ -539,7 +539,10 @@ export default function DataProducts() {
       cell: ({ row }) => {
         const product = row.original;
         const domainName = product.domain;
-        const domainId = getDomainIdByName(domainName);
+        const domainId = product.primary_domain_id || getDomainIdByName(domainName);
+        // Multi-domain (#520): show a +N indicator for additional (non-primary) domains.
+        const totalDomains = product.domain_ids?.length ?? (domainId ? 1 : 0);
+        const additionalCount = Math.max(0, totalDomains - 1);
         return (
           <div>
             <div className="font-medium">{product.name || 'Unnamed Product'}</div>
@@ -551,7 +554,7 @@ export default function DataProducts() {
                   navigate(`/settings/data-domains/${domainId}`);
                 }}
               >
-                ↳ Domain: {domainName}
+                ↳ Domain: {domainName}{additionalCount > 0 && ` +${additionalCount}`}
               </div>
             )}
           </div>

--- a/src/frontend/src/views/teams.tsx
+++ b/src/frontend/src/views/teams.tsx
@@ -154,7 +154,12 @@ export default function TeamsView() {
       ),
       cell: ({ row }) => {
         const team = row.original;
-        const domainName = team.domain_name || getDomainName(team.domain_id);
+        // Multi-domain (#520): prefer the assigned-domains list; fall back to legacy fields.
+        const primaryId = team.primary_domain_id || team.domain_id || (team.domain_ids && team.domain_ids[0]);
+        const primaryFromList = team.domains?.find(d => d.is_primary) || team.domains?.[0];
+        const primaryName = primaryFromList?.domain_name || team.domain_name || getDomainName(primaryId);
+        const totalDomains = team.domains?.length ?? team.domain_ids?.length ?? (primaryId ? 1 : 0);
+        const additionalCount = Math.max(0, totalDomains - 1);
         return (
           <div>
             <span
@@ -166,15 +171,16 @@ export default function TeamsView() {
             >
               {team.name}
             </span>
-            {domainName && team.domain_id && (
+            {primaryName && primaryId && (
               <div
                 className="text-xs text-muted-foreground cursor-pointer hover:underline"
                 onClick={(e) => {
                   e.stopPropagation();
-                  navigate(`/settings/data-domains/${team.domain_id}`);
+                  navigate(`/settings/data-domains/${primaryId}`);
                 }}
               >
-                {t('table.domainPrefix')} {domainName}
+                {t('table.domainPrefix')} {primaryName}
+                {additionalCount > 0 && ` +${additionalCount}`}
               </div>
             )}
           </div>

--- a/src/frontend/src/views/teams.tsx
+++ b/src/frontend/src/views/teams.tsx
@@ -23,7 +23,7 @@ import SettingsPageWrapper from '@/components/settings/settings-page-wrapper';
 import { useProjectContext } from '@/stores/project-store';
 import { TeamFormDialog } from '@/components/teams/team-form-dialog';
 import { useNavigate } from 'react-router-dom';
-import { useDomains } from '@/hooks/use-domains';
+import DomainBadgeList from '@/components/ui/domain-badge-list';
 import { useTranslation } from 'react-i18next';
 
 // Check API response helper
@@ -49,7 +49,6 @@ export default function TeamsView() {
   const { toast } = useToast();
   const { hasPermission, isLoading: permissionsLoading } = usePermissions();
   const navigate = useNavigate();
-  const { getDomainName } = useDomains();
   const { currentProject, hasProjectContext } = useProjectContext();
 
   const featureId = 'teams';
@@ -154,14 +153,11 @@ export default function TeamsView() {
       ),
       cell: ({ row }) => {
         const team = row.original;
-        // Multi-domain (#520): prefer the assigned-domains list; fall back to legacy fields.
-        const primaryId = team.primary_domain_id || team.domain_id || (team.domain_ids && team.domain_ids[0]);
-        const primaryFromList = team.domains?.find(d => d.is_primary) || team.domains?.[0];
-        const primaryName = primaryFromList?.domain_name || team.domain_name || getDomainName(primaryId);
-        const totalDomains = team.domains?.length ?? team.domain_ids?.length ?? (primaryId ? 1 : 0);
-        const additionalCount = Math.max(0, totalDomains - 1);
+        // Multi-domain (#520): render every assigned domain as a badge (primary starred).
+        const domainIds = team.domain_ids ?? (team.domain_id ? [team.domain_id] : []);
+        const primaryId = team.primary_domain_id || team.domain_id || domainIds[0] || null;
         return (
-          <div>
+          <div className="space-y-1">
             <span
               className="font-medium cursor-pointer hover:underline"
               onClick={(e) => {
@@ -171,18 +167,12 @@ export default function TeamsView() {
             >
               {team.name}
             </span>
-            {primaryName && primaryId && (
-              <div
-                className="text-xs text-muted-foreground cursor-pointer hover:underline"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  navigate(`/settings/data-domains/${primaryId}`);
-                }}
-              >
-                {t('table.domainPrefix')} {primaryName}
-                {additionalCount > 0 && ` +${additionalCount}`}
-              </div>
-            )}
+            <DomainBadgeList
+              domains={team.domains}
+              domainIds={domainIds}
+              primaryDomainId={primaryId}
+              onDomainClick={(id) => navigate(`/settings/data-domains/${id}`)}
+            />
           </div>
         );
       },
@@ -286,7 +276,7 @@ export default function TeamsView() {
         );
       },
     },
-  ], [canWrite, canAdmin, getDomainName, navigate, t, handleOpenEditDialog]);
+  ], [canWrite, canAdmin, navigate, t, handleOpenEditDialog]);
 
   return (
     <SettingsPageWrapper title={t('title')} permissionId="teams">


### PR DESCRIPTION
## Summary

Implements **multi-domain assignment** (issue #520): replaces each entity's single domain reference — `teams.domain_id`, `data_contracts.domain_id`, `assets.domain_id`, and the free-text `data_products.domain` — with one polymorphic junction table, `entity_domain_associations`, modeled on `entity_tag_associations`, with an `is_primary` flag (exactly one primary per entity). The **primary** feeds single-value integrations (ODCS/ODPS `domain`, UC `data_domain` tag); **additional** domains ride extension fields (`customProperties.additionalDomains`, `data_domain_additional` UC tags) and participate in any-of search, filter, and discovery.

Closes #520.

## What changed

**Data model & migration**
- New `entity_domain_associations` junction (`is_primary`, uniqueness on `(domain_id, entity_type, entity_id)`, partial-unique primary per entity).
- Alembic `l1` migration backfills every existing single-domain value as a primary association (data-product `domain` resolved id-then-name; unresolvable values logged), then drops the four legacy columns.

**Backend**
- `EntityDomainAssociationRepository` (replace-all set, batch reads, any-of inverse lookups, deletion-block queries) and `DomainExportAdapter` (ODCS/ODPS + UC tag conventions).
- Teams, contracts, products, and assets wired to the junction (managers/repos/models/routes); MCP tools and the UC tag-sync workflow updated.
- Domain deletion blocked (409, structured impact body) when a domain is primary anywhere; `GET /data-domains/{id}/deletion-impact`.
- `?domain_ids=` (CSV, any-of) filter on all four list routes; search index matches any assigned domain name; project visibility unions all of a user's teams' domains.

**Frontend**
- Shared `DomainMultiSelector` (searchable, star marks primary) on team/contract/product/asset forms; `DomainBadgeList` on list rows and asset-detail.
- Domain-detail page lists assigned products/contracts/assets (primary vs additional); marketplace discovery matches any assigned domain; `useDomains.getDomainNames`.

## Verification
- Backend **1434** unit tests pass (1 pre-existing, unrelated network-hang); frontend **880** pass; `tsc` type-check clean.
- The migration was exercised on a real **Lakebase Postgres 16** instance — upgrade backfill (incl. uuid cast + product id/name resolution + unresolvable skip), downgrade restore, single alembic head, and the repositories end-to-end.
- Four `/code-review` (high-effort) passes; the final pass found no issues.

## Not in this PR (non-blocking)
- Per-entity integration tests + dialog-payload tests (blocked by the integration audit-fixture harness and Radix-in-jsdom; pure-logic tests added instead).
- Search-index full-reindex issues a per-entity domain query (perf-only, infrequent path).

This pull request and its description were written by Isaac.