### PR TITLE
fix(build): correct ruff target-version and harden bump_version.py version replacement

### DIFF
--- a/src/backend/tests/test_bump_version_scoping.py
+++ b/src/backend/tests/test_bump_version_scoping.py
@@ -1,0 +1,102 @@
+"""Regression tests for the ``scripts/bump_version.py`` pyproject.toml scoping fix.
+
+The version bumper edits ``pyproject.toml`` with a regex substitution. A prior
+bug used an unanchored pattern with a global ``re.sub``, so bumping the project
+version also clobbered ``[tool.ruff]``'s ``target-version`` (and would clobber a
+``version`` key under any other table). The fix scopes the pattern to the
+``[project]`` table and passes ``count=1``.
+
+These tests pin that behavioral guarantee: bumping rewrites ONLY the
+``[project]`` table's ``version`` key and leaves ``target-version`` and a decoy
+table's ``version`` untouched. They are hermetic — the module is loaded straight
+from its file path and all edits happen against ``tmp_path``, never the real
+repo ``pyproject.toml``.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load scripts/bump_version.py directly by path so the test does not depend on
+# ``scripts`` being importable as a package from the pytest rootdir.
+_SRC_ROOT = Path(__file__).resolve().parents[2]  # .../src
+_BUMP_PATH = _SRC_ROOT / "scripts" / "bump_version.py"
+_spec = importlib.util.spec_from_file_location("bump_version_under_test", _BUMP_PATH)
+bump_version = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bump_version)
+
+
+# TOML content exercising every case the scoped pattern must distinguish:
+#   - the real [project].version         -> MUST be bumped
+#   - a decoy [tool.decoy].version        -> MUST be left alone
+#   - [tool.ruff].target-version          -> MUST be left alone
+_SAMPLE_TOML = """\
+[build-system]
+requires = ["hatchling>=1.21.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ontos"
+version = "1.0.1"
+requires-python = ">=3.11,<3.13"
+
+[tool.decoy]
+version = "9.9.9"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+"""
+
+
+def _pyproject_entry():
+    """Return the VERSION_FILES entry (pattern, replacement) for pyproject.toml."""
+    for rel_path, is_json, pattern, replacement in bump_version.VERSION_FILES:
+        if rel_path == "pyproject.toml":
+            return pattern, replacement
+    raise AssertionError("pyproject.toml entry missing from VERSION_FILES")
+
+
+def test_bump_rewrites_only_project_version(tmp_path: Path):
+    """Bumping rewrites ONLY [project].version; decoy + target-version survive."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(_SAMPLE_TOML, encoding="utf-8")
+
+    pattern, replacement = _pyproject_entry()
+    old_version = bump_version.update_text_version(
+        pyproject, pattern, replacement, "2.3.4"
+    )
+
+    assert old_version == "1.0.1"
+
+    result = pyproject.read_text(encoding="utf-8")
+
+    # The [project] version was bumped, exactly once.
+    assert 'version = "2.3.4"' in result
+    assert result.count('version = "2.3.4"') == 1
+
+    # The decoy table's version and ruff's target-version are untouched.
+    assert 'version = "9.9.9"' in result
+    assert 'target-version = "py311"' in result
+
+    # And no residue of the old project version remains.
+    assert '"1.0.1"' not in result
+
+
+def test_get_current_version_reads_project_version(tmp_path: Path):
+    """The read path returns the [project] version, not the decoy value."""
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(_SAMPLE_TOML, encoding="utf-8")
+
+    assert bump_version.get_current_version(tmp_path) == "1.0.1"
+
+
+def test_pattern_matches_project_version_exactly_once():
+    """The pyproject pattern matches the [project] version and nothing else."""
+    import re
+
+    pattern, _ = _pyproject_entry()
+    matches = re.findall(pattern, _SAMPLE_TOML)
+    assert len(matches) == 1

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -125,7 +125,7 @@ exclude_lines = [
 directory = "backend/htmlcov"
 
 [tool.ruff]
-target-version = "1.0.1"
+target-version = "py311"
 line-length = 100
 src = ["backend/src"]
 

--- a/src/scripts/bump_version.py
+++ b/src/scripts/bump_version.py
@@ -28,7 +28,14 @@ VERSION_FILES = [
     (
         "pyproject.toml",
         False,
-        r'(version\s*=\s*")[^"]+(")',
+        # Scope the match to the `[project]` table's `version` key ONLY.
+        # After the `[project]` header, the tempered dot `(?:(?!^\[).)*?`
+        # consumes lines lazily but can never cross a line-start `[` (the next
+        # TOML table header), so the anchored `^version = "..."` it finds must
+        # belong to `[project]`. This can never match `target-version` (not at
+        # line start) nor a `version` key under any other table (e.g.
+        # `[tool.*]`). DOTALL+MULTILINE via inline `(?ms)`.
+        r'(?ms)(^\[project\](?:(?!^\[).)*?^version\s*=\s*")[^"]+(")',
         r'\g<1>{version}\g<2>',
     ),
     # Python runtime __version__
@@ -82,8 +89,10 @@ def update_text_version(
         old_match = re.search(r"\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?", match.group(0))
         old_version = old_match.group(0) if old_match else "unknown"
 
-        # Replace with new version
-        new_content = re.sub(pattern, replacement.format(version=new_version), content)
+        # Replace with new version. count=1 guarantees only the first (and, for
+        # the scoped pyproject.toml pattern, the only) match is rewritten, so a
+        # future stray `version = "..."` under another table can never be hit.
+        new_content = re.sub(pattern, replacement.format(version=new_version), content, count=1)
         filepath.write_text(new_content, encoding="utf-8")
         return old_version
     except IOError as e:


### PR DESCRIPTION
## Summary

`[tool.ruff]` in `src/pyproject.toml` had `target-version = "1.0.1"` — the project's application version, which is **not** a valid ruff target. Ruff only accepts language targets (`py37`..`py315`), so it fails at **config-parse time** before linting anything:

```
ruff failed
  Cause: Failed to parse .../src/pyproject.toml
  Cause: TOML parse error at line 128, column 18
128 | target-version = "1.0.1"
unknown variant `1.0.1`, expected one of `py37`, `py38`, ... `py315`
```

This breaks `hatch -e dev run lint`, `ruff format --check`, and the ruff pre-commit hooks for every contributor.

This resolves the semantics issue a reviewer flagged during #558: *"target-version seems to be referring to the Python language version like py311."*

## What changed

- **`src/pyproject.toml`** — set `[tool.ruff] target-version = "py311"` (matches `requires-python = ">=3.11,<3.13"`).
- **`src/scripts/bump_version.py`** — fixed the **root cause**. The pyproject version-bump used an unanchored regex (`(version\s*=\s*")[^"]+(")`) with a global `re.sub`, which also matched `target-version` — so every version bump rewrote ruff's `target-version` with the app version. The replacement is now scoped to the `[project]` table (`(?ms)(^\[project\](?:(?!^\[).)*?^version\s*=\s*")[^"]+(")`) with `count=1`, so it can only ever touch the project version.
- **`src/backend/tests/test_bump_version_scoping.py`** — new hermetic regression test proving a bump rewrites **only** `[project].version` and leaves `target-version` and any other table's `version` key untouched. Fails against the old unanchored behavior.

## Why

Without this, backend lint/format and the ruff pre-commit hooks are unusable out of the box, and the next `bump_version.py` run would silently re-introduce the invalid value.

## How to test

```bash
# ruff config now parses and runs (previously errored at parse time)
cd src && hatch -e dev run lint
cd src && hatch -e dev run ruff format backend --check

# regression test for the bump_version scoping fix
cd src && hatch -e dev run python -m pytest backend/tests/test_bump_version_scoping.py -v
# -> 3 passed

# full suites
cd src && hatch -e dev run test            # 1452 passed
cd src/frontend && yarn type-check && yarn test:run
```

## Notes

- Scope is intentionally limited to fixing the broken config + its root cause. Now that ruff's config parses, `ruff check`/`format` surface substantial **pre-existing** lint/format debt in `backend/` — that cleanup is deliberately **out of scope** for this fix and left for a follow-up.
- CI is unaffected: no workflow currently invokes ruff.
