### PR TITLE
Fix non-deterministic frontend build on Databricks Apps (npm ERESOLVE)

### DIFF
--- a/src/frontend/.npmrc
+++ b/src/frontend/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+legacy-peer-deps=true


### PR DESCRIPTION
Fixes #654.

## Problem

Deploying Ontos as a Databricks App fails during the frontend build. In the Databricks Apps build image there is no yarn, so `scripts/build_static.sh` falls back to the npm path: `npm ci` fails (no `package-lock.json`, since `.npmrc` sets `package-lock=false`), then `npm install` resolves every `^`-ranged dependency to the newest version on the registry. It recently began resolving `@hookform/resolvers@5.5.7`, whose `peerOptional ajv-formats@^2` conflicts with the project's `ajv-formats@^3`, so npm aborts with `ERESOLVE` before Vite runs. The same source built fine weeks ago, no source change involved.

## Fix

Add `legacy-peer-deps=true` to `src/frontend/.npmrc` so the npm fallback resolves peer deps instead of aborting. Verified locally (Node 24/25, npm 11, no yarn): `npm install` + `vite build` succeed and emit `static/`.

## Note

This unblocks the build but the npm path stays non-deterministic. A more robust follow-up would be committing a `package-lock.json`, or ensuring yarn (with the existing `yarn.lock` and `--frozen-lockfile`) is actually used in the Databricks Apps build.