### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/src/backend/src/__init__.py
+++ b/src/backend/src/__init__.py
@@ -4,4 +4,4 @@ Databricks App API package.
 This package provides a FastAPI-based API for managing Unity Catalog and related services.
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontos",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/package.json
+++ b/src/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ontos-backend-build",
   "private": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Builds frontend and copies assets into backend static directory.",
   "engines": {
     "node": ">=18"

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ontos"
-version = "1.0.1"
+version = "1.0.2"
 description = "A Business Catalog for the Databricks Platform"
 readme = "../README.md"
 authors = [
@@ -125,7 +125,7 @@ exclude_lines = [
 directory = "backend/htmlcov"
 
 [tool.ruff]
-target-version = "1.0.1"
+target-version = "py311"
 line-length = 100
 src = ["backend/src"]
 

--- a/src/scripts/bump_version.py
+++ b/src/scripts/bump_version.py
@@ -24,11 +24,13 @@ from pathlib import Path
 # Version file configurations
 # Format: (relative_path, is_json, pattern_to_find, replacement_template)
 VERSION_FILES = [
-    # Python/Hatch build config
+    # Python/Hatch build config.
+    # Anchor to line start (?m) so we only match the top-level `version = "..."`
+    # key and never `target-version` (ruff) or other `*-version` keys.
     (
         "pyproject.toml",
         False,
-        r'(version\s*=\s*")[^"]+(")',
+        r'(?m)^(version\s*=\s*")[^"]+(")',
         r'\g<1>{version}\g<2>',
     ),
     # Python runtime __version__


### PR DESCRIPTION
## Summary

Bumps the version to **1.0.2** so a release/tag can be cut off `main` and the Databricks Apps Marketplace listing (and the git-install path) can point at a tagged version that includes the npm-only frontend build from #657.

Without this, `main` is 33 commits ahead of the last release (`v1.0.1`) and the npm-only fix isn't reachable from any tag.

## Changes

- **Version bump 1.0.1 → 1.0.2** across the four tracked files via `bump_version.py`: `src/pyproject.toml`, `src/backend/src/__init__.py`, `src/frontend/package.json`, `src/package.json`.
- **Fix a long-standing `bump_version.py` bug.** The `pyproject.toml` regex `(version\s*=\s*")[^"]+(")` was unanchored, so it also matched `target-version` under `[tool.ruff]` and wrote a semver there on every bump (it had been `"1.0.1"`, `"0.6.1"`, etc. — invalid; ruff expects a Python target like `py311`). Anchored the pattern to line start (`(?m)^...`) so only the top-level `version` key is touched, and corrected `target-version` to `py311` (matches `requires-python = ">=3.11,<3.13"`).

## Verification

- `bump_version.py` re-run: anchored regex matches exactly one line (top-level `version`), leaves `target-version` untouched.
- **Git-install deploy tested end-to-end on a Databricks Apps workspace** from this npm-only source: cloud-side build ran `Building frontend... → vite v6.4.3 → ✓ built in 22.70s`, `npm ci` with **zero ERESOLVE**, deployment state `SUCCEEDED`. (App start requires the usual warehouse + Lakebase resource bindings, unrelated to the build.)

## Follow-ups (not in this PR)

- After merge: cut the release/tag off `main` and publish the new Marketplace listing version pointing at it.
- Back-merge `main` → `development` (npm-only fix currently only on `main`); #655 (`legacy-peer-deps` band-aid, targeting `development`) is superseded by #657 and can be closed.

This pull request and its description were written by Isaac.