### PR TITLE
fix(search,demo): correct asset search link + invalid workflow step_type in demo seeds

### DIFF
--- a/src/backend/src/controller/assets_manager.py
+++ b/src/backend/src/controller/assets_manager.py
@@ -617,7 +617,7 @@ class AssetsManager(SearchableAsset):
             type=f"asset-{type_name.lower().replace(' ', '-')}",
             title=asset_db_obj.name,
             description=asset_db_obj.description or '',
-            link=f"/governance/assets/{asset_db_obj.id}",
+            link=f"/assets/{asset_db_obj.id}",
             tags=tags,
             feature_id="assets",
             extra_data={

--- a/src/backend/src/data/demo_data_auto.sql
+++ b/src/backend/src/data/demo_data_auto.sql
@@ -684,16 +684,16 @@ ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO workflow_steps (id, workflow_id, step_id, name, step_type, config, on_pass, on_fail, "order", position, created_at, updated_at) VALUES
 ('02b00101-0004-4000-8000-000000000001', '02a00101-0004-4000-8000-000000000001', 'cybersec_review', 'Cybersecurity Officer Review',
- 'manual_approval',
- '{"approver_role": "0f000003-0004-4000-8000-000000000003"}',
+ 'approval',
+ '{"approvers": "business:0f000003-0004-4000-8000-000000000003"}',
  'safety_review', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
 ('02b00102-0004-4000-8000-000000000002', '02a00101-0004-4000-8000-000000000001', 'safety_review',   'Functional Safety Sign-off',
- 'manual_approval',
- '{"approver_role": "0f000002-0004-4000-8000-000000000002"}',
+ 'approval',
+ '{"approvers": "business:0f000002-0004-4000-8000-000000000002"}',
  'pgm_approval',  'reject', 2, '{"x": 300, "y": 100}', NOW(), NOW()),
 ('02b00103-0004-4000-8000-000000000003', '02a00101-0004-4000-8000-000000000001', 'pgm_approval',    'Program Manager Approval',
- 'manual_approval',
- '{"approver_role": "0f000001-0004-4000-8000-000000000001"}',
+ 'approval',
+ '{"approvers": "business:0f000001-0004-4000-8000-000000000001"}',
  'approve',       'reject', 3, '{"x": 500, "y": 100}', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 

--- a/src/backend/src/data/demo_data_fsi.sql
+++ b/src/backend/src/data/demo_data_fsi.sql
@@ -716,12 +716,12 @@ INSERT INTO workflow_steps (id, workflow_id, step_id, name, step_type, config, o
  '{"policy_id": "01100001-0002-4000-8000-000000000001"}',
  'cro_attest', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
 ('02b00102-0002-4000-8000-000000000002', '02a00101-0002-4000-8000-000000000001', 'cro_attest',        'CRO Attestation',
- 'manual_approval',
- '{"approver_role": "0f000001-0002-4000-8000-000000000001"}',
+ 'approval',
+ '{"approvers": "business:0f000001-0002-4000-8000-000000000001"}',
  'approve', 'reject', 2, '{"x": 300, "y": 100}', NOW(), NOW()),
 ('02b00103-0002-4000-8000-000000000003', '02a00102-0002-4000-8000-000000000002', 'mrm_review',        'Model Risk Manager Review',
- 'manual_approval',
- '{"approver_role": "0f000003-0002-4000-8000-000000000003"}',
+ 'approval',
+ '{"approvers": "business:0f000003-0002-4000-8000-000000000003"}',
  'approve', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 

--- a/src/backend/src/data/demo_data_hls.sql
+++ b/src/backend/src/data/demo_data_hls.sql
@@ -737,16 +737,16 @@ INSERT INTO workflow_steps (id, workflow_id, step_id, name, step_type, config, o
  '{"policy_id": "01100002-0001-4000-8000-000000000002"}',
  'irb_active', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
 ('02b00102-0001-4000-8000-000000000002', '02a00101-0001-4000-8000-000000000001', 'irb_active',     'IRB Approval Active',
- 'manual_approval',
- '{"approver_role": "0f000003-0001-4000-8000-000000000003"}',
+ 'approval',
+ '{"approvers": "business:0f000003-0001-4000-8000-000000000003"}',
  'approve', 'reject', 2, '{"x": 300, "y": 100}', NOW(), NOW()),
 ('02b00103-0001-4000-8000-000000000003', '02a00102-0001-4000-8000-000000000002', 'phi_classification', 'PHI Classification',
  'policy_check',
  '{"policy_id": "01100001-0001-4000-8000-000000000001"}',
  'phi_review', 'block', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
 ('02b00104-0001-4000-8000-000000000004', '02a00102-0001-4000-8000-000000000002', 'phi_review', 'Privacy Officer Review',
- 'manual_approval',
- '{"approver_role": "0f000004-0001-4000-8000-000000000004"}',
+ 'approval',
+ '{"approvers": "business:0f000004-0001-4000-8000-000000000004"}',
  'approve', 'block', 2, '{"x": 300, "y": 100}', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 

--- a/src/backend/src/data/demo_data_mfg.sql
+++ b/src/backend/src/data/demo_data_mfg.sql
@@ -703,12 +703,12 @@ ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO workflow_steps (id, workflow_id, step_id, name, step_type, config, on_pass, on_fail, "order", position, created_at, updated_at) VALUES
 ('02b00101-0003-4000-8000-000000000001', '02a00101-0003-4000-8000-000000000001', 'qm_review',    'Quality Manager Review',
- 'manual_approval',
- '{"approver_role": "0f000002-0003-4000-8000-000000000002"}',
+ 'approval',
+ '{"approvers": "business:0f000002-0003-4000-8000-000000000002"}',
  'pm_review', 'reject', 1, '{"x": 100, "y": 100}', NOW(), NOW()),
 ('02b00102-0003-4000-8000-000000000002', '02a00101-0003-4000-8000-000000000001', 'pm_review',    'Plant Manager Approval',
- 'manual_approval',
- '{"approver_role": "0f000001-0003-4000-8000-000000000001"}',
+ 'approval',
+ '{"approvers": "business:0f000001-0003-4000-8000-000000000001"}',
  'approve', 'reject', 2, '{"x": 300, "y": 100}', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 


### PR DESCRIPTION
## Summary

Two related fixes surfaced while validating the demo data end to end on a fresh deploy.

### 1. Asset global-search results 404
`AssetsManager` built search-result links as `/governance/assets/{id}`, but that route does not exist in the frontend router — only `/assets/:assetId` is registered (`src/frontend/src/app.tsx`). Every asset hit from global search therefore 404s. Fixed the link to `/assets/{id}`.

### 2. Demo seeds insert an invalid workflow `step_type`, crashing `/api/workflows`
The `auto`, `fsi`, `hls`, and `mfg` demo packs insert `workflow_steps` with `step_type='manual_approval'`, which is not a member of the `StepType` enum. Once any of these presets is loaded, `GET /api/workflows` returns **500** for the whole list:

```
ValueError: 'manual_approval' is not a valid StepType
  at workflows_manager.py  step_type=StepType(step.step_type)
```

The same steps also used the dead config key `approver_role` with a bare business-role UUID. The approval step handler reads `config['approvers']`, and the role resolver requires the `business:` prefix to resolve a `BusinessRoleDb` id — so even after the enum fix the steps would fail at execution with "No approvers configured". Corrected both:
- `step_type`: `manual_approval` → `approval`
- `config`: `{"approver_role": "<uuid>"}` → `{"approvers": "business:<uuid>"}`

## Testing
- Deployed to a dev workspace, loaded `preset=auto`.
- Before: `GET /api/workflows` → 500; asset search click → 404.
- After: `GET /api/workflows` → 200; seeded approval workflow shows `approvers: business:<uuid>`; asset search click opens the asset detail page.

## Notes
- Only `retail` was already clean; the other four packs are fixed here.
- Observed (out of scope, not fixed here): `DELETE /api/settings/demo-data` skips one `assets` delete (`0f9%`) due to a FK constraint on `asset_relationships` — pre-existing, unrelated to these changes.

This pull request and its description were written by Isaac.