### PR TITLE
feat(dqx): gate Profile with DQX button on job state + optional admin request

### DIFF
--- a/src/backend/src/common/config.py
+++ b/src/backend/src/common/config.py
@@ -158,6 +158,11 @@ class Settings(BaseSettings):
     sandbox_allowed_schemas: List[str] = Field(default_factory=lambda: ['sandbox'], validation_alias=AliasChoices('SANDBOX_ALLOWED_SCHEMAS', 'sandbox_allowed_schemas'))
     sandbox_enforce_allowlist: bool = Field(True, validation_alias=AliasChoices('SANDBOX_ENFORCE_ALLOWLIST', 'sandbox_enforce_allowlist'))
 
+    # Background job enablement requests
+    # When True, users who hit a feature backed by a disabled background job may
+    # send an ACTION_REQUIRED notification to the Admin role asking for it to be enabled.
+    ALLOW_JOB_ENABLEMENT_REQUESTS: bool = Field(False, env='ALLOW_JOB_ENABLEMENT_REQUESTS')
+
     # Delivery Mode settings
     # Controls how governance changes (GRANTs, tag assignments, etc.) are propagated
     DELIVERY_MODE_DIRECT: bool = Field(False, env='DELIVERY_MODE_DIRECT')  # Apply changes directly to Unity Catalog via SDK

--- a/src/backend/src/controller/data_contracts_manager.py
+++ b/src/backend/src/controller/data_contracts_manager.py
@@ -39,6 +39,7 @@ from src.common.search_registry import searchable_asset
 
 from src.common.logging import get_logger
 from src.common.database import get_session_factory
+from src.common.errors import ConflictError
 from src.db_models.data_contracts import (
     DataContractDb,
     DataContractTagDb,
@@ -3840,6 +3841,20 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         if not contract:
             raise ValueError("Contract not found")
         
+        # Get jobs manager and workflow installation.
+        # Checked BEFORE the run record is created: a failed precondition used to leave
+        # behind a 'pending' run that the UI would then poll indefinitely.
+        if not jobs_manager:
+            raise ValueError("Jobs manager not available")
+
+        workflow_id = "dqx_profile_datasets"
+        installation = workflow_installation_repo.get_by_workflow_id(db=db, workflow_id=workflow_id)
+        if not installation:
+            raise ConflictError(
+                "The DQX profiling background job is not enabled. "
+                "Ask an administrator to enable it under Settings > Jobs."
+            )
+
         # Create profiling run record
         profile_run_id = str(uuid4())
         run = DataProfilingRunDb(
@@ -3854,16 +3869,7 @@ class DataContractsManager(DeliveryMixin, SearchableAsset):
         db.add(run)
         db.commit()
         db.refresh(run)
-        
-        # Get jobs manager and workflow installation
-        if not jobs_manager:
-            raise ValueError("Jobs manager not available")
-        
-        workflow_id = "dqx_profile_datasets"
-        installation = workflow_installation_repo.get_by_workflow_id(db=db, workflow_id=workflow_id)
-        if not installation:
-            raise ValueError(f"Workflow '{workflow_id}' not installed. Please install it via Settings > Jobs.")
-        
+
         # Trigger workflow with parameters
         # Only pass workflow-specific parameters
         # Database connection params are auto-injected by JobsManager

--- a/src/backend/src/controller/notifications_manager.py
+++ b/src/backend/src/controller/notifications_manager.py
@@ -309,6 +309,36 @@ class NotificationsManager:
             db.rollback()
             raise
 
+    def has_unhandled_actionable_notification(self, db: Session, action_type: str, action_payload: Dict) -> bool:
+        """Return True if an unread notification already matches this action type/payload.
+
+        Used to deduplicate user-triggered requests (e.g. asking an admin to enable a
+        background job) so repeated clicks don't flood the admin notification bell.
+        Matching mirrors handle_actionable_notification: the provided payload must be a
+        subset of the stored payload.
+        """
+        try:
+            for notification_db in self._repo.get_multi(db, limit=5000):
+                if notification_db.action_type != action_type or notification_db.read:
+                    continue
+
+                payload_db = {}
+                if notification_db.action_payload:
+                    try:
+                        payload_db = json.loads(notification_db.action_payload)
+                    except json.JSONDecodeError:
+                        logger.warning("Could not parse action_payload for notification %s", notification_db.id)
+                        continue
+
+                if all(item in payload_db.items() for item in action_payload.items()):
+                    return True
+
+            return False
+        except Exception as e:
+            logger.error("Error checking for existing actionable notification: %s", e, exc_info=True)
+            # Fail open: a duplicate notification is preferable to silently dropping a request.
+            return False
+
     def handle_actionable_notification(self, db: Session, action_type: str, action_payload: Dict) -> bool:
         """Finds notifications by action type/payload and marks them as read using the repository."""
         logger.debug(f"Attempting to handle notification: type={action_type}, payload={action_payload}")

--- a/src/backend/src/controller/settings_manager.py
+++ b/src/backend/src/controller/settings_manager.py
@@ -251,6 +251,11 @@ class SettingsManager:
             if 'TAG_DISPLAY_FORMAT' in all_settings and all_settings['TAG_DISPLAY_FORMAT'] is not None:
                 logger.debug(f"Loaded TAG_DISPLAY_FORMAT from database: {all_settings['TAG_DISPLAY_FORMAT']}")
             
+            # Background job enablement requests
+            if 'ALLOW_JOB_ENABLEMENT_REQUESTS' in all_settings and all_settings['ALLOW_JOB_ENABLEMENT_REQUESTS'] is not None:
+                self._settings.ALLOW_JOB_ENABLEMENT_REQUESTS = all_settings['ALLOW_JOB_ENABLEMENT_REQUESTS'].lower() == 'true'
+                logger.debug(f"Loaded ALLOW_JOB_ENABLEMENT_REQUESTS from database: {self._settings.ALLOW_JOB_ENABLEMENT_REQUESTS}")
+
             # Delivery mode settings
             if 'DELIVERY_MODE_DIRECT' in all_settings and all_settings['DELIVERY_MODE_DIRECT'] is not None:
                 self._settings.DELIVERY_MODE_DIRECT = all_settings['DELIVERY_MODE_DIRECT'].lower() == 'true'
@@ -1258,6 +1263,8 @@ class SettingsManager:
             'llm_disclaimer_text': self._settings.LLM_DISCLAIMER_TEXT,
             # Tag display settings
             'tag_display_format': tag_display_format,
+            # Background job enablement requests
+            'allow_job_enablement_requests': self._settings.ALLOW_JOB_ENABLEMENT_REQUESTS,
             # Delivery mode settings
             'delivery_mode_direct': self._settings.DELIVERY_MODE_DIRECT,
             'delivery_mode_indirect': self._settings.DELIVERY_MODE_INDIRECT,
@@ -1506,6 +1513,13 @@ class SettingsManager:
             else:
                 logger.warning(f"Invalid tag_display_format value: {value}. Must be 'short' or 'long'.")
         
+        # Handle background job enablement requests
+        if 'allow_job_enablement_requests' in settings:
+            value = settings.get('allow_job_enablement_requests')
+            app_settings_repo.set(self._db, 'ALLOW_JOB_ENABLEMENT_REQUESTS', str(value).lower() if value is not None else None)
+            self._settings.ALLOW_JOB_ENABLEMENT_REQUESTS = bool(value) if value is not None else self._settings.ALLOW_JOB_ENABLEMENT_REQUESTS
+            logger.info(f"Updated ALLOW_JOB_ENABLEMENT_REQUESTS to: {value}")
+
         # Handle delivery mode settings
         if 'delivery_mode_direct' in settings:
             value = settings.get('delivery_mode_direct')

--- a/src/backend/src/routes/data_contracts_routes.py
+++ b/src/backend/src/routes/data_contracts_routes.py
@@ -2120,6 +2120,10 @@ async def start_profiling(
         )
         
         return result
+    except HTTPException:
+        # Includes ConflictError raised when the DQX background job is not enabled;
+        # its message is actionable, so let it reach the client unchanged.
+        raise
     except ValueError as e:
         logger.error("Validation error starting profiling for contract %s: %s", contract_id, e)
         raise HTTPException(status_code=400, detail="Invalid profiling request")

--- a/src/backend/src/routes/jobs_routes.py
+++ b/src/backend/src/routes/jobs_routes.py
@@ -1,14 +1,23 @@
+import uuid
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
 from src.common.authorization import PermissionChecker
-from src.common.dependencies import DBSessionDep, AuditManagerDep, AuditCurrentUserDep
+from src.common.dependencies import DBSessionDep, AuditManagerDep, AuditCurrentUserDep, CurrentUserDep
 from src.common.features import FeatureAccessLevel
-from src.common.manager_dependencies import get_jobs_manager
+from src.common.manager_dependencies import (
+    get_jobs_manager,
+    get_notifications_manager,
+    get_settings_manager,
+)
 from src.common.database import get_db
 from src.controller.jobs_manager import JobsManager
+from src.controller.notifications_manager import NotificationsManager
+from src.controller.settings_manager import SettingsManager
+from src.models.notifications import Notification, NotificationType
 from src.repositories.workflow_job_runs_repository import workflow_job_run_repo
 from src.models.workflow_job_runs import WorkflowJobRun
 from src.repositories.workflow_installations_repository import workflow_installation_repo
@@ -688,4 +697,134 @@ async def update_workflow_configuration(
             action="UPDATE",
             success=success,
             details=details
+        )
+
+
+# Workflows whose install state gates a user-facing feature. Features backed by these
+# jobs need to know whether the job is installed so they can disable their entry point
+# instead of failing on click. Deliberately an allowlist: the capabilities endpoint is
+# readable by every authenticated user, so it must not become a full job inventory.
+FEATURE_GATING_WORKFLOW_IDS = (
+    'dqx_profile_datasets',
+    'mdm_match_detect',
+)
+
+
+@router.get('/jobs/capabilities')
+async def get_job_capabilities(
+    db: DBSessionDep,
+    _current_user: CurrentUserDep,
+    settings_manager: SettingsManager = Depends(get_settings_manager),
+) -> Dict[str, Any]:
+    """Report install state of feature-gating workflows to any authenticated user.
+
+    The regular job endpoints require the 'jobs' feature permission, which non-admin
+    roles do not have. Features like DQX profiling still need to know whether their
+    backing job exists so the UI can disable the button and explain why, so this
+    endpoint exposes only booleans for an allowlist of workflow IDs — no job IDs,
+    cluster IDs or run history.
+    """
+    installed_ids = {inst.workflow_id for inst in workflow_installation_repo.get_all_installed(db)}
+
+    return {
+        'workflows': {
+            workflow_id: {'installed': workflow_id in installed_ids}
+            for workflow_id in FEATURE_GATING_WORKFLOW_IDS
+        },
+        # Whether users may ask an admin to enable a disabled job.
+        'enablement_requests_allowed': settings_manager.get_settings().get(
+            'allow_job_enablement_requests', False
+        ),
+    }
+
+
+@router.post('/jobs/workflows/{workflow_id}/request-enablement')
+async def request_workflow_enablement(
+    workflow_id: str,
+    request: Request,
+    db: DBSessionDep,
+    audit_manager: AuditManagerDep,
+    current_user: AuditCurrentUserDep,
+    settings_manager: SettingsManager = Depends(get_settings_manager),
+    notifications_manager: NotificationsManager = Depends(get_notifications_manager),
+) -> Dict[str, Any]:
+    """Notify admins that a user needs a disabled background job enabled.
+
+    Intentionally not gated by the 'jobs' permission: the point is to let ordinary
+    users who cannot manage jobs ask someone who can. Guarded instead by the
+    ALLOW_JOB_ENABLEMENT_REQUESTS setting and the workflow allowlist, and deduplicated
+    so repeated clicks do not flood the admin bell.
+    """
+    success = False
+    details: Dict[str, Any] = {'workflow_id': workflow_id}
+
+    try:
+        if workflow_id not in FEATURE_GATING_WORKFLOW_IDS:
+            raise HTTPException(status_code=404, detail="Unknown workflow")
+
+        if not settings_manager.get_settings().get('allow_job_enablement_requests', False):
+            raise HTTPException(
+                status_code=403,
+                detail="Background job enablement requests are disabled for this deployment.",
+            )
+
+        # Nothing to request if it is already installed.
+        if workflow_installation_repo.get_by_workflow_id(db=db, workflow_id=workflow_id):
+            details['already_installed'] = True
+            success = True
+            return {'requested': False, 'reason': 'already_installed'}
+
+        requester_email = current_user.email or current_user.username if current_user else 'unknown'
+        action_payload = {'workflow_id': workflow_id}
+
+        # Dedupe on workflow only (not requester) so one pending ask per job reaches admins.
+        if notifications_manager.has_unhandled_actionable_notification(
+            db=db,
+            action_type='handle_job_enable_request',
+            action_payload=action_payload,
+        ):
+            details['deduplicated'] = True
+            success = True
+            return {'requested': False, 'reason': 'already_requested'}
+
+        display_name = next(
+            (w['name'] for w in settings_manager.list_available_workflows() if w.get('id') == workflow_id),
+            workflow_id,
+        )
+
+        notification = Notification(
+            id=str(uuid.uuid4()),
+            created_at=datetime.utcnow(),
+            type=NotificationType.ACTION_REQUIRED,
+            title="Background job enablement requested",
+            subtitle=f"Job: {display_name}",
+            description=(
+                f"User '{requester_email}' tried to use a feature that needs the "
+                f"'{display_name}' background job, which is not enabled. "
+                f"Enable it under Settings > Jobs."
+            ),
+            link='/settings/jobs',
+            recipient="Admin",
+            action_type='handle_job_enable_request',
+            action_payload={**action_payload, 'requester_email': requester_email},
+            can_delete=False,
+        )
+        notifications_manager.create_notification(notification=notification, db=db)
+
+        success = True
+        return {'requested': True}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to request enablement for workflow %s: %s", workflow_id, e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to submit enablement request")
+    finally:
+        audit_manager.log_action(
+            db=db,
+            username=current_user.username if current_user else "anonymous",
+            ip_address=request.client.host if request.client else None,
+            feature="jobs",
+            action="REQUEST_ENABLEMENT",
+            success=success,
+            details=details,
         )

--- a/src/backend/src/routes/settings_routes.py
+++ b/src/backend/src/routes/settings_routes.py
@@ -90,6 +90,8 @@ async def update_settings(
             details['sync_repository'] = settings_payload.get('sync_repository')
         if 'enabled_jobs' in settings_payload:
             details['enabled_jobs'] = settings_payload.get('enabled_jobs')
+        if 'allow_job_enablement_requests' in settings_payload:
+            details['allow_job_enablement_requests'] = settings_payload.get('allow_job_enablement_requests')
 
         updated = manager.update_settings(settings_payload)
         success = True

--- a/src/frontend/src/components/settings/general-settings.tsx
+++ b/src/frontend/src/components/settings/general-settings.tsx
@@ -21,6 +21,7 @@ interface AppSettings {
   llmEndpoint: string;
   llmSystemPrompt: string;
   llmDisclaimerText: string;
+  allowJobEnablementRequests: boolean;
 }
 
 export default function GeneralSettings() {
@@ -39,6 +40,7 @@ export default function GeneralSettings() {
     llmEndpoint: '',
     llmSystemPrompt: '',
     llmDisclaimerText: '',
+    allowJobEnablementRequests: false,
   });
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -59,6 +61,7 @@ export default function GeneralSettings() {
             llmEndpoint: data.llm_endpoint || '',
             llmSystemPrompt: data.llm_system_prompt || '',
             llmDisclaimerText: data.llm_disclaimer_text || '',
+            allowJobEnablementRequests: data.allow_job_enablement_requests || false,
           });
         }
       } catch (error) {
@@ -85,6 +88,7 @@ export default function GeneralSettings() {
           llm_endpoint: settings.llmEndpoint,
           llm_system_prompt: settings.llmSystemPrompt,
           llm_disclaimer_text: settings.llmDisclaimerText,
+          allow_job_enablement_requests: settings.allowJobEnablementRequests,
         }),
       });
       if (response.ok) {
@@ -202,6 +206,35 @@ export default function GeneralSettings() {
           <p className="text-sm text-muted-foreground">
             {t('settings:general.auditLog.help', 'Directory where audit log files are stored.')}
           </p>
+        </div>
+
+        <Separator />
+
+        {/* Background Job Settings */}
+        <div>
+          <h3 className="text-lg font-medium mb-3">
+            {t('settings:general.backgroundJobs.title', 'Background Jobs')}
+          </h3>
+
+          <div className="space-y-2">
+            <div className="flex items-center space-x-2">
+              <Switch
+                id="allowJobEnablementRequests"
+                checked={settings.allowJobEnablementRequests}
+                onCheckedChange={(checked) => setSettings(prev => ({ ...prev, allowJobEnablementRequests: checked }))}
+                disabled={!hasWriteAccess || isLoading}
+              />
+              <Label htmlFor="allowJobEnablementRequests">
+                {t('settings:general.backgroundJobs.allowEnablementRequests.label', 'Allow users to request background job enablement')}
+              </Label>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              {t(
+                'settings:general.backgroundJobs.allowEnablementRequests.help',
+                'When a user hits a feature whose background job is not enabled, they can send a notification asking an administrator to enable it.'
+              )}
+            </p>
+          </div>
         </div>
 
         <Separator />

--- a/src/frontend/src/i18n/locales/de/settings.json
+++ b/src/frontend/src/i18n/locales/de/settings.json
@@ -50,6 +50,13 @@
       "placeholder": "audit_logs",
       "help": "Verzeichnis, in dem Audit-Log-Dateien gespeichert werden."
     },
+    "backgroundJobs": {
+      "title": "Hintergrundjobs",
+      "allowEnablementRequests": {
+        "label": "Benutzern erlauben, die Aktivierung von Hintergrundjobs anzufordern",
+        "help": "Wenn ein Benutzer eine Funktion aufruft, deren Hintergrundjob nicht aktiviert ist, kann er eine Benachrichtigung an einen Administrator senden, um die Aktivierung anzufordern."
+      }
+    },
     "llm": {
       "title": "AI / LLM Konfiguration",
       "enabled": {

--- a/src/frontend/src/i18n/locales/en/settings.json
+++ b/src/frontend/src/i18n/locales/en/settings.json
@@ -143,6 +143,13 @@
       "placeholder": "audit_logs",
       "help": "Directory where audit log files are stored."
     },
+    "backgroundJobs": {
+      "title": "Background Jobs",
+      "allowEnablementRequests": {
+        "label": "Allow users to request background job enablement",
+        "help": "When a user hits a feature whose background job is not enabled, they can send a notification asking an administrator to enable it."
+      }
+    },
     "llm": {
       "title": "AI / LLM Configuration",
       "enabled": {

--- a/src/frontend/src/i18n/locales/es/settings.json
+++ b/src/frontend/src/i18n/locales/es/settings.json
@@ -50,6 +50,13 @@
       "placeholder": "audit_logs",
       "help": "Directorio donde se almacenan los archivos de log de auditoría."
     },
+    "backgroundJobs": {
+      "title": "Trabajos en segundo plano",
+      "allowEnablementRequests": {
+        "label": "Permitir a los usuarios solicitar la activación de trabajos en segundo plano",
+        "help": "Cuando un usuario accede a una función cuyo trabajo en segundo plano no está activado, puede enviar una notificación para pedir a un administrador que lo active."
+      }
+    },
     "llm": {
       "title": "Configuración de AI / LLM",
       "enabled": {

--- a/src/frontend/src/i18n/locales/fr/settings.json
+++ b/src/frontend/src/i18n/locales/fr/settings.json
@@ -50,6 +50,13 @@
       "placeholder": "audit_logs",
       "help": "Répertoire où les fichiers de journaux d'audit sont stockés."
     },
+    "backgroundJobs": {
+      "title": "Tâches en arrière-plan",
+      "allowEnablementRequests": {
+        "label": "Autoriser les utilisateurs à demander l'activation des tâches en arrière-plan",
+        "help": "Lorsqu'un utilisateur accède à une fonctionnalité dont la tâche en arrière-plan n'est pas activée, il peut envoyer une notification demandant à un administrateur de l'activer."
+      }
+    },
     "llm": {
       "title": "Configuration AI / LLM",
       "enabled": {

--- a/src/frontend/src/i18n/locales/it/settings.json
+++ b/src/frontend/src/i18n/locales/it/settings.json
@@ -50,6 +50,13 @@
       "placeholder": "audit_logs",
       "help": "Directory dove vengono archiviati i file di log di audit."
     },
+    "backgroundJobs": {
+      "title": "Processi in background",
+      "allowEnablementRequests": {
+        "label": "Consenti agli utenti di richiedere l'abilitazione dei processi in background",
+        "help": "Quando un utente utilizza una funzionalità il cui processo in background non è abilitato, può inviare una notifica per chiedere a un amministratore di abilitarlo."
+      }
+    },
     "llm": {
       "title": "Configurazione AI / LLM",
       "enabled": {

--- a/src/frontend/src/i18n/locales/ja/settings.json
+++ b/src/frontend/src/i18n/locales/ja/settings.json
@@ -50,6 +50,13 @@
       "placeholder": "audit_logs",
       "help": "監査ログファイルが保存されるディレクトリ。"
     },
+    "backgroundJobs": {
+      "title": "バックグラウンドジョブ",
+      "allowEnablementRequests": {
+        "label": "ユーザーによるバックグラウンドジョブの有効化リクエストを許可する",
+        "help": "バックグラウンドジョブが有効になっていない機能をユーザーが使用しようとした場合、管理者に有効化を依頼する通知を送信できます。"
+      }
+    },
     "llm": {
       "title": "AI / LLM 設定",
       "enabled": {

--- a/src/frontend/src/i18n/locales/nl/settings.json
+++ b/src/frontend/src/i18n/locales/nl/settings.json
@@ -50,6 +50,13 @@
       "placeholder": "audit_logs",
       "help": "Directory waar auditlog bestanden worden opgeslagen."
     },
+    "backgroundJobs": {
+      "title": "Achtergrondtaken",
+      "allowEnablementRequests": {
+        "label": "Gebruikers toestaan om activering van achtergrondtaken aan te vragen",
+        "help": "Wanneer een gebruiker een functie gebruikt waarvan de achtergrondtaak niet is ingeschakeld, kan deze een melding sturen om een beheerder te vragen die in te schakelen."
+      }
+    },
     "llm": {
       "title": "AI / LLM Configuratie",
       "enabled": {

--- a/src/frontend/src/stores/job-capabilities-store.ts
+++ b/src/frontend/src/stores/job-capabilities-store.ts
@@ -1,0 +1,75 @@
+import { create } from 'zustand';
+
+/**
+ * Install state of the background jobs that gate user-facing features.
+ *
+ * The regular job endpoints require the 'jobs' feature permission, which non-admin
+ * roles do not have, so features read their gating job's state from
+ * /api/jobs/capabilities instead. It returns booleans only, for an allowlist of
+ * workflow IDs.
+ */
+export type FeatureGatingWorkflowId = 'dqx_profile_datasets' | 'mdm_match_detect';
+
+interface JobCapabilitiesState {
+  installed: Partial<Record<FeatureGatingWorkflowId, boolean>>;
+  enablementRequestsAllowed: boolean;
+  isLoading: boolean;
+  isLoaded: boolean;
+  fetchCapabilities: () => Promise<void>;
+  isWorkflowInstalled: (workflowId: FeatureGatingWorkflowId) => boolean;
+  requestEnablement: (workflowId: FeatureGatingWorkflowId) => Promise<'requested' | 'already_requested' | 'already_installed'>;
+}
+
+export const useJobCapabilitiesStore = create<JobCapabilitiesState>()((set, get) => ({
+  installed: {},
+  enablementRequestsAllowed: false,
+  isLoading: false,
+  isLoaded: false,
+
+  fetchCapabilities: async () => {
+    if (get().isLoaded || get().isLoading) return;
+
+    set({ isLoading: true });
+    try {
+      const response = await fetch('/api/jobs/capabilities');
+      if (response.ok) {
+        const data = await response.json();
+        const installed: Partial<Record<FeatureGatingWorkflowId, boolean>> = {};
+        for (const [workflowId, state] of Object.entries(data.workflows ?? {})) {
+          installed[workflowId as FeatureGatingWorkflowId] = Boolean(
+            (state as { installed?: boolean }).installed
+          );
+        }
+        set({
+          installed,
+          enablementRequestsAllowed: Boolean(data.enablement_requests_allowed),
+        });
+      }
+    } catch (err) {
+      console.error('Error fetching job capabilities:', err);
+    } finally {
+      set({ isLoading: false, isLoaded: true });
+    }
+  },
+
+  isWorkflowInstalled: (workflowId: FeatureGatingWorkflowId) => {
+    // Assume available until proven otherwise, so a failed capabilities fetch
+    // does not disable working features.
+    const { installed, isLoaded } = get();
+    if (!isLoaded) return true;
+    return installed[workflowId] !== false;
+  },
+
+  requestEnablement: async (workflowId: FeatureGatingWorkflowId) => {
+    const response = await fetch(`/api/jobs/workflows/${workflowId}/request-enablement`, {
+      method: 'POST',
+    });
+    if (!response.ok) {
+      const detail = await response.json().catch(() => null);
+      throw new Error(detail?.detail || 'Failed to submit enablement request');
+    }
+    const data = await response.json();
+    if (data.requested) return 'requested';
+    return data.reason === 'already_installed' ? 'already_installed' : 'already_requested';
+  },
+}));

--- a/src/frontend/src/views/data-contract-details.tsx
+++ b/src/frontend/src/views/data-contract-details.tsx
@@ -15,6 +15,7 @@ import {
 import { Badge } from '@/components/ui/badge'
 import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DataTable } from '@/components/ui/data-table'
 import { ColumnDef } from '@tanstack/react-table'
@@ -35,6 +36,7 @@ import { FeatureAccessLevel } from '@/types/settings'
 import type { EntitySemanticLink } from '@/types/semantic-link'
 import type { DataContract, SchemaObject, QualityRule, TeamMember, ServerConfig, SLARequirements } from '@/types/data-contract'
 import useBreadcrumbStore from '@/stores/breadcrumb-store'
+import { useJobCapabilitiesStore } from '@/stores/job-capabilities-store'
 import RequestContractActionDialog from '@/components/data-contracts/request-contract-action-dialog'
 import CreateVersionDialog from '@/components/data-products/create-version-dialog'
 import DataContractBasicFormDialog from '@/components/data-contracts/data-contract-basic-form-dialog'
@@ -362,6 +364,14 @@ export default function DataContractDetails() {
   const [latestProfileRun, setLatestProfileRun] = useState<DataProfilingRun | null>(null)
   const [pendingSuggestionsCount, setPendingSuggestionsCount] = useState(0)
   const [isProfilingRunning, setIsProfilingRunning] = useState(false)
+  const [isRequestingDqxJob, setIsRequestingDqxJob] = useState(false)
+
+  // The DQX profiling button is backed by a background job an admin has to enable;
+  // without it, clicking through only produces an error.
+  const fetchJobCapabilities = useJobCapabilitiesStore(state => state.fetchCapabilities)
+  const isDqxJobInstalled = useJobCapabilitiesStore(state => state.isWorkflowInstalled('dqx_profile_datasets'))
+  const canRequestJobEnablement = useJobCapabilitiesStore(state => state.enablementRequestsAllowed)
+  const requestJobEnablement = useJobCapabilitiesStore(state => state.requestEnablement)
 
   // Editing states
   const [editingSchemaIndex, setEditingSchemaIndex] = useState<number | null>(null)
@@ -637,8 +647,11 @@ export default function DataContractDetails() {
           setLatestProfileRun(latest)
           setPendingSuggestionsCount(latest.suggestion_counts?.pending || 0)
           
-          // Check if profiling is still running
-          const isRunning = latest.status === 'running' || latest.status === 'pending'
+          // Check if profiling is still running. Nothing can advance a run while the
+          // DQX job is not installed, so a lingering 'pending'/'running' record is
+          // stale (e.g. left behind by an earlier failed start) rather than live work.
+          const isRunning =
+            (latest.status === 'running' || latest.status === 'pending') && isDqxJobInstalled
           setIsProfilingRunning(isRunning)
           
           // Notify when profiling completes
@@ -670,7 +683,7 @@ export default function DataContractDetails() {
       console.warn('Failed to fetch profile runs:', e)
       setIsProfilingRunning(false)
     }
-  }, [contractId, isProfilingRunning, toast])
+  }, [contractId, isProfilingRunning, isDqxJobInstalled, toast])
 
   // Determine default view mode based on user role and ownership
   const getDefaultViewMode = useCallback((): ViewMode => {
@@ -717,6 +730,10 @@ export default function DataContractDetails() {
       if (Array.isArray(data)) setCertificationLevels(data)
     })
   }, [get])
+
+  useEffect(() => {
+    fetchJobCapabilities()
+  }, [fetchJobCapabilities])
 
   useEffect(() => {
     setStaticSegments([{ label: 'Data Contracts', path: listPath }])
@@ -1534,8 +1551,10 @@ export default function DataContractDetails() {
         body: JSON.stringify({ schema_names: selectedSchemaNames })
       })
       if (!res.ok) {
-        const errorText = await res.text()
-        throw new Error(errorText || 'Failed to start profiling')
+        // The backend returns an actionable `detail` (e.g. the DQX job is not enabled);
+        // prefer it over the raw response body.
+        const errorDetail = await res.json().catch(() => null)
+        throw new Error(errorDetail?.detail || 'Failed to start profiling')
       }
       await res.json()
       toast({ 
@@ -1553,6 +1572,37 @@ export default function DataContractDetails() {
         description: e instanceof Error ? e.message : 'Could not start DQX profiling', 
         variant: 'destructive' 
       })
+    }
+  }
+
+  const handleRequestDqxJob = async () => {
+    setIsRequestingDqxJob(true)
+    try {
+      const result = await requestJobEnablement('dqx_profile_datasets')
+      if (result === 'already_installed') {
+        toast({
+          title: 'DQX profiling is already enabled',
+          description: 'Reload the page to start profiling.'
+        })
+      } else if (result === 'already_requested') {
+        toast({
+          title: 'Request already pending',
+          description: 'An administrator has already been notified about this job.'
+        })
+      } else {
+        toast({
+          title: 'Administrators notified',
+          description: 'They have been asked to enable the DQX profiling background job.'
+        })
+      }
+    } catch (e) {
+      toast({
+        title: 'Failed to notify administrators',
+        description: e instanceof Error ? e.message : 'Could not submit the request',
+        variant: 'destructive'
+      })
+    } finally {
+      setIsRequestingDqxJob(false)
     }
   }
 
@@ -2037,15 +2087,38 @@ export default function DataContractDetails() {
               <CardDescription>Database schema definitions</CardDescription>
             </div>
             <div className="flex gap-2">
-              <Button 
-                size="sm" 
-                variant="outline" 
-                onClick={() => setIsDqxSchemaSelectOpen(true)}
-                disabled={!contract.schema || contract.schema.length === 0}
-              >
-                <Sparkles className="h-4 w-4 mr-1.5" />
-                Profile with DQX
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {/* Wrapper span: a disabled button emits no pointer events of its own. */}
+                  <span tabIndex={isDqxJobInstalled ? -1 : 0}>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => setIsDqxSchemaSelectOpen(true)}
+                      disabled={!contract.schema || contract.schema.length === 0 || !isDqxJobInstalled}
+                    >
+                      <Sparkles className="h-4 w-4 mr-1.5" />
+                      Profile with DQX
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                {!isDqxJobInstalled && (
+                  <TooltipContent className="max-w-xs">
+                    <p>Ask your admin to enable the background job.</p>
+                    {canRequestJobEnablement && (
+                      <button
+                        type="button"
+                        onClick={handleRequestDqxJob}
+                        disabled={isRequestingDqxJob}
+                        className="mt-1 inline-flex items-center underline underline-offset-2 hover:no-underline disabled:opacity-60"
+                      >
+                        {isRequestingDqxJob && <Loader2 className="h-3 w-3 mr-1 animate-spin" />}
+                        {isRequestingDqxJob ? 'Notifying admin...' : 'Notify admin'}
+                      </button>
+                    )}
+                  </TooltipContent>
+                )}
+              </Tooltip>
               {canEditInPlace && (
                 <>
                   <Button size="sm" variant="outline" onClick={() => setIsInferFromCatalogOpen(true)} disabled={isInferringSchema}>


### PR DESCRIPTION
## Problem

Users clicked **Profile with DQX** while the backing background job was disabled and got a generic error toast. The button gave no indication that the feature was unavailable, and there was no path to ask an admin to turn it on.

## Approach

The button now reflects the job's install state, explains why it is disabled, and can optionally notify admins.

The main constraint: every existing endpoint that exposes job state (`/api/settings`, `/api/jobs/workflows/statuses`) is gated on `PermissionChecker('jobs', READ_ONLY)`, and `jobs` is absent from `DEFAULT_ROLE_PERMISSIONS` for **all** non-admin roles. So exactly the users who see this button (Data Steward / Data Producer, who have `data-contracts` READ_WRITE) would get a 403 from all of them. Hence a new minimal capability endpoint rather than reusing what exists.

### Backend

- **`ALLOW_JOB_ENABLEMENT_REQUESTS` setting** — persisted via `app_settings`, mirroring the existing `LLM_ENABLED` load/get/save pattern. Controls whether users may ask admins to enable a background job. Defaults to `false`.
- **`GET /api/jobs/capabilities`** — authenticated-only, no `jobs` permission required. Reports install state for an allowlist of feature-gating workflows (`dqx_profile_datasets`, `mdm_match_detect`). Returns booleans only — deliberately no job IDs, cluster IDs or run history, so it cannot become a job inventory for unprivileged users.
- **`POST /api/jobs/workflows/{id}/request-enablement`** — sends a deduplicated `ACTION_REQUIRED` notification to the `Admin` role, following the existing access-grant / deploy-request pattern. Not gated by the `jobs` permission by design: the point is to let users who *cannot* manage jobs ask someone who can. Guarded instead by the setting and the workflow allowlist.
- **`NotificationsManager.has_unhandled_actionable_notification()`** — dedupe helper so repeated clicks don't flood the admin bell. Fails open: a duplicate notification is preferable to silently dropping a request.

### Two bugs found while wiring this up

Both in the profiling start path, both user-visible:

1. **Dangling profiling runs.** `start_profiling()` committed the run record *before* checking the workflow was installed, so every failed click left a permanent `pending` row. The UI reads the latest run, sees `pending`, and shows *"DQX profiling in progress..."* indefinitely — with no job in existence to ever advance it. The check now runs first.
2. **Swallowed error message.** The route collapsed the sanitized `ValueError` into `detail="Invalid profiling request"`, which is why the toast was useless. It now raises `ConflictError` (409) with an actionable message and re-raises `HTTPException` so it reaches the client. (`.cursor/rules/05-code-style-and-structure.mdc:28` explicitly permits exposing sanitized `ValueError` messages.)

### Frontend

- **`job-capabilities-store`** — assumes the job is available until proven otherwise, so a failed capabilities fetch can never disable a working feature.
- **Button + hint** — disabled when the job isn't installed, with the hint in a tooltip and the *Notify admin* action **inside** the tooltip, so the request doesn't compete visually with the primary schema actions.
- **Stale-run guard** — a lingering `pending`/`running` record is treated as stale when the job isn't installed, fixing the false in-progress spinner.
- **Settings > General** toggle for admins, with translations for all 7 locales.

## Verification

Exercised end-to-end against a local backend + frontend on isolated ports:

| Check | Result |
|---|---|
| `GET /api/jobs/capabilities` | correct booleans, allowlist only |
| `POST .../request-enablement`, flag off | `403` |
| `POST .../request-enablement`, flag on | `{"requested": true}` |
| repeat request | `{"requested": false, "reason": "already_requested"}` |
| non-allowlisted workflow ID | `404 Unknown workflow` |
| admin notification | lands with resolved display name, correct payload |
| setting round-trip | persists through `PUT`/`GET /api/settings` |
| disabled button + tooltip | renders; in-tooltip *Notify admin* click fires |
| false in-progress spinner | gone |

`tsc --noEmit` clean. No new lint errors — `data-contract-details.tsx` has 24, verified identical to its pre-change baseline.

## Follow-ups (not in this PR)

- **Existing deployments may hold dangling `pending` profiling runs** created before this fix. The UI now ignores them, but a cleanup `UPDATE` or migration would remove them properly.
- **Pre-existing, unrelated to this change:** `can_delete=False` is stored correctly in Postgres but the API returns `true` for every notification — confirmed against the existing `workflow_approval` notification from `workflow_executor.py:631`, so it affects all notification flows. Worth its own issue.