### PR TITLE
fix(notifications): enforce can_delete and recipient access on DELETE

### DIFF
--- a/src/backend/src/controller/notifications_manager.py
+++ b/src/backend/src/controller/notifications_manager.py
@@ -23,6 +23,15 @@ logger = get_logger(__name__)
 class NotificationNotFoundError(Exception):
     """Raised when a notification is not found."""
 
+class NotificationNotDeletableError(Exception):
+    """Raised when a notification is marked ``can_delete=False``.
+
+    Actionable notifications (approval requests, access grants, contract
+    deploy requests, role access requests) are created with
+    ``can_delete=False`` to mean "you must respond to this, you cannot
+    dismiss it". Only an admin may override.
+    """
+
 class NotificationsManager:
     def __init__(self, settings_manager: 'SettingsManager'):
         """Initialize the notification manager.
@@ -33,6 +42,43 @@ class NotificationsManager:
         # self.notifications: List[Notification] = [] # REMOVE In-memory list
         self._repo = notification_repo # Use the repository instance
         self._settings_manager = settings_manager # Store the manager
+
+    def _role_maps(self) -> tuple[Dict[str, Any], Dict[str, Any]]:
+        """Build (role_by_id, role_by_name) lookups for recipient resolution.
+
+        ``role_by_name`` carries the exact name plus normalized and CamelCase
+        variants so legacy string recipients still resolve. A lookup failure
+        is non-fatal and yields empty maps, which fails closed downstream.
+        """
+        role_by_id: Dict[str, Any] = {}
+        role_by_name: Dict[str, Any] = {}
+        try:
+            for role in self._settings_manager.list_app_roles():
+                role_by_id[role.id] = role
+                role_by_name[role.name] = role
+                role_by_name[role.name.lower().replace(' ', '')] = role
+                role_by_name[''.join(word.capitalize() for word in role.name.split())] = role
+        except Exception as e:
+            logger.error(f"Failed to retrieve roles for notification handling: {e}")
+        return role_by_id, role_by_name
+
+    def is_app_admin(self, user_info: Optional[UserInfo], role_by_name: Optional[Dict[str, Any]] = None) -> bool:
+        """Whether the user holds the 'Admin' app role.
+
+        This is the same notion of admin used by ``get_notifications`` when it
+        overrides ``can_delete`` to True, so what the API reports and what it
+        enforces stay in step. Distinct from ``FeatureAccessLevel.ADMIN`` on
+        the notifications feature, which is a per-feature permission.
+        """
+        if not user_info:
+            return False
+        if role_by_name is None:
+            _, role_by_name = self._role_maps()
+        admin_role = role_by_name.get('Admin')
+        if not admin_role or not admin_role.assigned_groups:
+            return False
+        user_groups = set(user_info.groups or [])
+        return any(group in user_groups for group in admin_role.assigned_groups)
 
     def get_notification_by_id(self, db: Session, notification_id: str) -> Optional[Notification]:
         """Get a single notification by ID."""
@@ -70,32 +116,10 @@ class NotificationsManager:
         user_name = user_info.username  # Also check username for matching
 
         # Pre-fetch all role definitions for efficient lookup
-        # Create multiple mappings: by UUID, by name, and flexible name variants
-        try:
-            all_roles = self._settings_manager.list_app_roles()
-            role_by_id: Dict[str, 'AppRole'] = {}  # UUID -> role
-            role_by_name: Dict[str, 'AppRole'] = {}  # Name variants -> role
-            for role in all_roles:
-                # Map by UUID
-                role_by_id[role.id] = role
-                # Map by exact name
-                role_by_name[role.name] = role
-                # Also map by normalized name (no spaces, lowercase) for flexible matching
-                normalized = role.name.lower().replace(' ', '')
-                role_by_name[normalized] = role
-                # Also try CamelCase variant
-                camel_case = ''.join(word.capitalize() for word in role.name.split())
-                role_by_name[camel_case] = role
-        except Exception as e:
-            logger.error(f"Failed to retrieve roles for notification filtering: {e}")
-            role_by_id = {}
-            role_by_name = {}
+        role_by_id, role_by_name = self._role_maps()
 
         # Check if user is an admin (member of Admin role's groups)
-        is_admin = False
-        admin_role = role_by_name.get('Admin')
-        if admin_role and admin_role.assigned_groups:
-            is_admin = any(group in user_groups for group in admin_role.assigned_groups)
+        is_admin = self.is_app_admin(user_info, role_by_name)
 
         filtered_notifications = []
         for n in all_notifications_api:
@@ -166,29 +190,11 @@ class NotificationsManager:
         user_name = user_info.username
         
         # Pre-fetch all role definitions for efficient lookup
-        try:
-            all_roles = self._settings_manager.list_app_roles()
-            role_by_id: Dict[str, Any] = {}
-            role_by_name: Dict[str, Any] = {}
-            for role in all_roles:
-                role_by_id[role.id] = role
-                role_by_name[role.name] = role
-                # Normalized variants
-                normalized = role.name.lower().replace(' ', '')
-                role_by_name[normalized] = role
-                camel_case = ''.join(word.capitalize() for word in role.name.split())
-                role_by_name[camel_case] = role
-        except Exception as e:
-            logger.error(f"Failed to retrieve roles for notification access check: {e}")
-            role_by_id = {}
-            role_by_name = {}
-        
+        role_by_id, role_by_name = self._role_maps()
+
         # Check if user is an admin
-        is_admin = False
-        admin_role = role_by_name.get('Admin')
-        if admin_role and admin_role.assigned_groups:
-            is_admin = any(group in user_groups for group in admin_role.assigned_groups)
-        
+        is_admin = self.is_app_admin(user_info, role_by_name)
+
         recipient = notification.recipient
         target_role = None
         
@@ -280,11 +286,56 @@ class NotificationsManager:
              logger.error(f"Error creating notification in DB: {e}", exc_info=True)
              raise # Re-raise to be handled by the caller/route
 
-    def delete_notification(self, db: Session, notification_id: str) -> bool:
-        """Delete a notification by ID using the repository."""
+    def delete_notification(
+        self,
+        db: Session,
+        notification_id: str,
+        *,
+        is_admin: bool = False,
+    ) -> bool:
+        """Delete a notification by ID using the repository.
+
+        Enforces ``can_delete`` server-side. The flag was previously honoured
+        by the frontend alone, so a direct API call could dismiss a
+        notification that exists specifically to force a response.
+
+        Admins may override, matching ``get_notifications``, which reports
+        ``can_delete=True`` on every notification an admin can see. Without the
+        override an admin's UI would offer a delete button that always fails,
+        and orphaned notifications from dead workflows would be undeletable.
+
+        Args:
+            db: Database session
+            notification_id: ID of the notification to delete
+            is_admin: Whether the caller holds the 'Admin' app role
+
+        Returns:
+            True if the notification was deleted
+
+        Raises:
+            NotificationNotFoundError: No notification with that ID
+            NotificationNotDeletableError: ``can_delete`` is False and the
+                caller is not an admin
+        """
         try:
-             deleted_obj = self._repo.remove(db=db, id=notification_id)
-             return deleted_obj is not None
+            db_obj = self._repo.get(db=db, id=notification_id)
+            if not db_obj:
+                raise NotificationNotFoundError(f"Notification {notification_id} not found")
+
+            if not db_obj.can_delete and not is_admin:
+                raise NotificationNotDeletableError(
+                    f"Notification {notification_id} is marked as non-deletable"
+                )
+
+            if not db_obj.can_delete:
+                logger.info(
+                    f"Admin override: deleting non-deletable notification {notification_id}"
+                )
+
+            deleted_obj = self._repo.remove(db=db, id=notification_id)
+            return deleted_obj is not None
+        except (NotificationNotFoundError, NotificationNotDeletableError):
+            raise
         except Exception as e:
              logger.error(f"Error deleting notification {notification_id}: {e}", exc_info=True)
              raise

--- a/src/backend/src/routes/notifications_routes.py
+++ b/src/backend/src/routes/notifications_routes.py
@@ -9,7 +9,11 @@ from src.common.authorization import PermissionChecker
 from src.common.dependencies import NotificationsManagerDep, DBSessionDep, CurrentUserDep, AuditManagerDep, AuditCurrentUserDep
 from src.common.features import FeatureAccessLevel
 from src.models.users import UserInfo
-from src.controller.notifications_manager import NotificationNotFoundError, NotificationsManager
+from src.controller.notifications_manager import (
+    NotificationNotDeletableError,
+    NotificationNotFoundError,
+    NotificationsManager,
+)
 from src.models.notifications import Notification
 
 # Configure logging
@@ -105,11 +109,37 @@ async def delete_notification(
     }
 
     try:
-        deleted = manager.delete_notification(db=db, notification_id=notification_id)
+        # Mirror the mark-as-read endpoint: the feature permission says the
+        # caller may use notifications at all, not that they may act on
+        # someone else's. Without this a principal with notifications:ADMIN
+        # could delete any other user's notification, including ones scoped
+        # to a role they are not in.
+        notification = manager.get_notification_by_id(db=db, notification_id=notification_id)
+        if not notification:
+            raise HTTPException(status_code=404, detail="Notification not found")
+
+        if not manager.can_user_access_notification(db=db, notification=notification, user_info=current_user):
+            raise HTTPException(status_code=403, detail="Cannot delete other user's notifications")
+
+        is_admin = manager.is_app_admin(current_user)
+        details["params"]["admin_override"] = is_admin and not notification.can_delete
+
+        deleted = manager.delete_notification(
+            db=db, notification_id=notification_id, is_admin=is_admin
+        )
         if not deleted:
             raise HTTPException(status_code=404, detail="Notification not found")
         success = True
         return None
+    except NotificationNotFoundError:
+        details["exception"] = {"type": "NotificationNotFoundError", "status_code": 404}
+        raise HTTPException(status_code=404, detail="Notification not found")
+    except NotificationNotDeletableError:
+        details["exception"] = {"type": "NotificationNotDeletableError", "status_code": 403}
+        raise HTTPException(
+            status_code=403,
+            detail="This notification requires a response and cannot be dismissed",
+        )
     except HTTPException as e:
         details["exception"] = {
             "type": "HTTPException",

--- a/src/backend/src/tests/unit/test_notification_delete_authz.py
+++ b/src/backend/src/tests/unit/test_notification_delete_authz.py
@@ -1,0 +1,322 @@
+"""Unit tests for notification delete authorization (#675).
+
+Two checks were missing from `DELETE /api/notifications/{id}`, both of which
+already existed in the codebase and were simply not called here:
+
+1. **`can_delete` was never enforced server-side.** Approval requests, access
+   grants, contract deploy requests and role access requests are created with
+   `can_delete=False` to mean "you must respond to this". The flag was
+   persisted correctly but only the frontend honoured it, so a direct API call
+   dismissed the notification anyway.
+
+2. **No recipient check.** The endpoint was guarded only by
+   `PermissionChecker('notifications', ADMIN)`, so any principal holding that
+   feature permission could delete another user's notification — including one
+   scoped to a role they are not in. Mark-as-read, the weaker operation,
+   already called `can_user_access_notification()`.
+
+Admins may override `can_delete`, matching `get_notifications`, which reports
+`can_delete=True` on everything an admin can see. These tests pin both the
+enforcement and the override.
+"""
+
+# Set test environment variables BEFORE any app imports
+import os
+
+os.environ['TESTING'] = 'true'
+os.environ['SKIP_STARTUP_TASKS'] = 'true'
+
+import uuid
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy.orm import Session
+from src.controller.notifications_manager import (
+    NotificationNotDeletableError,
+    NotificationNotFoundError,
+    NotificationsManager,
+)
+from src.db_models.notifications import NotificationDb
+from src.models.users import UserInfo
+
+ADMIN_GROUP = "ontos_admins"
+USER_GROUP = "data_consumers"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _role(role_id: str, name: str, groups):
+    role = Mock()
+    role.id = role_id
+    role.name = name
+    role.assigned_groups = groups
+    return role
+
+
+@pytest.fixture
+def settings_manager():
+    """Settings manager exposing an Admin role bound to ADMIN_GROUP."""
+    mgr = Mock()
+    mgr.list_app_roles.return_value = [
+        _role("role-admin", "Admin", [ADMIN_GROUP]),
+        _role("role-consumer", "Data Consumer", [USER_GROUP]),
+    ]
+    return mgr
+
+
+@pytest.fixture
+def manager(settings_manager) -> NotificationsManager:
+    return NotificationsManager(settings_manager=settings_manager)
+
+
+@pytest.fixture
+def admin_user() -> UserInfo:
+    return UserInfo(
+        username="admin", email="admin@example.com", user="admin",
+        ip="127.0.0.1", groups=[ADMIN_GROUP],
+    )
+
+
+@pytest.fixture
+def normal_user() -> UserInfo:
+    return UserInfo(
+        username="alice", email="alice@example.com", user="alice",
+        ip="127.0.0.1", groups=[USER_GROUP],
+    )
+
+
+def _make_notification(db: Session, *, recipient=None, can_delete=True, role_id=None) -> str:
+    notification_id = str(uuid.uuid4())
+    db.add(NotificationDb(
+        id=notification_id,
+        type="info",
+        title="Approval required",
+        recipient=recipient,
+        recipient_role_id=role_id,
+        can_delete=can_delete,
+        read=False,
+    ))
+    db.commit()
+    return notification_id
+
+
+# ---------------------------------------------------------------------------
+# can_delete enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_deletable_notification_is_deleted(manager, db_session: Session):
+    notification_id = _make_notification(db_session, recipient="alice@example.com")
+
+    assert manager.delete_notification(db_session, notification_id) is True
+    assert db_session.query(NotificationDb).filter_by(id=notification_id).first() is None
+
+
+def test_non_deletable_notification_is_refused(manager, db_session: Session):
+    """The core of #675: this used to go straight to _repo.remove()."""
+    notification_id = _make_notification(
+        db_session, recipient="alice@example.com", can_delete=False
+    )
+
+    with pytest.raises(NotificationNotDeletableError):
+        manager.delete_notification(db_session, notification_id)
+
+    assert db_session.query(NotificationDb).filter_by(id=notification_id).first() is not None
+
+
+def test_admin_may_override_can_delete(manager, db_session: Session):
+    """Mirrors get_notifications, which reports can_delete=True to admins.
+
+    Without the override an admin's UI offers a delete button that always
+    fails, and notifications orphaned by a dead workflow can never be cleaned
+    up.
+    """
+    notification_id = _make_notification(
+        db_session, recipient="alice@example.com", can_delete=False
+    )
+
+    assert manager.delete_notification(db_session, notification_id, is_admin=True) is True
+    assert db_session.query(NotificationDb).filter_by(id=notification_id).first() is None
+
+
+def test_missing_notification_raises_not_found(manager, db_session: Session):
+    with pytest.raises(NotificationNotFoundError):
+        manager.delete_notification(db_session, str(uuid.uuid4()))
+
+
+def test_delete_defaults_to_non_admin(manager, db_session: Session):
+    """`is_admin` must default to False so any caller that forgets to pass it
+    gets the safe behaviour."""
+    notification_id = _make_notification(db_session, can_delete=False)
+
+    with pytest.raises(NotificationNotDeletableError):
+        manager.delete_notification(db=db_session, notification_id=notification_id)
+
+
+# ---------------------------------------------------------------------------
+# is_app_admin
+# ---------------------------------------------------------------------------
+
+
+def test_is_app_admin_true_for_admin_group(manager, admin_user):
+    assert manager.is_app_admin(admin_user) is True
+
+
+def test_is_app_admin_false_for_normal_user(manager, normal_user):
+    assert manager.is_app_admin(normal_user) is False
+
+
+def test_is_app_admin_false_without_user(manager):
+    assert manager.is_app_admin(None) is False
+
+
+def test_is_app_admin_false_when_admin_role_has_no_groups(admin_user):
+    """A role with no assigned groups must not silently promote everyone."""
+    settings_manager = Mock()
+    settings_manager.list_app_roles.return_value = [_role("role-admin", "Admin", [])]
+    manager = NotificationsManager(settings_manager=settings_manager)
+
+    assert manager.is_app_admin(admin_user) is False
+
+
+def test_is_app_admin_false_when_role_lookup_fails(admin_user):
+    """Role-lookup failure must fail closed, not grant admin."""
+    settings_manager = Mock()
+    settings_manager.list_app_roles.side_effect = RuntimeError("settings unavailable")
+    manager = NotificationsManager(settings_manager=settings_manager)
+
+    assert manager.is_app_admin(admin_user) is False
+
+
+# ---------------------------------------------------------------------------
+# Recipient access — the check the delete endpoint now calls
+# ---------------------------------------------------------------------------
+
+
+def test_other_users_notification_is_not_accessible(manager, db_session: Session, normal_user):
+    """A notification addressed to someone else is off-limits to a non-admin."""
+    notification_id = _make_notification(db_session, recipient="bob@example.com")
+    notification = manager.get_notification_by_id(db_session, notification_id)
+
+    assert manager.can_user_access_notification(
+        db=db_session, notification=notification, user_info=normal_user
+    ) is False
+
+
+def test_own_notification_is_accessible(manager, db_session: Session, normal_user):
+    notification_id = _make_notification(db_session, recipient="alice@example.com")
+    notification = manager.get_notification_by_id(db_session, notification_id)
+
+    assert manager.can_user_access_notification(
+        db=db_session, notification=notification, user_info=normal_user
+    ) is True
+
+
+def test_role_scoped_notification_needs_role_membership(manager, db_session: Session, normal_user, admin_user):
+    """Role-scoped notifications reach members of that role, not outsiders."""
+    notification_id = _make_notification(db_session, role_id="role-consumer")
+    notification = manager.get_notification_by_id(db_session, notification_id)
+
+    assert manager.can_user_access_notification(
+        db=db_session, notification=notification, user_info=normal_user
+    ) is True
+
+    outsider = UserInfo(
+        username="carol", email="carol@example.com", user="carol",
+        ip="127.0.0.1", groups=["unrelated_group"],
+    )
+    assert manager.can_user_access_notification(
+        db=db_session, notification=notification, user_info=outsider
+    ) is False
+
+
+def test_broadcast_notification_is_accessible_to_everyone(manager, db_session: Session, normal_user):
+    notification_id = _make_notification(db_session, recipient=None)
+    notification = manager.get_notification_by_id(db_session, notification_id)
+
+    assert manager.can_user_access_notification(
+        db=db_session, notification=notification, user_info=normal_user
+    ) is True
+
+
+# ---------------------------------------------------------------------------
+# Route wiring — DELETE /api/notifications/{id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_manager_client(client, db_session: Session):
+    """TestClient whose notifications manager is a stub we can steer.
+
+    Lets us exercise the endpoint's mapping from manager outcome to HTTP
+    status without standing up a full role/permission fixture.
+    """
+    from src.app import app
+    from src.common.manager_dependencies import get_audit_manager, get_notifications_manager
+
+    stub = Mock()
+
+    app.dependency_overrides[get_notifications_manager] = lambda: stub
+    # Startup tasks are skipped in tests, so app.state has no audit manager and
+    # the real dependency 503s before the route body runs.
+    app.dependency_overrides[get_audit_manager] = lambda: Mock()
+    yield client, stub
+    app.dependency_overrides.pop(get_notifications_manager, None)
+    app.dependency_overrides.pop(get_audit_manager, None)
+
+
+def test_delete_route_403_for_other_users_notification(stub_manager_client, db_session: Session):
+    client, stub = stub_manager_client
+    notification_id = _make_notification(db_session, recipient="bob@example.com")
+
+    stub.get_notification_by_id.return_value = Mock(can_delete=True)
+    stub.can_user_access_notification.return_value = False
+
+    response = client.delete(f"/api/notifications/{notification_id}")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Cannot delete other user's notifications"
+    stub.delete_notification.assert_not_called()
+
+
+def test_delete_route_403_when_not_deletable(stub_manager_client, db_session: Session):
+    client, stub = stub_manager_client
+    notification_id = _make_notification(db_session, can_delete=False)
+
+    stub.get_notification_by_id.return_value = Mock(can_delete=False)
+    stub.can_user_access_notification.return_value = True
+    stub.is_app_admin.return_value = False
+    stub.delete_notification.side_effect = NotificationNotDeletableError("nope")
+
+    response = client.delete(f"/api/notifications/{notification_id}")
+
+    assert response.status_code == 403
+    assert "requires a response" in response.json()["detail"]
+
+
+def test_delete_route_404_for_missing_notification(stub_manager_client):
+    client, stub = stub_manager_client
+    stub.get_notification_by_id.return_value = None
+
+    response = client.delete(f"/api/notifications/{uuid.uuid4()}")
+
+    assert response.status_code == 404
+    stub.delete_notification.assert_not_called()
+
+
+def test_delete_route_204_on_success(stub_manager_client, db_session: Session):
+    client, stub = stub_manager_client
+    notification_id = _make_notification(db_session, recipient="alice@example.com")
+
+    stub.get_notification_by_id.return_value = Mock(can_delete=True)
+    stub.can_user_access_notification.return_value = True
+    stub.is_app_admin.return_value = False
+    stub.delete_notification.return_value = True
+
+    response = client.delete(f"/api/notifications/{notification_id}")
+
+    assert response.status_code == 204
+    assert stub.delete_notification.call_args.kwargs["is_admin"] is False

--- a/src/backend/src/tests/unit/test_notifications_manager.py
+++ b/src/backend/src/tests/unit/test_notifications_manager.py
@@ -4,7 +4,11 @@ Unit tests for NotificationsManager
 import pytest
 from datetime import datetime
 from unittest.mock import Mock, MagicMock, patch, mock_open
-from src.controller.notifications_manager import NotificationsManager, NotificationNotFoundError
+from src.controller.notifications_manager import (
+    NotificationNotDeletableError,
+    NotificationNotFoundError,
+    NotificationsManager,
+)
 from src.models.notifications import Notification, NotificationType
 from src.models.users import UserInfo
 from src.db_models.notifications import NotificationDb
@@ -343,17 +347,39 @@ class TestNotificationsManager:
             manager.delete_notification(mock_db, notification_id="nonexistent")
 
     def test_delete_notification_cannot_delete(self, manager):
-        """Test trying to delete a notification marked as non-deletable."""
+        """Test trying to delete a notification marked as non-deletable.
+
+        Raises rather than returning False so the route can distinguish it
+        from "not found" and answer 403 instead of 404 (see #675).
+        """
         mock_db = Mock()
-        
+
         notif_db = Mock(spec=NotificationDb)
         notif_db.id = "notif-123"
         notif_db.can_delete = False
-        
+
         manager._repo.get.return_value = notif_db
 
-        result = manager.delete_notification(mock_db, notification_id="notif-123")
+        with pytest.raises(NotificationNotDeletableError):
+            manager.delete_notification(mock_db, notification_id="notif-123")
 
-        assert result is False
         manager._repo.remove.assert_not_called()
+
+    def test_delete_notification_admin_override(self, manager):
+        """Admins may delete a non-deletable notification (#675)."""
+        mock_db = Mock()
+
+        notif_db = Mock(spec=NotificationDb)
+        notif_db.id = "notif-123"
+        notif_db.can_delete = False
+
+        manager._repo.get.return_value = notif_db
+        manager._repo.remove.return_value = notif_db
+
+        result = manager.delete_notification(
+            mock_db, notification_id="notif-123", is_admin=True
+        )
+
+        assert result is True
+        manager._repo.remove.assert_called_once()
 


### PR DESCRIPTION
Closes #675.

## The two missing checks

Both already exist in the codebase; the delete endpoint just never called them.

### 1. `can_delete` was not enforced server-side

`NotificationsManager.delete_notification` went straight to `self._repo.remove(...)`. Reproduced against a session with a `can_delete=False` row present:

```
### development ###
before: can_delete=False
delete_notification returned: True
after: row DELETED

### this branch ###
before: can_delete=False
delete_notification raised: NotificationNotDeletableError: Notification … is marked as non-deletable
after: row still present
```

The four flows that rely on the flag — approval requests (`workflow_executor.py:631`), access grants (`access_grants_manager.py:765`), contract deploys (`data_contracts_manager.py:5264`), role access requests (`user_routes.py:449`) — were protected by the frontend alone.

### 2. No recipient access check

The endpoint was guarded only by `PermissionChecker('notifications', FeatureAccessLevel.ADMIN)`. That permission says the caller may use the notifications feature, not that they may act on someone else's notification. `can_user_access_notification()` was already called by mark-as-read (`notifications_routes.py:153`) and the workflow approval handler (`workflows_routes.py:1224`) — the strictly more destructive operation had the weaker check.

## The open question in the issue

> Worth deciding deliberately whether "admins may delete anything" should extend to `can_delete=False` rows, since those exist specifically to force a response. The GET override implies yes; the flag's purpose implies no.

**This PR lets admins override, and makes it explicit.** Reasoning:

- `get_notifications` already sets `can_delete = True` on everything an admin can see, and the issue confirms that override is intentional. If DELETE refused unconditionally, an admin's UI would render a delete button that always 403s — the API would report one thing and enforce another.
- There is no other cleanup path. A notification orphaned by a workflow that died mid-flight has `can_delete=False` forever and no way to respond to it.
- The override is narrow and observable: it requires the `Admin` app role, is logged at INFO, and is recorded in the audit entry as `admin_override`.

Non-admins get the strict behaviour, and `is_admin` defaults to `False` so any caller that forgets to pass it fails safe. If you'd rather have no override at all, it's a two-line change and I'm happy to make it.

## Changes

- `delete_notification(db, notification_id, *, is_admin=False)` loads the row first, raises `NotificationNotFoundError` when absent and the new `NotificationNotDeletableError` when `can_delete` is False and the caller is not an admin. A typed exception rather than a `False` return so the route can answer **403** and not **404** — the previous `if not deleted: 404` could not tell the two apart.
- The route calls `can_user_access_notification()` before deleting, mirroring mark-as-read, and returns 403 on failure.
- New `NotificationsManager.is_app_admin()` plus a `_role_maps()` helper. The role-lookup-and-detect-admin block was duplicated verbatim in `get_notifications` and `can_user_access_notification`; both now share one implementation, so what the API reports as `can_delete` and what it enforces cannot drift apart. Net −40 lines there.

Backend only. The frontend already respects the flag it is served, so no UI change is needed.

## Tests

18 new cases in `src/backend/src/tests/unit/test_notification_delete_authz.py`, against a real session rather than a mocked repository:

- `can_delete` enforcement, the admin override, and the default-to-non-admin contract
- `is_app_admin` — true for the Admin role's groups, false for a normal user, false with no user, false when the Admin role has no assigned groups, and **false when the role lookup raises** (fails closed rather than promoting on error)
- recipient access — own / other user's / role-scoped / broadcast
- route status mapping — 403 for a non-recipient, 403 for non-deletable, 404 for missing, 204 on success, and that `delete_notification` is not called at all on the two 403 paths

| | |
|---|---|
| New suite | **18 passed** |
| Full backend suite (`backend/src/tests/unit` + `backend/tests`) | **1503 passed, 1 skipped** |

The delete cases in the quarantined `test_notifications_manager.py` are updated to the new contract. That module stays quarantined — it assigns to `manager._repo.get.return_value` where `_repo` is the real repository singleton, so every case in it fails at setup, independently of this change.

## Unrelated, spotted in passing

`NotificationsManager.update_notification` is defined twice (lines 416 and 470); the second shadows the first, and ruff flags it `F811`. Same failure mode as the tool-module duplicates in #677. Not touched here — happy to file it separately.
