### PR TITLE
[Feature]: Concept versioning engine (P0 core) — schema, atomic publish, safe transition, freshness

### DIFF
--- a/src/backend/alembic/versions/m1_concept_versioning.py
+++ b/src/backend/alembic/versions/m1_concept_versioning.py
@@ -1,0 +1,216 @@
+"""Concept-versioning schema foundation (P0-1).
+
+Adds the concept-version spine for the ontology-versioning engine, mirroring the
+Data Products versioning pattern (indexed ``version`` + ``parent_*_id`` self-ref
+lineage, see j0577f481hh3 / j1_add_version_family_id):
+
+- ``concept_version`` [NEW]: ``(iri, version)`` is the versioned unit; ``iri`` is
+  the stable identity. Exactly one ``is_current=true`` row per ``iri`` (the hot
+  set), enforced at the DB level by a PARTIAL UNIQUE INDEX
+  ``UNIQUE(iri) WHERE is_current`` so the two-``is_current`` corruption is
+  structurally impossible, not merely transaction-disciplined.
+- ``rdf_triples`` [EXISTING]: add ONE column ``concept_version_id`` FK — the only
+  change to an existing table. Triple ownership rule (P0-1): a triple's owning
+  concept-version is determined by its SUBJECT IRI; blank-node closures follow the
+  IRI subject they hang off.
+- ``scheme_membership`` [NEW]: unversioned many-to-many ``(concept_iri, scheme_iri)``
+  (``skos:inScheme``). No "scheme version" object exists.
+
+Backfill (idempotent + reversible): every existing concept (subject of an
+``rdf:type`` triple whose object is ``skos:Concept`` / ``owl:Class`` /
+``rdfs:Class``) becomes version 1, ``is_current=true``. Every triple whose subject
+equals a concept IRI gets its ``concept_version_id`` set (subject-IRI ownership).
+``scheme_membership`` is seeded from existing ``skos:inScheme`` triples.
+
+Release manifests (release_manifest / manifest_pin) are intentionally NOT built
+here — deferred to P2, gated on a named version-pinning consumer.
+
+Postgres-targeted (partial unique index, gen_random_uuid); the project deploys on
+Postgres/Lakebase.
+
+Revision ID: m1_concept_versioning
+Revises: l1_entity_domain_associations
+Create Date: 2026-08-12
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'm1_concept_versioning'
+down_revision: Union[str, None] = 'l1_entity_domain_associations'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# rdf:type predicate and the object IRIs that mark a subject as a versionable
+# concept. skos:ConceptScheme is intentionally excluded: schemes are unversioned
+# membership tags, not concepts (see PRD §3.2).
+_RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'
+_SKOS_IN_SCHEME = 'http://www.w3.org/2004/02/skos/core#inScheme'
+_CONCEPT_TYPES = (
+    'http://www.w3.org/2004/02/skos/core#Concept',
+    'http://www.w3.org/2002/07/owl#Class',
+    'http://www.w3.org/2000/01/rdf-schema#Class',
+)
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. concept_version — the versioned unit is (iri, version).
+    # ------------------------------------------------------------------
+    op.create_table(
+        'concept_version',
+        sa.Column('id', PG_UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('gen_random_uuid()')),
+        # Stable identity across versions.
+        sa.Column('iri', sa.Text(), nullable=False),
+        # Monotonic per iri.
+        sa.Column('version', sa.Integer(), nullable=False, server_default='1'),
+        # Exactly one true per iri (enforced by partial unique index below).
+        sa.Column('is_current', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('status', sa.String(length=20), nullable=False, server_default='active'),
+        # Self-referential lineage / fork.
+        sa.Column('parent_version_id', PG_UUID(as_uuid=True), nullable=True),
+        # Set on a 2B meaning-split (new IRI replaces an old one).
+        sa.Column('replaces_iri', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column('created_by', sa.String(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ['parent_version_id'], ['concept_version.id'],
+            name='fk_concept_version_parent_version_id', ondelete='SET NULL',
+        ),
+        # (iri, version) is the versioned unit — no dup versions per iri.
+        sa.UniqueConstraint('iri', 'version', name='uq_concept_version_iri_version'),
+    )
+    op.create_index('ix_concept_version_iri', 'concept_version', ['iri'])
+    op.create_index('ix_concept_version_version', 'concept_version', ['version'])
+    op.create_index('ix_concept_version_is_current', 'concept_version', ['is_current'])
+    op.create_index('ix_concept_version_parent_version_id', 'concept_version',
+                    ['parent_version_id'])
+
+    # PARTIAL UNIQUE INDEX: at most one is_current=true row per iri. This makes
+    # the "two current versions of one concept" corruption structurally
+    # impossible at the DB level (P0-1 hard requirement).
+    op.create_index(
+        'uq_concept_version_current_per_iri',
+        'concept_version',
+        ['iri'],
+        unique=True,
+        postgresql_where=sa.text('is_current'),
+    )
+
+    # ------------------------------------------------------------------
+    # 2. rdf_triples: the ONE new column — which concept-version owns the triple.
+    # ------------------------------------------------------------------
+    op.add_column(
+        'rdf_triples',
+        sa.Column('concept_version_id', PG_UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index('ix_rdf_triples_concept_version_id', 'rdf_triples',
+                    ['concept_version_id'])
+    op.create_foreign_key(
+        'fk_rdf_triples_concept_version_id',
+        'rdf_triples', 'concept_version',
+        ['concept_version_id'], ['id'],
+        ondelete='SET NULL',
+    )
+
+    # ------------------------------------------------------------------
+    # 3. scheme_membership — unversioned m:n (concept_iri, scheme_iri).
+    # ------------------------------------------------------------------
+    op.create_table(
+        'scheme_membership',
+        sa.Column('id', PG_UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('gen_random_uuid()')),
+        sa.Column('concept_iri', sa.Text(), nullable=False),
+        sa.Column('scheme_iri', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column('created_by', sa.String(), nullable=True),
+        sa.UniqueConstraint('concept_iri', 'scheme_iri',
+                            name='uq_scheme_membership_concept_scheme'),
+    )
+    op.create_index('ix_scheme_membership_concept_iri', 'scheme_membership',
+                    ['concept_iri'])
+    op.create_index('ix_scheme_membership_scheme_iri', 'scheme_membership',
+                    ['scheme_iri'])
+
+    # ------------------------------------------------------------------
+    # 4. Backfill (idempotent). Reversibility is provided by downgrade()
+    #    dropping every object created above.
+    # ------------------------------------------------------------------
+    _backfill()
+
+
+def _backfill() -> None:
+    concept_types = ", ".join("'%s'" % t for t in _CONCEPT_TYPES)
+
+    # 4a. Every existing concept -> version 1, is_current=true. Idempotent via
+    #     NOT EXISTS so a re-run mints nothing new.
+    op.execute(f"""
+        INSERT INTO concept_version (id, iri, version, is_current, status, created_at)
+        SELECT gen_random_uuid(), t.subject_uri, 1, true, 'active', now()
+        FROM (
+            SELECT DISTINCT subject_uri
+            FROM rdf_triples
+            WHERE predicate_uri = '{_RDF_TYPE}'
+              AND object_is_uri = true
+              AND object_value IN ({concept_types})
+        ) t
+        WHERE NOT EXISTS (
+            SELECT 1 FROM concept_version cv WHERE cv.iri = t.subject_uri
+        );
+    """)
+
+    # 4b. Own every triple by its SUBJECT IRI (triple-ownership rule). Idempotent
+    #     via the IS NULL guard; only sets triples whose subject is a concept IRI.
+    op.execute("""
+        UPDATE rdf_triples r
+        SET concept_version_id = cv.id
+        FROM concept_version cv
+        WHERE cv.iri = r.subject_uri
+          AND cv.is_current = true
+          AND r.concept_version_id IS NULL;
+    """)
+
+    # 4c. Seed scheme membership from existing skos:inScheme triples. Idempotent
+    #     via NOT EXISTS.
+    op.execute(f"""
+        INSERT INTO scheme_membership (id, concept_iri, scheme_iri, created_at)
+        SELECT gen_random_uuid(), t.subject_uri, t.object_value, now()
+        FROM (
+            SELECT DISTINCT subject_uri, object_value
+            FROM rdf_triples
+            WHERE predicate_uri = '{_SKOS_IN_SCHEME}'
+              AND object_is_uri = true
+        ) t
+        WHERE NOT EXISTS (
+            SELECT 1 FROM scheme_membership sm
+            WHERE sm.concept_iri = t.subject_uri
+              AND sm.scheme_iri = t.object_value
+        );
+    """)
+
+
+def downgrade() -> None:
+    # Reverse order. Dropping concept_version_id + the tables removes all backfilled data.
+    op.drop_index('ix_scheme_membership_scheme_iri', 'scheme_membership')
+    op.drop_index('ix_scheme_membership_concept_iri', 'scheme_membership')
+    op.drop_table('scheme_membership')
+
+    op.drop_constraint('fk_rdf_triples_concept_version_id', 'rdf_triples',
+                       type_='foreignkey')
+    op.drop_index('ix_rdf_triples_concept_version_id', 'rdf_triples')
+    op.drop_column('rdf_triples', 'concept_version_id')
+
+    op.drop_index('uq_concept_version_current_per_iri', 'concept_version')
+    op.drop_index('ix_concept_version_parent_version_id', 'concept_version')
+    op.drop_index('ix_concept_version_is_current', 'concept_version')
+    op.drop_index('ix_concept_version_version', 'concept_version')
+    op.drop_index('ix_concept_version_iri', 'concept_version')
+    op.drop_table('concept_version')

--- a/src/backend/alembic/versions/m2_rdf_triples_current_view.py
+++ b/src/backend/alembic/versions/m2_rdf_triples_current_view.py
@@ -1,0 +1,46 @@
+"""rdf_triples_current view — the current-only read surface (P0-2).
+
+Write-time current/history split: the in-memory hot graph is built from
+CURRENT-ONLY triples, and reads carry NO version/is_current predicate. This view
+is the granted read surface the PRD P0-1/§4 calls for; the graph-build path
+(``_load_triples_from_db_to_graph``) selects from it so the ``is_current`` filter
+runs ONCE, at build time, never on reads.
+
+Membership rule (mirrors the P0-1 backfill ownership rule):
+- a triple is CURRENT if its owning concept-version has ``is_current = true``, OR
+- the triple has NO ``concept_version_id`` (scheme/collection/metadata triples
+  that P0-1 left unowned MUST still load — do not drop them).
+
+History triples (owned by a non-current concept-version) are excluded and never
+enter the materialized graph.
+
+Postgres-targeted. Reversible: downgrade drops the view.
+
+Revision ID: m2_rdf_triples_current
+Revises: m1_concept_versioning
+Create Date: 2026-08-12
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'm2_rdf_triples_current'
+down_revision: Union[str, None] = 'm1_concept_versioning'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE OR REPLACE VIEW rdf_triples_current AS
+        SELECT r.*
+        FROM rdf_triples r
+        LEFT JOIN concept_version cv ON cv.id = r.concept_version_id
+        WHERE r.concept_version_id IS NULL
+           OR cv.is_current = true;
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW IF EXISTS rdf_triples_current;")

--- a/src/backend/alembic/versions/m4_rdf_triple_version_uniqueness.py
+++ b/src/backend/alembic/versions/m4_rdf_triple_version_uniqueness.py
@@ -1,0 +1,60 @@
+"""Add concept_version_id to rdf_triples uniqueness (snapshot-per-version).
+
+Publish must FREEZE the prior version's triples: v1 keeps its old field values,
+v2 gets a COPY with the new values. Same (subject, predicate, object, lang,
+datatype, context) but a different concept_version_id. The original 6-column
+``uq_rdf_triple`` (s,p,o,lang,datatype,context) BLOCKS that copy — verified: the
+second insert raises UniqueViolation. Without per-version rows the old definition
+text is destroyed on publish and P0-4's diff engine has nothing to diff.
+
+Fix: widen ``uq_rdf_triple`` to include ``concept_version_id`` as the 7th column,
+using ``UNIQUE NULLS NOT DISTINCT`` (Postgres 15+) so that:
+  - two rows differing ONLY by concept_version_id are allowed (per-version snapshot), AND
+  - two rows with a NULL concept_version_id are still treated as duplicates
+    (NULLS NOT DISTINCT), preserving the ON CONFLICT DO NOTHING dedup that
+    rdf_triples_repository relies on for unowned/metadata triples.
+Both behaviours verified empirically against Postgres 16 before writing this.
+
+Postgres-targeted (NULLS NOT DISTINCT is PG15+; the project deploys on
+Postgres/Lakebase). Reversible: downgrade restores the 6-column constraint (safe
+only once per-version duplicate rows are removed — see downgrade note).
+
+Revision ID: m4_rdf_triple_version_uq
+Revises: m2_rdf_triples_current
+Create Date: 2026-08-12
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'm4_rdf_triple_version_uq'
+down_revision: Union[str, None] = 'm2_rdf_triples_current'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_COLS_6 = "subject_uri, predicate_uri, object_value, object_language, object_datatype, context_name"
+_COLS_7 = _COLS_6 + ", concept_version_id"
+
+
+def upgrade() -> None:
+    # Swap the 6-col constraint for a 7-col NULLS NOT DISTINCT one so per-version
+    # snapshots (same triple, different concept_version_id) are allowed while
+    # NULL-owned duplicates are still deduped.
+    op.execute("ALTER TABLE rdf_triples DROP CONSTRAINT IF EXISTS uq_rdf_triple")
+    op.execute(
+        f"ALTER TABLE rdf_triples ADD CONSTRAINT uq_rdf_triple "
+        f"UNIQUE NULLS NOT DISTINCT ({_COLS_7})"
+    )
+
+
+def downgrade() -> None:
+    # Restore the original 6-column constraint. NOTE: if per-version snapshot rows
+    # exist (same 6-tuple, different concept_version_id), this will FAIL on the
+    # duplicate — that is correct: you cannot collapse snapshots back into the
+    # 6-col uniqueness without losing version history. Remove non-current
+    # (is_current=false) duplicate rows first if a true downgrade is required.
+    op.execute("ALTER TABLE rdf_triples DROP CONSTRAINT IF EXISTS uq_rdf_triple")
+    op.execute(
+        f"ALTER TABLE rdf_triples ADD CONSTRAINT uq_rdf_triple UNIQUE ({_COLS_6})"
+    )

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -154,6 +154,16 @@ class CachedResult:
         return datetime.now() < self.expires_at
 
 
+class ReferenceCountError(Exception):
+    """Raised when a concept cannot be retired because it is still referenced (P0-6).
+
+    Carries the live reference ``count`` so the route can surface it in the 409.
+    """
+    def __init__(self, message: str, count: int = 0):
+        super().__init__(message)
+        self.count = count
+
+
 @searchable_asset
 class SemanticModelsManager(SearchableAsset):
     def __init__(self, db: Session, data_dir: Optional[Path] = None):
@@ -3949,6 +3959,169 @@ class SemanticModelsManager(SearchableAsset):
             else:
                 obj = Literal(triple.object_value)
             coll_context.add((concept_uri, pred, obj))
+
+    # -- P0-6: reference-count / safe-transition primitives -------------------
+    def reference_count(self, concept_iri: str) -> int:
+        """How many things reference this concept — the retire gate (P0-6).
+
+        Counts:
+          - rows in ``entity_semantic_links`` for this iri (physical UC/asset
+            references — the IRI is the join key baked into UC tags), PLUS
+          - concept->concept references: any OTHER concept pointing at this iri
+            via skos:broader / skos:narrower / skos:related / rdfs:subClassOf in
+            the served graph.
+
+        Retirement is gated on this being 0 (tombstone, never hard-delete).
+        """
+        from src.repositories.semantic_links_repository import entity_semantic_links_repo
+
+        link_count = entity_semantic_links_repo.count_for_iri(self._db, concept_iri)
+
+        # Concept->concept references in the hot graph. The iri appears as the
+        # OBJECT of a relationship predicate from some other subject.
+        concept_uri = URIRef(concept_iri)
+        ref_predicates = (SKOS.broader, SKOS.narrower, SKOS.related, RDFS.subClassOf)
+        concept_refs = 0
+        for pred in ref_predicates:
+            for subj in self._graph.subjects(pred, concept_uri):
+                if str(subj) != concept_iri:  # a concept referencing itself doesn't count
+                    concept_refs += 1
+
+        return link_count + concept_refs
+
+    def deprecate_concept(
+        self,
+        concept_iri: str,
+        replaced_by: Optional[List[str]] = None,
+        deprecated_by: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Deprecate a concept (stop-using) — stays fully resolvable (P0-6).
+
+        Sets concept status to ``deprecated`` (this is the CONCEPT-level
+        stop-using signal, NOT the version-level ``superseded``). If ``replaced_by``
+        IRIs are given (a 2B meaning-split), writes the lineage links so the old
+        IRI still resolves and points forward, and each successor points back:
+          - old  --dct:isReplacedBy-->  new   (forward pointer)
+          - new  --prov:wasRevisionOf--> old  (provenance back-pointer)
+          - new  --dct:replaces-->       old  (Dublin Core back-pointer)
+
+        DB-first then graph patch, matching the create/update dual-write pattern.
+        """
+        from datetime import datetime
+
+        existing = self.get_concept(concept_iri)
+        if not existing:
+            raise ValueError(f"Concept not found: {concept_iri}")
+
+        collection_iri = existing.get("source_context")
+        if not collection_iri:
+            raise ValueError("Cannot determine collection for concept")
+        collection = self.get_collection(collection_iri)
+        if collection and not collection.get("is_editable"):
+            raise ValueError(f"Collection is not editable: {collection_iri}")
+
+        replaced_by = replaced_by or []
+        concept_uri = URIRef(concept_iri)
+        coll_context = self._graph.get_context(URIRef(collection_iri))
+        now = datetime.utcnow().isoformat() + "Z"
+
+        # 1. status -> deprecated (overwrite existing status).
+        rdf_triples_repo.remove_by_subject_predicate(self._db, concept_iri, str(ONTOS.status), collection_iri)
+        rdf_triples_repo.add_triple(
+            self._db, subject_uri=concept_iri, predicate_uri=str(ONTOS.status),
+            object_value="deprecated", object_is_uri=False, context_name=collection_iri,
+            source_type="concept", source_identifier=concept_iri, created_by=deprecated_by,
+        )
+        coll_context.remove((concept_uri, ONTOS.status, None))
+        coll_context.add((concept_uri, ONTOS.status, Literal("deprecated")))
+
+        # 2. 2B split lineage links (idempotent add — ON CONFLICT DO NOTHING).
+        for successor in replaced_by:
+            succ_uri = URIRef(successor)
+            # old --isReplacedBy--> new
+            rdf_triples_repo.add_triple(
+                self._db, subject_uri=concept_iri, predicate_uri=str(DCT.isReplacedBy),
+                object_value=successor, object_is_uri=True, context_name=collection_iri,
+                source_type="concept", source_identifier=concept_iri, created_by=deprecated_by,
+            )
+            coll_context.add((concept_uri, DCT.isReplacedBy, succ_uri))
+            # new --wasRevisionOf--> old
+            rdf_triples_repo.add_triple(
+                self._db, subject_uri=successor, predicate_uri=str(PROV.wasRevisionOf),
+                object_value=concept_iri, object_is_uri=True, context_name=collection_iri,
+                source_type="concept", source_identifier=successor, created_by=deprecated_by,
+            )
+            coll_context.add((succ_uri, PROV.wasRevisionOf, concept_uri))
+            # new --replaces--> old
+            rdf_triples_repo.add_triple(
+                self._db, subject_uri=successor, predicate_uri=str(DCT.replaces),
+                object_value=concept_iri, object_is_uri=True, context_name=collection_iri,
+                source_type="concept", source_identifier=successor, created_by=deprecated_by,
+            )
+            coll_context.add((succ_uri, DCT.replaces, concept_uri))
+
+        self._db.commit()
+        self._invalidate_cache()
+
+        refreshed = self.get_concept(concept_iri) or {}
+        return {
+            "iri": concept_iri,
+            "label": refreshed.get("label") or existing.get("label"),
+            "status": "deprecated",
+            "replaced_by": replaced_by,
+        }
+
+    def retire_concept(self, concept_iri: str, retired_by: Optional[str] = None) -> Dict[str, Any]:
+        """Retire a concept to a tombstone — gated on reference_count == 0 (P0-6).
+
+        If anything still references the concept, raises ``ReferenceCountError``
+        (the route maps it to 409) — retirement is REFUSED. If nothing references
+        it, sets status ``retired``; the concept row and triples STAY (tombstone,
+        still resolvable). NEVER a hard delete.
+        """
+        from datetime import datetime
+
+        existing = self.get_concept(concept_iri)
+        if not existing:
+            raise ValueError(f"Concept not found: {concept_iri}")
+
+        collection_iri = existing.get("source_context")
+        if not collection_iri:
+            raise ValueError("Cannot determine collection for concept")
+        collection = self.get_collection(collection_iri)
+        if collection and not collection.get("is_editable"):
+            raise ValueError(f"Collection is not editable: {collection_iri}")
+
+        # Retire gate: refuse while still referenced.
+        count = self.reference_count(concept_iri)
+        if count > 0:
+            raise ReferenceCountError(
+                f"Cannot retire concept referenced by {count} place(s). "
+                f"Remap references first.",
+                count=count,
+            )
+
+        concept_uri = URIRef(concept_iri)
+        coll_context = self._graph.get_context(URIRef(collection_iri))
+
+        rdf_triples_repo.remove_by_subject_predicate(self._db, concept_iri, str(ONTOS.status), collection_iri)
+        rdf_triples_repo.add_triple(
+            self._db, subject_uri=concept_iri, predicate_uri=str(ONTOS.status),
+            object_value="retired", object_is_uri=False, context_name=collection_iri,
+            source_type="concept", source_identifier=concept_iri, created_by=retired_by,
+        )
+        coll_context.remove((concept_uri, ONTOS.status, None))
+        coll_context.add((concept_uri, ONTOS.status, Literal("retired")))
+
+        self._db.commit()
+        self._invalidate_cache()
+
+        refreshed = self.get_concept(concept_iri) or {}
+        return {
+            "iri": concept_iri,
+            "label": refreshed.get("label") or existing.get("label"),
+            "status": "retired",
+        }
 
     def delete_concept(self, concept_iri: str, deleted_by: Optional[str] = None) -> bool:
         """Delete a concept.

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -3408,9 +3408,29 @@ class SemanticModelsManager(SearchableAsset):
         if created_by:
             user_uri = f"urn:user:{created_by}" if not created_by.startswith("urn:") else created_by
             coll_context.add((concept_uri, ONTOS.createdBy, URIRef(user_uri)))
-        
+
+        # Mint the v1 concept_version row so a freshly-created concept is
+        # versioned like a backfilled one (P0-1 backfill only versioned
+        # PRE-EXISTING concepts). Without this, a later publish computes
+        # max_version=0 -> new_version=1 and history is empty. version=1,
+        # is_current=true, status=draft (matching the ONTOS.status triple
+        # above). Assign every triple owned by this subject IRI (subject-IRI
+        # ownership, same rule as the backfill + publish) in the SAME commit.
+        from src.repositories.concept_versions_repository import concept_versions_repo
+        v1 = concept_versions_repo.create_version(  # flushes -> v1.id available
+            self._db,
+            iri=concept_iri,
+            version=1,
+            is_current=True,
+            status="draft",
+            created_by=created_by,
+        )
+        rdf_triples_repo.reassign_subject_to_concept_version(
+            self._db, concept_iri, v1.id, context_name=collection_iri
+        )
+
         self._db.commit()
-        
+
         # Add owners if provided
         for owner in owners:
             owner_user = owner.get("user_uri", "")

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -1418,9 +1418,10 @@ class SemanticModelsManager(SearchableAsset):
             served in-memory graph (so users SEE that their edit is live).
           - concept_count: current concepts in the served graph.
           - uc_synced_at / uc_next_sync_est: last successful uc_tag_sync run end
-            and a rough next-run estimate — surfaced SEPARATELY so "not yet synced
-            to UC" (eventual, ~4h) is not confused with "not saved". Reuses the
-            same job-run source as get_tag_delivery_stats; null when unavailable.
+            and a next-run estimate derived from the observed run cadence —
+            surfaced SEPARATELY so "not yet synced to UC" (eventual) is not
+            confused with "not saved". Reuses the same job-run source as
+            get_tag_delivery_stats; est is null when cadence can't be inferred.
         """
         # concept_count from taxonomy stats (cached, always fresh post-rebuild).
         try:
@@ -1442,18 +1443,34 @@ class SemanticModelsManager(SearchableAsset):
         """(last_successful_uc_tag_sync_end_iso, next_run_estimate_iso) or (None, None).
 
         Reuses the existing uc_tag_sync job-run history (same source as
-        get_tag_delivery_stats). Does NOT invent a new job. The uc_tag_sync job
-        runs on roughly a 4h cadence (PRD §2); estimate = last success + 4h.
-        Returns (None, None) if the job never ran or timing isn't readable.
+        get_tag_delivery_stats). Does NOT invent a new job.
+
+        The next-run estimate is derived EMPIRICALLY from the observed cadence
+        (gap between the two most recent successful runs), not a hardcoded
+        assumption about the schedule: reading the actual quartz cron would need
+        a live Jobs API call + cron parsing on this hot freshness poll, and the
+        interval is user-configurable, so a fixed constant would just be wrong.
+        With only one successful run we cannot infer a cadence, so we return the
+        last-synced time and leave the estimate None rather than assert a guess.
         """
         try:
             from src.repositories.workflow_job_runs_repository import workflow_job_run_repo
             runs = workflow_job_run_repo.get_recent_runs(self._db, workflow_id='uc_tag_sync', limit=20)
-            for r in runs:
-                if r.result_state == 'SUCCESS' and r.end_time:
-                    synced = datetime.fromtimestamp(r.end_time / 1000, tz=timezone.utc)
-                    nxt = synced + timedelta(hours=4)
-                    return synced.isoformat(), nxt.isoformat()
+            successes = [
+                datetime.fromtimestamp(r.end_time / 1000, tz=timezone.utc)
+                for r in runs
+                if r.result_state == 'SUCCESS' and r.end_time
+            ]
+            if not successes:
+                return None, None
+            # get_recent_runs is newest-first; the first success is the latest.
+            synced = successes[0]
+            if len(successes) >= 2:
+                # Observed cadence = gap between the two most recent successes.
+                cadence = synced - successes[1]
+                if cadence.total_seconds() > 0:
+                    return synced.isoformat(), (synced + cadence).isoformat()
+            return synced.isoformat(), None
         except Exception as e:
             logger.warning(f"graph_freshness: could not read uc_tag_sync timing: {e}")
         return None, None

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -4050,6 +4050,82 @@ class SemanticModelsManager(SearchableAsset):
                 obj = Literal(triple.object_value)
             coll_context.add((concept_uri, pred, obj))
 
+    # -- P0-2/§1-§2: version-info + historical-detail reads --------------------
+    def get_concept_version_info(self, concept_iri: str) -> Optional[Dict[str, Any]]:
+        """Current version + version history for one concept (API contract §1).
+
+        Returns None if the concept isn't found. ``label`` is always populated
+        (Simple view requirement). Lineage pointers come from the graph:
+        ``replaces_iri`` from dct:replaces / prov:wasRevisionOf on this concept,
+        ``replaced_by_iris`` from dct:isReplacedBy on this concept.
+        """
+        from src.repositories.concept_versions_repository import concept_versions_repo
+
+        concept = self.get_concept(concept_iri)
+        if not concept:
+            return None
+
+        label = concept.get("label") or concept_iri
+        rows = concept_versions_repo.list_versions(self._db, concept_iri)  # newest-first
+        versions = [
+            {
+                "version": r.version,
+                "is_current": r.is_current,
+                "status": r.status,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "created_by": r.created_by,
+            }
+            for r in rows
+        ]
+        current = next((r for r in rows if r.is_current), rows[0] if rows else None)
+
+        # Lineage from the served graph (current-only triples).
+        concept_uri = URIRef(concept_iri)
+        replaced_by_iris = [str(o) for o in self._graph.objects(concept_uri, DCT.isReplacedBy)]
+        replaces = [str(o) for o in self._graph.objects(concept_uri, DCT.replaces)]
+        replaces_iri = replaces[0] if replaces else None
+
+        return {
+            "iri": concept_iri,
+            "label": label,
+            "current_version": current.version if current else None,
+            "status": (current.status if current else None) or concept.get("status"),
+            "versions": versions,
+            "replaces_iri": replaces_iri,
+            "replaced_by_iris": replaced_by_iris,
+        }
+
+    def get_concept_version_detail(
+        self, concept_iri: str, version: int
+    ) -> Optional[Dict[str, Any]]:
+        """Concept detail AS OF a specific version, by (iri, version) key (§2).
+
+        Cold-path fetch: does NOT touch the hot graph. Returns the same concept
+        detail shape as concepts/by-iri (via get_concept), plus ``version`` and
+        ``is_current``. Returns None if that (iri, version) does not exist.
+
+        NOTE: full point-in-time reconstruction of every historical field lands
+        with the P0-4 diff engine (per-version triple snapshots). Today the
+        current triples are the source; this returns the concept detail annotated
+        with the requested version's metadata (version number, is_current,
+        status, created_at/by) so the compare/history UI can bind to real
+        version rows.
+        """
+        from src.repositories.concept_versions_repository import concept_versions_repo
+
+        cv = concept_versions_repo.get_by_iri_version(self._db, concept_iri, version)
+        if cv is None:
+            return None
+
+        detail = self.get_concept(concept_iri) or {"iri": concept_iri}
+        detail = dict(detail)
+        detail["version"] = cv.version
+        detail["is_current"] = cv.is_current
+        detail["status"] = cv.status
+        detail["created_at"] = cv.created_at.isoformat() if cv.created_at else None
+        detail["created_by"] = cv.created_by
+        return detail
+
     # -- P0-6: reference-count / safe-transition primitives -------------------
     def reference_count(self, concept_iri: str) -> int:
         """How many things reference this concept — the retire gate (P0-6).

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -3901,10 +3901,20 @@ class SemanticModelsManager(SearchableAsset):
         if collection and not collection.get("is_editable"):
             raise ValueError(f"Collection is not editable: {collection_iri}")
 
-        # ---- 1-4: build the swap inside one transaction (no commit yet) -------
+        # ---- snapshot-per-version swap inside ONE transaction (no commit yet) --
+        # PRD "snapshots over deltas": the PRIOR version keeps its OWN frozen
+        # triple set (its old field values) so "what was the previous definition?"
+        # stays answerable and P0-4's diff engine has something to diff. We COPY
+        # the concept's current triples into a new set owned by v2, then mutate
+        # ONLY v2's copy. v1's rows are never touched.
         from src.repositories.concept_versions_repository import concept_versions_repo
 
+        # 1. Demote current version row -> history metadata (is_current=false,
+        #    status=superseded). Its triples STAY owned by this (demoted) id =
+        #    v1's frozen snapshot.
         demoted = concept_versions_repo.demote_current(self._db, concept_iri)  # flushes
+
+        # 2. Create the new current version row.
         new_version_num = concept_versions_repo.max_version(self._db, concept_iri) + 1
         new_cv = concept_versions_repo.create_version(  # flushes -> new_cv.id available
             self._db,
@@ -3916,11 +3926,28 @@ class SemanticModelsManager(SearchableAsset):
             created_by=published_by,
         )
 
-        # 3. Apply the human-field changes as triple overwrites (DB only here;
-        #    the graph is patched AFTER commit, per the recovery contract).
-        self._apply_publish_changes_to_db(concept_iri, collection_iri, changes, published_by)
+        # 3. COPY the concept's current triples into a NEW set owned by v2. The
+        #    source is the demoted version's rows (the live set before this
+        #    publish); if there is no demoted row (edge case), fall back to the
+        #    subject's currently-owned rows. v1's rows are left untouched.
+        source_version_id = demoted.id if demoted else None
+        rdf_triples_repo.copy_triples_to_version(
+            self._db,
+            subject_uri=concept_iri,
+            source_concept_version_id=source_version_id,
+            target_concept_version_id=new_cv.id,
+            context_name=collection_iri,
+            created_by=published_by,
+        )
 
-        # Optional change note as provenance on the concept.
+        # 4. Apply the human-field changes to v2's SET ONLY (remove/add the
+        #    changed predicates among rows owned by new_cv.id). DB-only here; the
+        #    graph is patched AFTER commit per the recovery contract.
+        self._apply_publish_changes_to_db(
+            concept_iri, collection_iri, changes, published_by, target_version_id=new_cv.id
+        )
+
+        # Optional change note as provenance on the NEW version's set.
         if change_note:
             rdf_triples_repo.add_triple(
                 self._db,
@@ -3932,12 +3959,8 @@ class SemanticModelsManager(SearchableAsset):
                 source_type="concept",
                 source_identifier=concept_iri,
                 created_by=published_by,
+                concept_version_id=new_cv.id,
             )
-
-        # 4. Move every triple owned by this subject IRI to the new version.
-        rdf_triples_repo.reassign_subject_to_concept_version(
-            self._db, concept_iri, new_cv.id, context_name=collection_iri
-        )
 
         # 5. ONE commit -> the whole swap is atomic. A concurrent reader sees
         #    all-old or all-new, never a torn mix.
@@ -3978,29 +4001,34 @@ class SemanticModelsManager(SearchableAsset):
         collection_iri: str,
         changes: Dict[str, Any],
         published_by: Optional[str],
+        target_version_id=None,
     ) -> None:
-        """Overwrite the concept's human SKOS fields in rdf_triples for a publish.
+        """Overwrite the human SKOS fields on the NEW version's triple set only.
 
         DB-only (no graph patch here — the graph is swapped after the commit).
-        Only fields present in ``changes`` are touched, matching update_concept's
-        remove-by-predicate-then-add pattern.
+        Only fields present in ``changes`` are touched. All removes/adds are
+        SCOPED to rows owned by ``target_version_id`` (v2's copied set), so the
+        prior version's frozen snapshot is never mutated.
         """
         for field, predicate in self._PUBLISH_LITERAL_FIELDS.items():
             if field in changes and changes[field] is not None:
                 rdf_triples_repo.remove_by_subject_predicate(
-                    self._db, concept_iri, str(predicate), collection_iri
+                    self._db, concept_iri, str(predicate), collection_iri,
+                    concept_version_id=target_version_id,
                 )
                 rdf_triples_repo.add_triple(
                     self._db, subject_uri=concept_iri, predicate_uri=str(predicate),
                     object_value=str(changes[field]), object_is_uri=False,
                     context_name=collection_iri, source_type="concept",
                     source_identifier=concept_iri, created_by=published_by,
+                    concept_version_id=target_version_id,
                 )
 
         for field, predicate in self._PUBLISH_LIST_LITERAL_FIELDS.items():
             if field in changes and changes[field] is not None:
                 rdf_triples_repo.remove_by_subject_predicate(
-                    self._db, concept_iri, str(predicate), collection_iri
+                    self._db, concept_iri, str(predicate), collection_iri,
+                    concept_version_id=target_version_id,
                 )
                 for val in changes[field]:
                     rdf_triples_repo.add_triple(
@@ -4008,12 +4036,14 @@ class SemanticModelsManager(SearchableAsset):
                         object_value=str(val), object_is_uri=False,
                         context_name=collection_iri, source_type="concept",
                         source_identifier=concept_iri, created_by=published_by,
+                        concept_version_id=target_version_id,
                     )
 
         for field, predicate in self._PUBLISH_LIST_URI_FIELDS.items():
             if field in changes and changes[field] is not None:
                 rdf_triples_repo.remove_by_subject_predicate(
-                    self._db, concept_iri, str(predicate), collection_iri
+                    self._db, concept_iri, str(predicate), collection_iri,
+                    concept_version_id=target_version_id,
                 )
                 for val in changes[field]:
                     rdf_triples_repo.add_triple(
@@ -4021,22 +4051,26 @@ class SemanticModelsManager(SearchableAsset):
                         object_value=str(val), object_is_uri=True,
                         context_name=collection_iri, source_type="concept",
                         source_identifier=concept_iri, created_by=published_by,
+                        concept_version_id=target_version_id,
                     )
 
     def _swap_concept_in_graph(self, concept_iri: str, collection_iri: str) -> None:
         """Swap one concept's triples in the served in-memory graph (P0-3).
 
         Remove every triple with this subject from the collection context, then
-        re-add the concept's CURRENT triples from the DB. Called AFTER the DB
-        commit; a failure here triggers the recovery-contract rebuild in the
-        caller.
+        re-add ONLY the concept's CURRENT-version triples from the DB. Since
+        publish now snapshots the prior version (its old rows remain in the DB
+        owned by the demoted version), we must re-add the current set only —
+        list_by_subject would leak the frozen v1 rows back into the served graph.
+        Called AFTER the DB commit; a failure here triggers the recovery-contract
+        rebuild in the caller.
         """
         concept_uri = URIRef(concept_iri)
         coll_context = self._graph.get_context(URIRef(collection_iri))
         # Remove the old view of this concept.
         coll_context.remove((concept_uri, None, None))
-        # Re-add from the DB (current rows for this subject in this context).
-        for triple in rdf_triples_repo.list_by_subject(self._db, concept_iri):
+        # Re-add the CURRENT-version (+ unowned) rows for this subject only.
+        for triple in rdf_triples_repo.list_current_by_subject(self._db, concept_iri):
             if triple.context_name != collection_iri:
                 continue
             pred = URIRef(triple.predicate_uri)
@@ -4100,16 +4134,10 @@ class SemanticModelsManager(SearchableAsset):
     ) -> Optional[Dict[str, Any]]:
         """Concept detail AS OF a specific version, by (iri, version) key (§2).
 
-        Cold-path fetch: does NOT touch the hot graph. Returns the same concept
-        detail shape as concepts/by-iri (via get_concept), plus ``version`` and
-        ``is_current``. Returns None if that (iri, version) does not exist.
-
-        NOTE: full point-in-time reconstruction of every historical field lands
-        with the P0-4 diff engine (per-version triple snapshots). Today the
-        current triples are the source; this returns the concept detail annotated
-        with the requested version's metadata (version number, is_current,
-        status, created_at/by) so the compare/history UI can bind to real
-        version rows.
+        Cold-path fetch: does NOT touch the hot graph. Reads the triples OWNED by
+        that version's concept_version_id (its frozen snapshot), so an old version
+        returns its OLD field values (e.g. the previous definition text). Returns
+        None if that (iri, version) does not exist.
         """
         from src.repositories.concept_versions_repository import concept_versions_repo
 
@@ -4117,13 +4145,43 @@ class SemanticModelsManager(SearchableAsset):
         if cv is None:
             return None
 
-        detail = self.get_concept(concept_iri) or {"iri": concept_iri}
-        detail = dict(detail)
-        detail["version"] = cv.version
-        detail["is_current"] = cv.is_current
-        detail["status"] = cv.status
-        detail["created_at"] = cv.created_at.isoformat() if cv.created_at else None
-        detail["created_by"] = cv.created_by
+        # Read this version's OWN triples into a throwaway graph, then extract the
+        # human fields exactly as get_concept would — but from the frozen snapshot.
+        snap = Graph()
+        concept_uri = URIRef(concept_iri)
+        for t in rdf_triples_repo.list_by_concept_version(self._db, cv.id):
+            pred = URIRef(t.predicate_uri)
+            if t.object_is_uri:
+                obj = URIRef(t.object_value)
+            elif t.object_language:
+                obj = Literal(t.object_value, lang=t.object_language)
+            elif t.object_datatype:
+                obj = Literal(t.object_value, datatype=URIRef(t.object_datatype))
+            else:
+                obj = Literal(t.object_value)
+            snap.add((concept_uri, pred, obj))
+
+        def _lit(pred):
+            v = snap.value(concept_uri, pred)
+            return str(v) if v is not None else None
+
+        label = _lit(SKOS.prefLabel) or _lit(RDFS.label) or concept_iri
+        definition = _lit(SKOS.definition) or _lit(RDFS.comment)
+        detail = {
+            "iri": concept_iri,
+            "label": label,
+            "definition": definition,
+            "synonyms": [str(o) for o in snap.objects(concept_uri, SKOS.altLabel)],
+            "examples": [str(o) for o in snap.objects(concept_uri, SKOS.example)],
+            "broader": [str(o) for o in snap.objects(concept_uri, SKOS.broader)],
+            "narrower": [str(o) for o in snap.objects(concept_uri, SKOS.narrower)],
+            "related": [str(o) for o in snap.objects(concept_uri, SKOS.related)],
+            "version": cv.version,
+            "is_current": cv.is_current,
+            "status": cv.status,
+            "created_at": cv.created_at.isoformat() if cv.created_at else None,
+            "created_by": cv.created_by,
+        }
         return detail
 
     # -- P0-6: reference-count / safe-transition primitives -------------------

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -738,7 +738,12 @@ class SemanticModelsManager(SearchableAsset):
         if disabled_contexts:
             logger.info(f"Skipping {len(disabled_contexts)} disabled contexts: {disabled_contexts}")
 
-        all_triples = rdf_triples_repo.list_all(self._db)
+        # P0-2 write-time current/history split: the served hot graph is built
+        # from CURRENT-ONLY triples. The is_current filter runs HERE, once, at
+        # build time — downstream SPARQL/MCP reads carry NO version predicate.
+        # list_current keeps unowned (scheme/collection/metadata) triples and
+        # drops only history triples owned by a non-current concept-version.
+        all_triples = rdf_triples_repo.list_current(self._db)
         loaded = 0
         skipped = 0
 

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -3728,8 +3728,220 @@ class SemanticModelsManager(SearchableAsset):
         
         self._db.commit()
         self._invalidate_cache()
-        
+
         return self.get_concept(concept_iri)
+
+    # -- P0-3: atomic publish (single-concept version swap) --------------------
+    # Human-field -> SKOS predicate map for applying `changes` on publish. Mirrors
+    # update_concept's predicate choices so the two write paths cannot drift.
+    _PUBLISH_LITERAL_FIELDS = {
+        "label": SKOS.prefLabel,
+        "definition": SKOS.definition,
+    }
+    _PUBLISH_LIST_LITERAL_FIELDS = {
+        "synonyms": SKOS.altLabel,
+        "examples": SKOS.example,
+    }
+    _PUBLISH_LIST_URI_FIELDS = {
+        "broader_iris": SKOS.broader,
+        "narrower_iris": SKOS.narrower,
+        "related_iris": SKOS.related,
+    }
+
+    def publish_concept_version(
+        self,
+        concept_iri: str,
+        changes: Optional[Dict[str, Any]] = None,
+        change_note: Optional[str] = None,
+        published_by: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Publish a new version of a concept — DB-first atomic swap (P0-3).
+
+        Transaction (ONE Postgres commit):
+          1. Demote the current ``concept_version`` -> history (is_current=false,
+             status='deprecated') and FLUSH, so the partial unique index
+             ``uq_concept_version_current_per_iri`` never sees two current rows.
+          2. Insert the new ``concept_version`` (version = max+1 for this iri,
+             is_current=true, parent_version_id = the demoted row's id).
+          3. Apply ``changes`` to the concept's rdf_triples (overwrite the human
+             SKOS fields, matching update_concept's predicate choices).
+          4. Reassign every triple owned by this subject IRI (triple-ownership
+             rule) to the new concept_version_id.
+          5. commit() — everything above lands atomically. The stable ``iri``
+             never changes.
+
+        Cross-store ordering (RECOVERY CONTRACT): the DB and the in-memory rdflib
+        graph are two separate stores; there is NO XA between them. We commit the
+        Postgres transaction FIRST, THEN patch the served graph (swap this
+        concept's triples). If the graph patch throws, the DB is the source of
+        truth and the served copy is merely stale for this one concept: we force
+        a full rebuild (``rebuild_graph_from_enabled``) to reconcile, and
+        re-raise so the endpoint surfaces a non-200 instead of pretending
+        success. No DB rollback — this is a STALENESS failure, not data loss.
+        """
+        changes = changes or {}
+
+        existing = self.get_concept(concept_iri)
+        if not existing:
+            raise ValueError(f"Concept not found: {concept_iri}")
+
+        collection_iri = existing.get("source_context")
+        if not collection_iri:
+            raise ValueError("Cannot determine collection for concept")
+
+        # Gate on editable scheme/collection (same guard as create/update).
+        collection = self.get_collection(collection_iri)
+        if collection and not collection.get("is_editable"):
+            raise ValueError(f"Collection is not editable: {collection_iri}")
+
+        # ---- 1-4: build the swap inside one transaction (no commit yet) -------
+        from src.repositories.concept_versions_repository import concept_versions_repo
+
+        demoted = concept_versions_repo.demote_current(self._db, concept_iri)  # flushes
+        new_version_num = concept_versions_repo.max_version(self._db, concept_iri) + 1
+        new_cv = concept_versions_repo.create_version(  # flushes -> new_cv.id available
+            self._db,
+            iri=concept_iri,
+            version=new_version_num,
+            is_current=True,
+            status="active",
+            parent_version_id=(demoted.id if demoted else None),
+            created_by=published_by,
+        )
+
+        # 3. Apply the human-field changes as triple overwrites (DB only here;
+        #    the graph is patched AFTER commit, per the recovery contract).
+        self._apply_publish_changes_to_db(concept_iri, collection_iri, changes, published_by)
+
+        # Optional change note as provenance on the concept.
+        if change_note:
+            rdf_triples_repo.add_triple(
+                self._db,
+                subject_uri=concept_iri,
+                predicate_uri=str(ONTOS.changeNote),
+                object_value=change_note,
+                object_is_uri=False,
+                context_name=collection_iri,
+                source_type="concept",
+                source_identifier=concept_iri,
+                created_by=published_by,
+            )
+
+        # 4. Move every triple owned by this subject IRI to the new version.
+        rdf_triples_repo.reassign_subject_to_concept_version(
+            self._db, concept_iri, new_cv.id, context_name=collection_iri
+        )
+
+        # 5. ONE commit -> the whole swap is atomic. A concurrent reader sees
+        #    all-old or all-new, never a torn mix.
+        self._db.commit()
+
+        # ---- Cross-store step: patch the served graph AFTER the DB commit -----
+        try:
+            self._swap_concept_in_graph(concept_iri, collection_iri)
+        except Exception:
+            # RECOVERY CONTRACT (P0-3): DB is already correct and committed; the
+            # served graph patch failed, so the served copy is stale for this one
+            # concept. Force a full rebuild to reconcile, then re-raise so the
+            # endpoint returns a non-200/warning rather than silently claiming
+            # success.
+            logger.error(
+                "Graph patch failed after DB commit for %s; forcing rebuild (recovery contract)",
+                concept_iri, exc_info=True,
+            )
+            try:
+                self.rebuild_graph_from_enabled()
+            except Exception:
+                logger.error("Recovery rebuild_graph_from_enabled also failed", exc_info=True)
+            raise
+
+        self._invalidate_cache()
+
+        refreshed = self.get_concept(concept_iri) or {}
+        return {
+            "iri": concept_iri,
+            "label": refreshed.get("label") or existing.get("label"),
+            "new_version": new_version_num,
+            "is_current": True,
+        }
+
+    def _apply_publish_changes_to_db(
+        self,
+        concept_iri: str,
+        collection_iri: str,
+        changes: Dict[str, Any],
+        published_by: Optional[str],
+    ) -> None:
+        """Overwrite the concept's human SKOS fields in rdf_triples for a publish.
+
+        DB-only (no graph patch here — the graph is swapped after the commit).
+        Only fields present in ``changes`` are touched, matching update_concept's
+        remove-by-predicate-then-add pattern.
+        """
+        for field, predicate in self._PUBLISH_LITERAL_FIELDS.items():
+            if field in changes and changes[field] is not None:
+                rdf_triples_repo.remove_by_subject_predicate(
+                    self._db, concept_iri, str(predicate), collection_iri
+                )
+                rdf_triples_repo.add_triple(
+                    self._db, subject_uri=concept_iri, predicate_uri=str(predicate),
+                    object_value=str(changes[field]), object_is_uri=False,
+                    context_name=collection_iri, source_type="concept",
+                    source_identifier=concept_iri, created_by=published_by,
+                )
+
+        for field, predicate in self._PUBLISH_LIST_LITERAL_FIELDS.items():
+            if field in changes and changes[field] is not None:
+                rdf_triples_repo.remove_by_subject_predicate(
+                    self._db, concept_iri, str(predicate), collection_iri
+                )
+                for val in changes[field]:
+                    rdf_triples_repo.add_triple(
+                        self._db, subject_uri=concept_iri, predicate_uri=str(predicate),
+                        object_value=str(val), object_is_uri=False,
+                        context_name=collection_iri, source_type="concept",
+                        source_identifier=concept_iri, created_by=published_by,
+                    )
+
+        for field, predicate in self._PUBLISH_LIST_URI_FIELDS.items():
+            if field in changes and changes[field] is not None:
+                rdf_triples_repo.remove_by_subject_predicate(
+                    self._db, concept_iri, str(predicate), collection_iri
+                )
+                for val in changes[field]:
+                    rdf_triples_repo.add_triple(
+                        self._db, subject_uri=concept_iri, predicate_uri=str(predicate),
+                        object_value=str(val), object_is_uri=True,
+                        context_name=collection_iri, source_type="concept",
+                        source_identifier=concept_iri, created_by=published_by,
+                    )
+
+    def _swap_concept_in_graph(self, concept_iri: str, collection_iri: str) -> None:
+        """Swap one concept's triples in the served in-memory graph (P0-3).
+
+        Remove every triple with this subject from the collection context, then
+        re-add the concept's CURRENT triples from the DB. Called AFTER the DB
+        commit; a failure here triggers the recovery-contract rebuild in the
+        caller.
+        """
+        concept_uri = URIRef(concept_iri)
+        coll_context = self._graph.get_context(URIRef(collection_iri))
+        # Remove the old view of this concept.
+        coll_context.remove((concept_uri, None, None))
+        # Re-add from the DB (current rows for this subject in this context).
+        for triple in rdf_triples_repo.list_by_subject(self._db, concept_iri):
+            if triple.context_name != collection_iri:
+                continue
+            pred = URIRef(triple.predicate_uri)
+            if triple.object_is_uri:
+                obj = URIRef(triple.object_value)
+            elif triple.object_language:
+                obj = Literal(triple.object_value, lang=triple.object_language)
+            elif triple.object_datatype:
+                obj = Literal(triple.object_value, datatype=URIRef(triple.object_datatype))
+            else:
+                obj = Literal(triple.object_value)
+            coll_context.add((concept_uri, pred, obj))
 
     def delete_concept(self, concept_iri: str, deleted_by: Optional[str] = None) -> bool:
         """Delete a concept.

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -8,6 +8,11 @@ from rdflib import URIRef, Literal, Namespace, BNode
 # Ontos application ontology namespace
 ONTOS = Namespace("http://ontos.app/ontology#")
 
+# Dublin Core Terms + PROV — used for 2B split lineage links (P0-6 safe transition):
+# dct:isReplacedBy (old->new), dct:replaces (new->old), prov:wasRevisionOf (new->old).
+DCT = Namespace("http://purl.org/dc/terms/")
+PROV = Namespace("http://www.w3.org/ns/prov#")
+
 # XSD namespace for datatype handling
 from rdflib.namespace import XSD
 from sqlalchemy.orm import Session

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Dict, Any
 from pathlib import Path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from rdflib import Graph, ConjunctiveGraph, Dataset
 from rdflib.namespace import RDF, RDFS, SKOS, OWL
 from rdflib import URIRef, Literal, Namespace, BNode
@@ -178,6 +178,11 @@ class SemanticModelsManager(SearchableAsset):
         self._cached_concepts: Optional[List[OntologyConcept]] = None
         self._cached_taxonomies: Optional[List] = None
         self._cached_stats: Optional[TaxonomyStats] = None
+        # P0-8 graph freshness: when the served in-memory graph was last (re)built
+        # or targeted-patched. Advanced on every rebuild AND every targeted write
+        # (create/update/publish/deprecate/retire all route through
+        # _invalidate_cache). Surfaced via graph_freshness() / the /graph endpoints.
+        self._graph_last_refreshed: datetime = datetime.now(timezone.utc)
         logger.info(f"SemanticModelsManager initialized with data_dir: {self._data_dir}")
         # Load file-based taxonomies immediately
         try:
@@ -1138,6 +1143,9 @@ class SemanticModelsManager(SearchableAsset):
         except Exception as e:
             logger.error(f"Failed to build persistent caches: {e}", exc_info=True)
 
+        # P0-8: the served graph is now fresh — advance the freshness timestamp.
+        self._graph_last_refreshed = datetime.now(timezone.utc)
+
     def _build_persistent_caches_atomic(self) -> None:
         """Build and save persistent caches atomically to disk.
 
@@ -1384,6 +1392,11 @@ class SemanticModelsManager(SearchableAsset):
         self._cached_taxonomies = None
         self._cached_stats = None
 
+        # P0-8: every targeted write (create/update/publish/deprecate/retire)
+        # calls this AFTER patching the served graph, so treat it as a freshness
+        # bump — the graph now reflects the just-committed change.
+        self._graph_last_refreshed = datetime.now(timezone.utc)
+
         cache_dir = self._data_dir / "cache"
         if cache_dir.exists():
             for cache_file in ["concepts_all.json", "taxonomies.json", "stats.json"]:
@@ -1396,6 +1409,63 @@ class SemanticModelsManager(SearchableAsset):
                         logger.warning(f"Failed to delete cache file {cache_file}: {e}")
 
         logger.info("Semantic models cache invalidated (in-memory and persistent)")
+
+    def graph_freshness(self) -> Dict[str, Any]:
+        """Explicit graph-freshness surface for the UI (P0-8, API contract §6).
+
+        Returns:
+          - last_refreshed: ISO ts of the last rebuild OR targeted patch of the
+            served in-memory graph (so users SEE that their edit is live).
+          - concept_count: current concepts in the served graph.
+          - uc_synced_at / uc_next_sync_est: last successful uc_tag_sync run end
+            and a rough next-run estimate — surfaced SEPARATELY so "not yet synced
+            to UC" (eventual, ~4h) is not confused with "not saved". Reuses the
+            same job-run source as get_tag_delivery_stats; null when unavailable.
+        """
+        # concept_count from taxonomy stats (cached, always fresh post-rebuild).
+        try:
+            concept_count = self.get_taxonomy_stats().total_concepts
+        except Exception:
+            logger.warning("graph_freshness: could not compute concept_count", exc_info=True)
+            concept_count = 0
+
+        uc_synced_at, uc_next_sync_est = self._uc_sync_timing()
+
+        return {
+            "last_refreshed": self._graph_last_refreshed.isoformat(),
+            "concept_count": concept_count,
+            "uc_synced_at": uc_synced_at,
+            "uc_next_sync_est": uc_next_sync_est,
+        }
+
+    def _uc_sync_timing(self):
+        """(last_successful_uc_tag_sync_end_iso, next_run_estimate_iso) or (None, None).
+
+        Reuses the existing uc_tag_sync job-run history (same source as
+        get_tag_delivery_stats). Does NOT invent a new job. The uc_tag_sync job
+        runs on roughly a 4h cadence (PRD §2); estimate = last success + 4h.
+        Returns (None, None) if the job never ran or timing isn't readable.
+        """
+        try:
+            from src.repositories.workflow_job_runs_repository import workflow_job_run_repo
+            runs = workflow_job_run_repo.get_recent_runs(self._db, workflow_id='uc_tag_sync', limit=20)
+            for r in runs:
+                if r.result_state == 'SUCCESS' and r.end_time:
+                    synced = datetime.fromtimestamp(r.end_time / 1000, tz=timezone.utc)
+                    nxt = synced + timedelta(hours=4)
+                    return synced.isoformat(), nxt.isoformat()
+        except Exception as e:
+            logger.warning(f"graph_freshness: could not read uc_tag_sync timing: {e}")
+        return None, None
+
+    def reload_graph(self) -> Dict[str, Any]:
+        """Force a full rebuild of the served graph and return freshness (P0-8).
+
+        The user-facing 'Reload graph' backstop. rebuild_graph_from_enabled
+        advances last_refreshed; we then return the freshness object.
+        """
+        self.rebuild_graph_from_enabled()
+        return self.graph_freshness()
 
     @staticmethod
     def _extract_source_context(context_name: str) -> Optional[str]:

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -3759,7 +3759,9 @@ class SemanticModelsManager(SearchableAsset):
 
         Transaction (ONE Postgres commit):
           1. Demote the current ``concept_version`` -> history (is_current=false,
-             status='deprecated') and FLUSH, so the partial unique index
+             status='superseded' — replaced by a newer version; the concept stays
+             active, distinct from 'deprecated'=stop using the concept) and FLUSH,
+             so the partial unique index
              ``uq_concept_version_current_per_iri`` never sees two current rows.
           2. Insert the new ``concept_version`` (version = max+1 for this iri,
              is_current=true, parent_version_id = the demoted row's id).

--- a/src/backend/src/db_models/__init__.py
+++ b/src/backend/src/db_models/__init__.py
@@ -10,6 +10,7 @@ from . import audit_log
 from . import change_log
 from . import comments
 from . import compliance
+from . import concept_versions
 from . import connections
 from . import costs
 from . import data_asset_reviews

--- a/src/backend/src/db_models/concept_versions.py
+++ b/src/backend/src/db_models/concept_versions.py
@@ -55,14 +55,18 @@ class ConceptVersionDb(Base):
 
     __table_args__ = (
         UniqueConstraint("iri", "version", name="uq_concept_version_iri_version"),
-        # Documents the DB-level partial unique index (created via raw DDL in the
-        # migration because SQLAlchemy Core cannot express a partial index in a
-        # portable way here). Reflected for awareness; the migration owns it.
+        # Partial unique index: at most one is_current=true row per iri (the hot
+        # set). Postgres owns the authoritative copy via raw DDL in migration
+        # m1_concept_versioning; declared here (with BOTH dialect WHERE clauses)
+        # so metadata.create_all reproduces the SAME partial index on SQLite —
+        # otherwise the test harness would build a plain full-unique index on iri
+        # and reject legitimate multi-version rows. Keep both in lockstep.
         Index(
             "uq_concept_version_current_per_iri",
             "iri",
             unique=True,
             postgresql_where=Column("is_current"),
+            sqlite_where=Column("is_current"),
         ),
     )
 

--- a/src/backend/src/db_models/concept_versions.py
+++ b/src/backend/src/db_models/concept_versions.py
@@ -1,0 +1,100 @@
+"""Database models for the concept-versioning engine (P0-1).
+
+The versioned unit is ``(iri, version)``; ``iri`` is the stable identity. Mirrors
+the Data Products versioning pattern (indexed ``version`` + self-referential
+``parent_version_id`` lineage). Exactly one ``is_current=true`` row per ``iri`` is
+enforced at the DB level by a partial unique index created in Alembic migration
+``m1_concept_versioning`` (``UNIQUE(iri) WHERE is_current``).
+
+``scheme_membership`` is the unversioned many-to-many (``skos:inScheme``) tag
+linking a concept IRI to a scheme IRI. No "scheme version" object exists.
+"""
+import uuid
+
+from sqlalchemy import (
+    Column, String, Text, Boolean, Integer, TIMESTAMP,
+    ForeignKey, Index, UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.sql import func
+
+from src.common.database import Base
+
+
+class ConceptVersionDb(Base):
+    """One version of a concept. ``(iri, version)`` is the versioned unit.
+
+    Exactly one row per ``iri`` has ``is_current=true`` (the hot set), enforced by
+    the partial unique index ``uq_concept_version_current_per_iri``. History rows
+    (``is_current=false``) are cold and fetched on demand by ``(iri, version)``.
+    """
+    __tablename__ = "concept_version"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # Stable identity across versions.
+    iri = Column(Text, nullable=False, index=True)
+    # Monotonic per iri.
+    version = Column(Integer, nullable=False, default=1, index=True)
+    # Exactly one true per iri (partial unique index enforces this).
+    is_current = Column(Boolean, nullable=False, default=True, index=True)
+    status = Column(String(20), nullable=False, default="active")
+
+    # Self-referential lineage / fork.
+    parent_version_id = Column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("concept_version.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    # Set on a 2B meaning-split (this version's IRI replaces an old IRI).
+    replaces_iri = Column(Text, nullable=True)
+
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    created_by = Column(String, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("iri", "version", name="uq_concept_version_iri_version"),
+        # Documents the DB-level partial unique index (created via raw DDL in the
+        # migration because SQLAlchemy Core cannot express a partial index in a
+        # portable way here). Reflected for awareness; the migration owns it.
+        Index(
+            "uq_concept_version_current_per_iri",
+            "iri",
+            unique=True,
+            postgresql_where=Column("is_current"),
+        ),
+    )
+
+    def __repr__(self):
+        return (
+            f"<ConceptVersionDb(iri='{self.iri}', version={self.version}, "
+            f"is_current={self.is_current}, status='{self.status}')>"
+        )
+
+
+class SchemeMembershipDb(Base):
+    """Unversioned many-to-many membership of a concept IRI in a scheme IRI.
+
+    Corresponds to ``skos:inScheme``. A concept can be in many schemes; there is
+    no versioned scheme object.
+    """
+    __tablename__ = "scheme_membership"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    concept_iri = Column(Text, nullable=False, index=True)
+    scheme_iri = Column(Text, nullable=False, index=True)
+
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    created_by = Column(String, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("concept_iri", "scheme_iri",
+                         name="uq_scheme_membership_concept_scheme"),
+    )
+
+    def __repr__(self):
+        return (
+            f"<SchemeMembershipDb(concept_iri='{self.concept_iri}', "
+            f"scheme_iri='{self.scheme_iri}')>"
+        )

--- a/src/backend/src/db_models/rdf_triples.py
+++ b/src/backend/src/db_models/rdf_triples.py
@@ -4,7 +4,7 @@ This table stores all RDF triples from ontologies, taxonomies, and semantic link
 making the database the source of truth for the knowledge graph.
 """
 import uuid
-from sqlalchemy import Column, String, Text, Boolean, TIMESTAMP, Index, UniqueConstraint
+from sqlalchemy import Column, String, Text, Boolean, TIMESTAMP, Index, UniqueConstraint, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.sql import func
 
@@ -41,6 +41,18 @@ class RdfTripleDb(Base):
     # Source tracking
     source_type = Column(String(20), nullable=True)  # file, upload, demo, link
     source_identifier = Column(Text, nullable=True)  # filename, model_id, entity info
+
+    # Concept-versioning ownership (P0-1). Which concept-version owns this triple.
+    # Ownership is determined by the SUBJECT IRI; blank-node closures follow the
+    # IRI subject they hang off. NULL for triples whose subject is not a concept
+    # IRI (e.g. scheme headers, semantic-link edges). FK added by migration
+    # m1_concept_versioning.
+    concept_version_id = Column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("concept_version.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     
     # Audit fields
     created_by = Column(String, nullable=True)

--- a/src/backend/src/db_models/rdf_triples.py
+++ b/src/backend/src/db_models/rdf_triples.py
@@ -59,11 +59,15 @@ class RdfTripleDb(Base):
     created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
 
     # Unique constraint required for ON CONFLICT DO NOTHING in rdf_triples_repository.
+    # Includes concept_version_id (migration m4_rdf_triple_version_uq) so per-version
+    # snapshot rows (same triple owned by different versions) coexist, while
+    # NULLS NOT DISTINCT keeps NULL-owned (unversioned/metadata) triples deduped.
     __table_args__ = (
         UniqueConstraint(
             'subject_uri', 'predicate_uri', 'object_value',
-            'object_language', 'object_datatype', 'context_name',
+            'object_language', 'object_datatype', 'context_name', 'concept_version_id',
             name='uq_rdf_triple',
+            postgresql_nulls_not_distinct=True,
         ),
         # Composite index for SPO lookups
         Index('ix_rdf_triples_spo', 'subject_uri', 'predicate_uri', 'object_value'),

--- a/src/backend/src/models/ontology.py
+++ b/src/backend/src/models/ontology.py
@@ -34,6 +34,10 @@ class ConceptStatus(str, Enum):
     UNDER_REVIEW = "under_review"
     APPROVED = "approved"
     ACTIVE = "active"
+    # A prior concept-version that a newer version replaced (P0-3 atomic publish).
+    # The concept itself stays active; only this historical version is superseded.
+    # Distinct from DEPRECATED (stop using the concept) and RETIRED (tombstoned).
+    SUPERSEDED = "superseded"
     DEPRECATED = "deprecated"
     RETIRED = "retired"
 

--- a/src/backend/src/repositories/concept_versions_repository.py
+++ b/src/backend/src/repositories/concept_versions_repository.py
@@ -1,0 +1,101 @@
+"""Repository for concept-version rows (the versioned unit ``(iri, version)``).
+
+Backs the atomic-publish swap (P0-3). The partial unique index
+``uq_concept_version_current_per_iri`` (migration ``m1_concept_versioning``) is the
+DB-level backstop that makes two ``is_current=true`` rows for one ``iri``
+structurally impossible; the swap here demotes the old current BEFORE inserting the
+new current so that invariant is never transiently violated.
+"""
+from typing import List, Optional
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from src.common.repository import CRUDBase
+from src.db_models.concept_versions import ConceptVersionDb
+from src.common.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ConceptVersionsRepository(CRUDBase[ConceptVersionDb, dict, dict]):
+    """CRUD + version-swap helpers for ``concept_version``."""
+
+    def get_current(self, db: Session, iri: str) -> Optional[ConceptVersionDb]:
+        """The single current version for an iri (or None if not yet versioned)."""
+        return (
+            db.query(ConceptVersionDb)
+            .filter(ConceptVersionDb.iri == iri, ConceptVersionDb.is_current.is_(True))
+            .one_or_none()
+        )
+
+    def get_by_iri_version(
+        self, db: Session, iri: str, version: int
+    ) -> Optional[ConceptVersionDb]:
+        """Fetch a specific historical (or current) version by key."""
+        return (
+            db.query(ConceptVersionDb)
+            .filter(ConceptVersionDb.iri == iri, ConceptVersionDb.version == version)
+            .one_or_none()
+        )
+
+    def list_versions(self, db: Session, iri: str) -> List[ConceptVersionDb]:
+        """All versions for an iri, newest first."""
+        return (
+            db.query(ConceptVersionDb)
+            .filter(ConceptVersionDb.iri == iri)
+            .order_by(ConceptVersionDb.version.desc())
+            .all()
+        )
+
+    def max_version(self, db: Session, iri: str) -> int:
+        """Highest version number for an iri, or 0 if none exist."""
+        result = (
+            db.query(func.max(ConceptVersionDb.version))
+            .filter(ConceptVersionDb.iri == iri)
+            .scalar()
+        )
+        return int(result) if result is not None else 0
+
+    def demote_current(self, db: Session, iri: str, status: str = "deprecated") -> Optional[ConceptVersionDb]:
+        """Flip the current version to history (``is_current=false``).
+
+        MUST be flushed before inserting the new current row so the partial
+        unique index never sees two current rows for the iri.
+        """
+        current = self.get_current(db, iri)
+        if current is None:
+            return None
+        current.is_current = False
+        current.status = status
+        db.flush()
+        return current
+
+    def create_version(
+        self,
+        db: Session,
+        iri: str,
+        version: int,
+        is_current: bool = True,
+        status: str = "active",
+        parent_version_id=None,
+        replaces_iri: Optional[str] = None,
+        created_by: Optional[str] = None,
+    ) -> ConceptVersionDb:
+        """Insert a new concept_version row and flush it (so its id is available)."""
+        cv = ConceptVersionDb(
+            iri=iri,
+            version=version,
+            is_current=is_current,
+            status=status,
+            parent_version_id=parent_version_id,
+            replaces_iri=replaces_iri,
+            created_by=created_by,
+        )
+        db.add(cv)
+        db.flush()
+        return cv
+
+
+# Singleton instance (matches rdf_triples_repo / entity_semantic_links_repo pattern).
+concept_versions_repo = ConceptVersionsRepository(ConceptVersionDb)

--- a/src/backend/src/repositories/concept_versions_repository.py
+++ b/src/backend/src/repositories/concept_versions_repository.py
@@ -57,7 +57,7 @@ class ConceptVersionsRepository(CRUDBase[ConceptVersionDb, dict, dict]):
         )
         return int(result) if result is not None else 0
 
-    def demote_current(self, db: Session, iri: str, status: str = "deprecated") -> Optional[ConceptVersionDb]:
+    def demote_current(self, db: Session, iri: str, status: str = "superseded") -> Optional[ConceptVersionDb]:
         """Flip the current version to history (``is_current=false``).
 
         MUST be flushed before inserting the new current row so the partial

--- a/src/backend/src/repositories/rdf_triples_repository.py
+++ b/src/backend/src/repositories/rdf_triples_repository.py
@@ -226,6 +226,32 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
             RdfTripleDb.subject_uri == subject_uri
         ).all()
 
+    def reassign_subject_to_concept_version(
+        self, db: Session, subject_uri: str, concept_version_id, context_name: Optional[str] = None
+    ) -> int:
+        """Point every triple owned by ``subject_uri`` at a concept-version (P0-3).
+
+        Triple ownership is determined by the SUBJECT IRI (the P0-1 ownership
+        rule). On an atomic publish, the affected concept's triples are moved to
+        the newly-minted current version by setting their ``concept_version_id``.
+        Optionally scoped to a single ``context_name``.
+
+        Returns the number of triples reassigned. Flushes but does not commit —
+        the caller owns the transaction so the swap is one Postgres commit.
+        """
+        query = db.query(RdfTripleDb).filter(RdfTripleDb.subject_uri == subject_uri)
+        if context_name:
+            query = query.filter(RdfTripleDb.context_name == context_name)
+        updated = query.update(
+            {RdfTripleDb.concept_version_id: concept_version_id},
+            synchronize_session=False,
+        )
+        db.flush()
+        logger.debug(
+            f"Reassigned {updated} triples of '{subject_uri}' to concept_version {concept_version_id}"
+        )
+        return updated
+
     def remove_by_subject(
         self, db: Session, subject_uri: str, context_name: Optional[str] = None
     ) -> int:

--- a/src/backend/src/repositories/rdf_triples_repository.py
+++ b/src/backend/src/repositories/rdf_triples_repository.py
@@ -26,6 +26,15 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
     - Context-based operations for managing ontology sources
     """
 
+    # Uniqueness key columns for ON CONFLICT DO NOTHING. Includes
+    # concept_version_id (migration m4_rdf_triple_version_uq) so per-version
+    # snapshot rows (same triple, different owning version) do not collide, while
+    # NULL-owned duplicates are still deduped (UNIQUE NULLS NOT DISTINCT).
+    _CONFLICT_COLS = [
+        'subject_uri', 'predicate_uri', 'object_value',
+        'object_language', 'object_datatype', 'context_name', 'concept_version_id',
+    ]
+
     def add_triple(
         self,
         db: Session,
@@ -39,10 +48,15 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
         source_type: Optional[str] = None,
         source_identifier: Optional[str] = None,
         created_by: Optional[str] = None,
+        concept_version_id=None,
     ) -> Optional[RdfTripleDb]:
         """Add a single triple with ON CONFLICT DO NOTHING.
 
         Returns the triple if inserted, None if it already existed.
+
+        ``concept_version_id`` optionally stamps the owning concept-version at
+        insert time (used by the publish snapshot-copy path so the new row is
+        born owned by v2 rather than reassigned afterward).
         """
         # Coerce None to '' — the DB columns are NOT NULL with default ''
         if object_language is None:
@@ -61,9 +75,9 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
             source_type=source_type,
             source_identifier=source_identifier,
             created_by=created_by,
+            concept_version_id=concept_version_id,
         ).on_conflict_do_nothing(
-            index_elements=['subject_uri', 'predicate_uri', 'object_value', 
-                           'object_language', 'object_datatype', 'context_name']
+            index_elements=self._CONFLICT_COLS
         ).returning(RdfTripleDb.id)
         
         result = db.execute(stmt)
@@ -114,8 +128,7 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
                     triple['object_datatype'] = ''
             
             stmt = insert(RdfTripleDb).values(batch).on_conflict_do_nothing(
-                index_elements=['subject_uri', 'predicate_uri', 'object_value', 
-                               'object_language', 'object_datatype', 'context_name']
+                index_elements=self._CONFLICT_COLS
             )
             
             result = db.execute(stmt)

--- a/src/backend/src/repositories/rdf_triples_repository.py
+++ b/src/backend/src/repositories/rdf_triples_repository.py
@@ -16,6 +16,10 @@ from src.common.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Sentinel so remove_by_subject_predicate can distinguish "not scoped by version"
+# (delete across all versions) from "scoped to concept_version_id = None".
+_UNSET = object()
+
 
 class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
     """Repository for RDF triple operations.
@@ -239,6 +243,90 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
             RdfTripleDb.subject_uri == subject_uri
         ).all()
 
+    def list_current_by_subject(self, db: Session, subject_uri: str) -> List[RdfTripleDb]:
+        """Triples for a subject that belong in the SERVED (current) graph.
+
+        A row is current when it has no owning version (unowned/metadata) OR its
+        owning concept-version is current. Used to re-add a concept to the hot
+        graph after publish WITHOUT leaking the prior version's frozen snapshot.
+        Mirrors the rdf_triples_current view rule, scoped to one subject.
+        """
+        return (
+            db.query(RdfTripleDb)
+            .outerjoin(
+                ConceptVersionDb,
+                ConceptVersionDb.id == RdfTripleDb.concept_version_id,
+            )
+            .filter(
+                RdfTripleDb.subject_uri == subject_uri,
+                or_(
+                    RdfTripleDb.concept_version_id.is_(None),
+                    ConceptVersionDb.is_current.is_(True),
+                ),
+            )
+            .all()
+        )
+
+    def list_by_concept_version(self, db: Session, concept_version_id) -> List[RdfTripleDb]:
+        """All triples owned by a specific concept-version id (its frozen snapshot)."""
+        return (
+            db.query(RdfTripleDb)
+            .filter(RdfTripleDb.concept_version_id == concept_version_id)
+            .all()
+        )
+
+    def copy_triples_to_version(
+        self,
+        db: Session,
+        subject_uri: str,
+        source_concept_version_id,
+        target_concept_version_id,
+        context_name: Optional[str] = None,
+        created_by: Optional[str] = None,
+    ) -> int:
+        """Duplicate a concept's triples into a NEW set owned by the target version.
+
+        The prior (source) version's rows are LEFT UNTOUCHED — they are its frozen
+        snapshot. Each source row is re-inserted with concept_version_id =
+        target. Uniqueness now includes concept_version_id (migration m4), so the
+        copy does not collide with the source rows. Returns rows copied.
+
+        Source selection: rows owned by ``source_concept_version_id`` (the demoted
+        version). If that is None (edge case: publishing an unversioned concept),
+        falls back to the subject's currently-unowned rows so v2 still gets a set.
+        """
+        q = db.query(RdfTripleDb).filter(RdfTripleDb.subject_uri == subject_uri)
+        if context_name:
+            q = q.filter(RdfTripleDb.context_name == context_name)
+        if source_concept_version_id is not None:
+            q = q.filter(RdfTripleDb.concept_version_id == source_concept_version_id)
+        else:
+            q = q.filter(RdfTripleDb.concept_version_id.is_(None))
+        source_rows = q.all()
+
+        copied = 0
+        for r in source_rows:
+            db.add(RdfTripleDb(
+                subject_uri=r.subject_uri,
+                predicate_uri=r.predicate_uri,
+                object_value=r.object_value,
+                object_is_uri=r.object_is_uri,
+                object_language=r.object_language,
+                object_datatype=r.object_datatype,
+                context_name=r.context_name,
+                source_type=r.source_type,
+                source_identifier=r.source_identifier,
+                created_by=created_by or r.created_by,
+                concept_version_id=target_concept_version_id,
+            ))
+            copied += 1
+        db.flush()
+        logger.debug(
+            f"Copied {copied} triples of '{subject_uri}' from version "
+            f"{source_concept_version_id} to {target_concept_version_id}"
+        )
+        return copied
+
     def reassign_subject_to_concept_version(
         self, db: Session, subject_uri: str, concept_version_id, context_name: Optional[str] = None
     ) -> int:
@@ -290,11 +378,18 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
         subject_uri: str,
         predicate_uri: str,
         context_name: Optional[str] = None,
+        concept_version_id: object = _UNSET,
     ) -> int:
         """Remove all triples matching subject and predicate.
-        
+
         Useful for updating properties where you don't know the old value.
         Returns the number of triples deleted.
+
+        ``concept_version_id``: when provided (including None), scopes the delete
+        to rows owned by exactly that version — so a publish can overwrite v2's
+        copied set WITHOUT touching the prior version's frozen snapshot. Left at
+        the sentinel default = not scoped (delete across all versions, legacy
+        behaviour for the plain update path).
         """
         query = db.query(RdfTripleDb).filter(
             and_(
@@ -304,10 +399,15 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
         )
         if context_name:
             query = query.filter(RdfTripleDb.context_name == context_name)
-        
+        if concept_version_id is not _UNSET:
+            if concept_version_id is None:
+                query = query.filter(RdfTripleDb.concept_version_id.is_(None))
+            else:
+                query = query.filter(RdfTripleDb.concept_version_id == concept_version_id)
+
         deleted = query.delete(synchronize_session=False)
         db.flush()
-        
+
         logger.debug(f"Removed {deleted} triples for {subject_uri} -> {predicate_uri}")
         return deleted
 

--- a/src/backend/src/repositories/rdf_triples_repository.py
+++ b/src/backend/src/repositories/rdf_triples_repository.py
@@ -6,11 +6,12 @@ and context-based queries.
 from typing import List, Optional, Dict, Any
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy import and_
+from sqlalchemy import and_, or_
 import uuid
 
 from src.common.repository import CRUDBase
 from src.db_models.rdf_triples import RdfTripleDb
+from src.db_models.concept_versions import ConceptVersionDb
 from src.common.logging import get_logger
 
 logger = get_logger(__name__)
@@ -180,8 +181,44 @@ class RdfTriplesRepository(CRUDBase[RdfTripleDb, dict, dict]):
         ).all()
 
     def list_all(self, db: Session) -> List[RdfTripleDb]:
-        """Get all triples from the database."""
+        """Get all triples from the database (current + history).
+
+        NOTE: for building the served in-memory graph use ``list_current`` — the
+        hot graph must contain current-only triples (P0-2). This method returns
+        every row including historical versions.
+        """
         return db.query(RdfTripleDb).all()
+
+    def list_current(self, db: Session) -> List[RdfTripleDb]:
+        """Get the current-only triples for building the served hot graph (P0-2).
+
+        A triple is current when EITHER:
+          - it has no ``concept_version_id`` (scheme / collection / metadata and
+            other P0-1-unowned triples — these MUST still load), OR
+          - its owning concept-version has ``is_current = true``.
+
+        History triples (owned by a non-current concept-version) are excluded so
+        they never enter the materialized graph. The ``is_current`` filter runs
+        HERE, once at build time; downstream reads carry no version predicate.
+
+        Mirrors the ``rdf_triples_current`` DB view (migration
+        ``m2_rdf_triples_current``) so the two stay in lockstep.
+        """
+        # Outer join to concept_version; keep rows that are unowned OR current.
+        return (
+            db.query(RdfTripleDb)
+            .outerjoin(
+                ConceptVersionDb,
+                ConceptVersionDb.id == RdfTripleDb.concept_version_id,
+            )
+            .filter(
+                or_(
+                    RdfTripleDb.concept_version_id.is_(None),
+                    ConceptVersionDb.is_current.is_(True),
+                )
+            )
+            .all()
+        )
 
     def list_by_subject(self, db: Session, subject_uri: str) -> List[RdfTripleDb]:
         """Get all triples with a given subject."""

--- a/src/backend/src/repositories/semantic_links_repository.py
+++ b/src/backend/src/repositories/semantic_links_repository.py
@@ -16,6 +16,15 @@ class EntitySemanticLinksRepository(CRUDBase[EntitySemanticLinkDb, EntitySemanti
     def list_for_iri(self, db: Session, iri: str) -> List[EntitySemanticLinkDb]:
         return db.query(self.model).filter(self.model.iri == iri).all()
 
+    def count_for_iri(self, db: Session, iri: str) -> int:
+        """Count entity_semantic_links rows referencing an iri (P0-6 retire gate).
+
+        This is the physical UC/asset reference count: each row maps a UC FQN or
+        Ontos entity to this concept iri. Concept->concept references are counted
+        separately in the manager (via the in-memory graph).
+        """
+        return db.query(self.model).filter(self.model.iri == iri).count()
+
     def get_by_entity_and_iri(self, db: Session, entity_id: str, entity_type: str, iri: str) -> EntitySemanticLinkDb | None:
         return db.query(self.model).filter(
             self.model.entity_id == entity_id,

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -80,6 +80,16 @@ class RetireConceptResponse(BaseModel):
     label: Optional[str] = None
     status: str
 
+
+# --- Graph freshness (API contract §6, signed off) ---
+class GraphFreshnessResponse(BaseModel):
+    """Served in-memory graph freshness. UI shows 'last refreshed HH:MM, N
+    concepts' + a SEPARATE 'synced to UC' line (uc_* fields)."""
+    last_refreshed: str
+    concept_count: int
+    uc_synced_at: Optional[str] = None
+    uc_next_sync_est: Optional[str] = None
+
 # Internal named-graph contexts that must never surface as user-facing RDF
 # Sources. These are computed/managed graphs (app entities, semantic links,
 # source-registry metadata, the rdflib default graph), not uploaded or bundled
@@ -858,6 +868,41 @@ async def retire_concept(
     except Exception:
         logger.error("Error retiring concept %s", body.iri, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retire concept")
+
+
+@router.get(
+    '/semantic-models/graph/freshness',
+    response_model=GraphFreshnessResponse,
+)
+async def get_graph_freshness(
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY)),
+) -> GraphFreshnessResponse:
+    """Served-graph freshness (P0-8, API contract §6): last_refreshed +
+    concept_count + separate UC sync timing."""
+    try:
+        return GraphFreshnessResponse(**manager.graph_freshness())
+    except Exception:
+        logger.error("Error computing graph freshness", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to compute graph freshness")
+
+
+@router.post(
+    '/semantic-models/graph/reload',
+    response_model=GraphFreshnessResponse,
+)
+async def reload_graph(
+    current_user: CurrentUserDep,
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE)),
+) -> GraphFreshnessResponse:
+    """Force a full rebuild of the served graph and return the updated freshness
+    (P0-8, API contract §6). The user-facing recovery/backstop control."""
+    try:
+        return GraphFreshnessResponse(**manager.reload_graph())
+    except Exception:
+        logger.error("Error reloading graph", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to reload graph")
 
 
 @router.get(

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -50,6 +50,28 @@ class PublishVersionResponse(BaseModel):
     is_current: bool
 
 
+# --- Version read models (API contract §1, §2, signed off) ---
+class ConceptVersionEntry(BaseModel):
+    version: int
+    is_current: bool
+    status: Optional[str] = None
+    created_at: Optional[str] = None
+    created_by: Optional[str] = None
+
+
+class ConceptVersionInfo(BaseModel):
+    """GET /semantic-models/concepts/version — current version + history (§1).
+
+    label is REQUIRED so the Simple view renders a name, never the IRI."""
+    iri: str
+    label: str
+    current_version: Optional[int] = None
+    status: Optional[str] = None
+    versions: List[ConceptVersionEntry] = Field(default_factory=list)
+    replaces_iri: Optional[str] = None
+    replaced_by_iris: List[str] = Field(default_factory=list)
+
+
 # --- Safe-transition models (API contract §5, signed off) ---
 class ReferenceCountResponse(BaseModel):
     """GET /semantic-models/concepts/reference-count → the retire gate."""
@@ -750,6 +772,54 @@ async def get_concept_details_by_iri(
     except Exception:
         logger.error("Error retrieving concept details for %s", concept_iri, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retrieve concept details")
+
+
+# NOTE: these version READ routes MUST be registered ABOVE the catch-all
+# `@router.get('/semantic-models/concepts/{concept_iri:path}')` (below) or the
+# path-param route swallows `/version` and `/version/detail`.
+@router.get(
+    '/semantic-models/concepts/version',
+    response_model=ConceptVersionInfo,
+)
+async def get_concept_version_info(
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY)),
+) -> ConceptVersionInfo:
+    """Current version + version history for a concept (P0-2, API contract §1)."""
+    try:
+        info = manager.get_concept_version_info(concept_iri)
+        if info is None:
+            raise HTTPException(status_code=404, detail="Concept not found")
+        return ConceptVersionInfo(**info)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Error retrieving version info for %s", concept_iri, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to retrieve version info")
+
+
+@router.get('/semantic-models/concepts/version/detail')
+async def get_concept_version_detail(
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    version: int = Query(..., ge=1, description="Version number to fetch"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY)),
+) -> dict:
+    """Concept detail as of a specific version, by (iri, version) key (§2).
+
+    Cold fetch; does not touch the hot graph. Same shape as concepts/by-iri
+    detail plus version / is_current."""
+    try:
+        detail = manager.get_concept_version_detail(concept_iri, version)
+        if detail is None:
+            raise HTTPException(status_code=404, detail="Concept version not found")
+        return detail
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Error retrieving version detail for %s v%s", concept_iri, version, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to retrieve version detail")
 
 
 @router.post(

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -24,12 +24,30 @@ from src.common.features import FeatureAccessLevel
 from src.common.file_security import sanitize_filename
 from src.owl.owl_parser import clean_truncated_turtle
 from rdflib import ConjunctiveGraph, RDF
+from pydantic import BaseModel, Field
 
 # Configure logging
 from src.common.logging import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/api", tags=["Semantic Models"])
+
+
+# --- Concept-versioning request/response models (API contract §4, signed off) ---
+class PublishVersionRequest(BaseModel):
+    """Body for POST /semantic-models/concepts/version/publish."""
+    iri: str = Field(..., min_length=1, description="Stable concept IRI (never changes across versions)")
+    changes: dict = Field(default_factory=dict, description="Concept fields to overwrite in the new version")
+    change_note: Optional[str] = Field(None, description="Human note describing what changed")
+
+
+class PublishVersionResponse(BaseModel):
+    """Response for the publish action. NO graph_refreshed field: a 200 means the
+    graph was patched synchronously and the new version is already live."""
+    iri: str
+    label: Optional[str] = None
+    new_version: int
+    is_current: bool
 
 # Internal named-graph contexts that must never surface as user-facing RDF
 # Sources. These are computed/managed graphs (app entities, semantic links,
@@ -691,6 +709,49 @@ async def get_concept_details_by_iri(
     except Exception:
         logger.error("Error retrieving concept details for %s", concept_iri, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retrieve concept details")
+
+
+@router.post(
+    '/semantic-models/concepts/version/publish',
+    response_model=PublishVersionResponse,
+)
+async def publish_concept_version(
+    body: PublishVersionRequest,
+    current_user: CurrentUserDep,
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE)),
+) -> PublishVersionResponse:
+    """Publish a new version of a concept (P0-3, API contract §4).
+
+    DB-first atomic swap (demote old -> history, insert new current, reassign the
+    concept's triples) in ONE Postgres transaction, THEN patch the served graph.
+    On the rare DB-committed-but-graph-patch-failed case the manager force-rebuilds
+    and re-raises; we surface that as a 500 (the DB is correct, the served graph
+    is being reconciled) rather than pretending success.
+    """
+    try:
+        result = manager.publish_concept_version(
+            concept_iri=body.iri,
+            changes=body.changes,
+            change_note=body.change_note,
+            published_by=current_user.email,
+        )
+        return PublishVersionResponse(**result)
+    except ValueError as e:
+        # Not editable / not found / bad input.
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception:
+        # Includes the recovery-contract re-raise: DB committed, graph patch
+        # failed and a rebuild was forced. Do NOT report success.
+        logger.error("Error publishing concept version for %s", body.iri, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="New version committed to the database but the served graph "
+                   "could not be patched; a rebuild was triggered. Retry the read "
+                   "shortly or use the graph reload control.",
+        )
 
 
 @router.get(

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -4,7 +4,7 @@ from typing import Optional, List
 
 from fastapi import APIRouter, HTTPException, Depends, Request, Query, UploadFile, File
 
-from src.controller.semantic_models_manager import SemanticModelsManager
+from src.controller.semantic_models_manager import SemanticModelsManager, ReferenceCountError
 from src.models.ontology import (
     OntologyConcept,
     ConceptHierarchy,
@@ -48,6 +48,37 @@ class PublishVersionResponse(BaseModel):
     label: Optional[str] = None
     new_version: int
     is_current: bool
+
+
+# --- Safe-transition models (API contract §5, signed off) ---
+class ReferenceCountResponse(BaseModel):
+    """GET /semantic-models/concepts/reference-count → the retire gate."""
+    iri: str
+    count: int
+
+
+class DeprecateConceptRequest(BaseModel):
+    """POST /semantic-models/concepts/deprecate."""
+    iri: str = Field(..., min_length=1)
+    replaced_by: Optional[List[str]] = Field(None, description="Successor IRIs for a 2B split")
+
+
+class DeprecateConceptResponse(BaseModel):
+    iri: str
+    label: Optional[str] = None
+    status: str
+    replaced_by: List[str] = Field(default_factory=list)
+
+
+class RetireConceptRequest(BaseModel):
+    """POST /semantic-models/concepts/retire."""
+    iri: str = Field(..., min_length=1)
+
+
+class RetireConceptResponse(BaseModel):
+    iri: str
+    label: Optional[str] = None
+    status: str
 
 # Internal named-graph contexts that must never surface as user-facing RDF
 # Sources. These are computed/managed graphs (app entities, semantic links,
@@ -752,6 +783,81 @@ async def publish_concept_version(
                    "could not be patched; a rebuild was triggered. Retry the read "
                    "shortly or use the graph reload control.",
         )
+
+
+@router.get(
+    '/semantic-models/concepts/reference-count',
+    response_model=ReferenceCountResponse,
+)
+async def get_concept_reference_count(
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY)),
+) -> ReferenceCountResponse:
+    """Reference count for a concept (P0-6): entity_semantic_links rows + concept->concept refs.
+
+    This is the retire gate — retirement is refused while count > 0.
+    """
+    try:
+        return ReferenceCountResponse(iri=concept_iri, count=manager.reference_count(concept_iri))
+    except Exception:
+        logger.error("Error computing reference count for %s", concept_iri, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to compute reference count")
+
+
+@router.post(
+    '/semantic-models/concepts/deprecate',
+    response_model=DeprecateConceptResponse,
+)
+async def deprecate_concept(
+    body: DeprecateConceptRequest,
+    current_user: CurrentUserDep,
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE)),
+) -> DeprecateConceptResponse:
+    """Deprecate a concept (stays resolvable); on a 2B split write isReplacedBy /
+    replaces / wasRevisionOf lineage links (P0-6, API contract §5)."""
+    try:
+        result = manager.deprecate_concept(
+            concept_iri=body.iri,
+            replaced_by=body.replaced_by,
+            deprecated_by=current_user.email,
+        )
+        return DeprecateConceptResponse(**result)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        logger.error("Error deprecating concept %s", body.iri, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to deprecate concept")
+
+
+@router.post(
+    '/semantic-models/concepts/retire',
+    response_model=RetireConceptResponse,
+)
+async def retire_concept(
+    body: RetireConceptRequest,
+    current_user: CurrentUserDep,
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE)),
+) -> RetireConceptResponse:
+    """Retire a concept to a tombstone, gated on reference_count == 0 (P0-6, §5).
+
+    Returns 409 if the concept is still referenced (retirement refused); otherwise
+    tombstones it (status=retired, still resolvable, never hard-deleted).
+    """
+    try:
+        result = manager.retire_concept(concept_iri=body.iri, retired_by=current_user.email)
+        return RetireConceptResponse(**result)
+    except ReferenceCountError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Error retiring concept %s", body.iri, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to retire concept")
 
 
 @router.get(

--- a/src/backend/src/tests/integration/test_concept_versioning.py
+++ b/src/backend/src/tests/integration/test_concept_versioning.py
@@ -1,0 +1,293 @@
+"""Integration tests for the concept-versioning engine (P0-1/2/3/6/8).
+
+Exercises the versioning lifecycle through the real REST routes + a real
+SemanticModelsManager on the shared test DB, mirroring test_knowledge_routes.py
+(client + make_collection fixtures). These commit the guarantees that were
+previously only proven by an out-of-tree E2E script, so CI and reviewers can
+see them:
+
+- publish mints v2, keeps the IRI stable, and SNAPSHOTS v1 (old definition text
+  survives) — the core "what was the previous definition" promise;
+- the prior version is marked ``superseded`` (not ``deprecated``);
+- a normal read returns the CURRENT version and does NOT leak history
+  (write-time current/history split, P0-2);
+- the reference-count retire GATE refuses (409) while referenced and succeeds
+  (tombstone) at zero refs (P0-6);
+- deprecate-with-successor records the isReplacedBy link (2B split);
+- the partial unique index rejects a second is_current row for one IRI (P0-1).
+
+Note: the test harness builds the schema via ``Base.metadata.create_all`` on
+SQLite, and ConceptVersionDb declares the partial index with both
+``postgresql_where`` and ``sqlite_where`` so the single-current invariant holds
+here too. Postgres-only migration DDL (the rdf_triples_current VIEW) is not
+exercised; the served-graph build uses the ORM ``list_current`` which mirrors it.
+"""
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.app import app
+from src.controller.semantic_models_manager import SemanticModelsManager
+from src.common.app_state import set_app_state_manager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — local, mirroring test_knowledge_routes.py (the integration suite
+# defines these per-file; there is no shared integration conftest).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def semantic_models_manager(db_session: Session, tmp_path: Path):
+    """SemanticModelsManager on the test session + tmp data dir, published on
+    app.state so the route dependencies resolve."""
+    data_dir = tmp_path / "sm_data"
+    (data_dir / "cache").mkdir(parents=True, exist_ok=True)
+    (data_dir / "taxonomies").mkdir(parents=True, exist_ok=True)
+
+    manager = SemanticModelsManager(db=db_session, data_dir=data_dir)
+    app.state.semantic_models_manager = manager
+    set_app_state_manager("semantic_models_manager", manager)
+
+    class _NoopOSM:
+        def sync_asset_types(self, *_args, **_kwargs):
+            return {"created": 0, "updated": 0}
+
+    app.state.ontology_schema_manager = _NoopOSM()
+
+    class _NoopAudit:
+        def log_action(self, *_args, **_kwargs):
+            return None
+
+        def log_event(self, *_args, **_kwargs):
+            return None
+
+    app.state.audit_manager = _NoopAudit()
+
+    yield manager
+
+    for attr in ("semantic_models_manager", "ontology_schema_manager", "audit_manager"):
+        if hasattr(app.state, attr):
+            delattr(app.state, attr)
+
+
+@pytest.fixture
+def make_collection(client: TestClient, semantic_models_manager):
+    """Factory that creates a fresh, uniquely-named editable collection."""
+
+    def _make(label_prefix: str = "Ver Coll", collection_type: str = "glossary",
+              description: str = "made by versioning test"):
+        label = f"{label_prefix} {uuid.uuid4().hex[:8]}"
+        r = client.post("/api/knowledge/collections", json={
+            "label": label,
+            "collection_type": collection_type,
+            "scope_level": "enterprise",
+            "description": description,
+        })
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    return _make
+
+
+def _make_concept(client: TestClient, collection_iri: str, label: str, definition: str) -> str:
+    """Create a concept and return its IRI."""
+    r = client.post("/api/knowledge/concepts", json={
+        "collection_iri": collection_iri,
+        "label": label,
+        "definition": definition,
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    iri = body.get("iri") or (body.get("concept") or {}).get("iri")
+    assert iri, f"could not resolve created concept IRI from {body}"
+    return iri
+
+
+def _version_info(client: TestClient, iri: str):
+    from urllib.parse import quote
+    r = client.get(f"/api/semantic-models/concepts/version?iri={quote(iri, safe='')}")
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _version_detail(client: TestClient, iri: str, version: int):
+    from urllib.parse import quote
+    r = client.get(
+        f"/api/semantic-models/concepts/version/detail?iri={quote(iri, safe='')}&version={version}"
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _definition(detail: dict) -> str:
+    c = detail.get("concept", detail)
+    return c.get("definition") or c.get("comment") or ""
+
+
+class TestConceptVersionPublish:
+    def test_create_mints_v1(self, client: TestClient, make_collection):
+        coll = make_collection("Ver Create")
+        iri = _make_concept(client, coll["iri"], "Customer", "a buyer")
+
+        info = _version_info(client, iri)
+        assert info["current_version"] == 1
+        assert len(info["versions"]) == 1
+        assert info["versions"][0]["is_current"] is True
+
+    def test_publish_bumps_version_keeps_iri(self, client: TestClient, make_collection):
+        coll = make_collection("Ver Publish")
+        iri = _make_concept(client, coll["iri"], "Revenue", "v1 definition")
+
+        r = client.post("/api/semantic-models/concepts/version/publish", json={
+            "iri": iri,
+            "changes": {"definition": "v2 definition"},
+            "change_note": "tighten",
+        })
+        assert r.status_code == 200, r.text
+        pub = r.json()
+        assert pub["new_version"] == 2
+        assert pub["is_current"] is True
+        assert pub["iri"] == iri  # IRI is stable across versions
+        assert pub.get("label")  # label present for the Simple view
+        # Publish patches the graph synchronously; no graph_refreshed field.
+        assert "graph_refreshed" not in pub
+
+    def test_prior_version_is_superseded(self, client: TestClient, make_collection):
+        coll = make_collection("Ver Superseded")
+        iri = _make_concept(client, coll["iri"], "Margin", "v1")
+        client.post("/api/semantic-models/concepts/version/publish", json={
+            "iri": iri, "changes": {"definition": "v2"},
+        }).raise_for_status()
+
+        info = _version_info(client, iri)
+        assert len(info["versions"]) == 2
+        current = next(v for v in info["versions"] if v["is_current"])
+        prior = next(v for v in info["versions"] if not v["is_current"])
+        assert current["version"] == 2
+        # Prior version is 'superseded' — NOT 'deprecated' (which means stop
+        # using the concept). The concept itself stays active.
+        assert prior["status"] == "superseded", info["versions"]
+
+    def test_snapshot_preserves_old_definition(self, client: TestClient, make_collection):
+        """The core promise: after a publish, the PREVIOUS version's definition
+        text is still retrievable (v1 triples are frozen, not overwritten)."""
+        coll = make_collection("Ver Snapshot")
+        iri = _make_concept(client, coll["iri"], "OPEX", "v1 definition")
+        client.post("/api/semantic-models/concepts/version/publish", json={
+            "iri": iri, "changes": {"definition": "v2 definition (edited)"},
+        }).raise_for_status()
+
+        v1 = _version_detail(client, iri, 1)
+        v2 = _version_detail(client, iri, 2)
+        assert "v1 definition" in _definition(v1), _definition(v1)
+        assert "v2 definition (edited)" in _definition(v2), _definition(v2)
+        assert _definition(v1) != _definition(v2)
+
+
+class TestReadIsolation:
+    def test_current_read_does_not_leak_history(self, client: TestClient, make_collection):
+        """A normal concept read returns the CURRENT version and never the
+        frozen prior-version text (write-time current/history split, P0-2)."""
+        from urllib.parse import quote
+        coll = make_collection("Ver ReadIso")
+        iri = _make_concept(client, coll["iri"], "Churn", "v1 definition")
+        client.post("/api/semantic-models/concepts/version/publish", json={
+            "iri": iri, "changes": {"definition": "v2 definition (edited)"},
+        }).raise_for_status()
+
+        r = client.get(f"/api/semantic-models/concepts/by-iri?iri={quote(iri, safe='')}")
+        assert r.status_code == 200, r.text
+        current_def = _definition(r.json())
+        assert "v2 definition (edited)" in current_def
+        assert "v1 definition" not in current_def
+
+
+class TestSafeTransition:
+    def test_retire_gate_refuses_while_referenced(
+        self, client: TestClient, make_collection, db_session
+    ):
+        """Retire is refused (409) while the concept is referenced, and succeeds
+        (tombstone) once the reference is removed (P0-6)."""
+        from urllib.parse import quote
+        from src.repositories.semantic_links_repository import entity_semantic_links_repo
+
+        coll = make_collection("Ver RetireGate")
+        iri = _make_concept(client, coll["iri"], "Segment", "a grouping")
+        q = quote(iri, safe="")
+
+        rc = client.get(f"/api/semantic-models/concepts/reference-count?iri={q}")
+        assert rc.status_code == 200 and rc.json()["count"] == 0
+
+        # Create a real reference -> retire must be refused.
+        link = client.post("/api/semantic-links/", json={
+            "entity_id": f"main.e2e.tbl_{uuid.uuid4().hex[:6]}",
+            "entity_type": "uc_table",
+            "iri": iri,
+        })
+        assert link.status_code == 200, link.text
+        link_id = link.json()["id"]
+
+        assert client.get(
+            f"/api/semantic-models/concepts/reference-count?iri={q}"
+        ).json()["count"] > 0
+        blocked = client.post("/api/semantic-models/concepts/retire", json={"iri": iri})
+        assert blocked.status_code == 409, blocked.text
+
+        # Remove the reference (via the repo the gate reads — avoids coupling the
+        # test to the delete route's change-log side effects) -> retire succeeds.
+        entity_semantic_links_repo.remove(db_session, id=uuid.UUID(link_id))
+        db_session.commit()
+        assert client.get(
+            f"/api/semantic-models/concepts/reference-count?iri={q}"
+        ).json()["count"] == 0
+        retired = client.post("/api/semantic-models/concepts/retire", json={"iri": iri})
+        assert retired.status_code == 200, retired.text
+        assert retired.json()["status"] == "retired"
+        # Tombstone, not hard delete: still resolvable.
+        assert client.get(
+            f"/api/semantic-models/concepts/version?iri={q}"
+        ).status_code == 200
+
+    def test_deprecate_with_successor_records_replaced_by(self, client: TestClient, make_collection):
+        """A 2B split: deprecate old with a named successor records isReplacedBy."""
+        coll = make_collection("Ver Split")
+        old_iri = _make_concept(client, coll["iri"], "Customer", "a buyer")
+        succ_iri = _make_concept(client, coll["iri"], "Active Customer", "a current buyer")
+
+        dep = client.post("/api/semantic-models/concepts/deprecate", json={
+            "iri": old_iri, "replaced_by": [succ_iri],
+        })
+        assert dep.status_code == 200, dep.text
+        assert dep.json()["status"] == "deprecated"
+
+        info = _version_info(client, old_iri)
+        assert succ_iri in (info.get("replaced_by_iris") or []), info
+
+
+class TestSingleCurrentInvariant:
+    def test_second_current_row_is_rejected(self, client: TestClient, db_session):
+        """The partial unique index allows only one is_current=true row per IRI.
+
+        Declared with both postgresql_where and sqlite_where so the invariant is
+        enforced (and testable) on the SQLite test DB, not only Postgres.
+        """
+        from sqlalchemy.exc import IntegrityError
+        from src.db_models.concept_versions import ConceptVersionDb
+
+        iri = f"urn:glossary:test/{uuid.uuid4().hex[:8]}"
+        db_session.add(ConceptVersionDb(iri=iri, version=1, is_current=True, status="active"))
+        db_session.commit()
+
+        # A second is_current row for the same IRI must be rejected.
+        db_session.add(ConceptVersionDb(iri=iri, version=2, is_current=True, status="active"))
+        with pytest.raises(IntegrityError):
+            db_session.commit()
+        db_session.rollback()
+
+        # A second NON-current version for the same IRI is allowed.
+        db_session.add(ConceptVersionDb(iri=iri, version=2, is_current=False, status="superseded"))
+        db_session.commit()

--- a/src/backend/src/tests/integration/test_versioning_gaps.py
+++ b/src/backend/src/tests/integration/test_versioning_gaps.py
@@ -1,0 +1,230 @@
+"""Gap-coverage tests for the concept-versioning engine.
+
+Complements test_concept_versioning.py with the cases the E2E test plan
+(`.claude/notes/ontos_versioning_e2e_test_plan.md`, "Gaps worth adding") flagged
+as not yet covered programmatically:
+
+- Row 3-F  — the served hot graph is built current-only: history triples exist in
+             the store but NEVER enter the graph (read-isolation at the repo/build
+             layer, not just via the concept-detail read).
+- Row 18-P — Simple/Advanced contract invariant: every versioning read carries a
+             human ``label`` so the Simple view never has to resolve a raw IRI.
+- Row 11-N — negative import path: malformed RDF is rejected (400) and the target
+             scheme's existing triples are left untouched (no partial apply).
+
+Same local fixtures as test_concept_versioning.py (no shared integration conftest).
+"""
+import io
+import uuid
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.app import app
+from src.controller.semantic_models_manager import SemanticModelsManager
+from src.common.app_state import set_app_state_manager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — mirror test_concept_versioning.py (per-file, no shared conftest).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def semantic_models_manager(db_session: Session, tmp_path: Path):
+    data_dir = tmp_path / "sm_data"
+    (data_dir / "cache").mkdir(parents=True, exist_ok=True)
+    (data_dir / "taxonomies").mkdir(parents=True, exist_ok=True)
+
+    manager = SemanticModelsManager(db=db_session, data_dir=data_dir)
+    app.state.semantic_models_manager = manager
+    set_app_state_manager("semantic_models_manager", manager)
+
+    class _NoopOSM:
+        def sync_asset_types(self, *_args, **_kwargs):
+            return {"created": 0, "updated": 0}
+
+    app.state.ontology_schema_manager = _NoopOSM()
+
+    class _NoopAudit:
+        def log_action(self, *_args, **_kwargs):
+            return None
+
+        def log_event(self, *_args, **_kwargs):
+            return None
+
+    app.state.audit_manager = _NoopAudit()
+
+    yield manager
+
+    for attr in ("semantic_models_manager", "ontology_schema_manager", "audit_manager"):
+        if hasattr(app.state, attr):
+            delattr(app.state, attr)
+
+
+@pytest.fixture
+def make_collection(client: TestClient, semantic_models_manager):
+    def _make(label_prefix: str = "Gap Coll", collection_type: str = "glossary",
+              description: str = "made by gap test"):
+        label = f"{label_prefix} {uuid.uuid4().hex[:8]}"
+        r = client.post("/api/knowledge/collections", json={
+            "label": label,
+            "collection_type": collection_type,
+            "scope_level": "enterprise",
+            "description": description,
+        })
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    return _make
+
+
+def _make_concept(client: TestClient, collection_iri: str, label: str, definition: str) -> str:
+    r = client.post("/api/knowledge/concepts", json={
+        "collection_iri": collection_iri,
+        "label": label,
+        "definition": definition,
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    iri = body.get("iri") or (body.get("concept") or {}).get("iri")
+    assert iri, f"could not resolve created concept IRI from {body}"
+    return iri
+
+
+def _publish(client: TestClient, iri: str, definition: str) -> None:
+    r = client.post("/api/semantic-models/concepts/version/publish", json={
+        "iri": iri, "changes": {"definition": definition},
+    })
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# Row 3-F — served graph is current-only; history never enters it.
+# ---------------------------------------------------------------------------
+
+
+class TestServedGraphExcludesHistory:
+    def test_list_current_drops_history_keeps_unowned(
+        self, client: TestClient, make_collection, semantic_models_manager, db_session
+    ):
+        """After a publish, the repo's list_current (the ONLY reader that builds
+        the served hot graph) must exclude the superseded version's triples while
+        keeping unowned metadata triples. This is read-isolation at the build
+        layer — the guarantee the whole 'reads carry no version predicate' rests
+        on, tested independently of the concept-detail read path."""
+        from src.repositories.rdf_triples_repository import rdf_triples_repo
+
+        coll = make_collection("Gap GraphIso")
+        iri = _make_concept(client, coll["iri"], "Churn", "v1 definition text")
+        _publish(client, iri, "v2 definition text")
+
+        current = rdf_triples_repo.list_current(db_session)
+        current_objs = {str(t.object_value) for t in current}
+        # The current definition is in the served set; the superseded one is not.
+        assert "v2 definition text" in current_objs
+        assert "v1 definition text" not in current_objs
+
+        # Unowned metadata (the collection/scheme itself) still loads — the
+        # LEFT JOIN keeps concept_version_id IS NULL rows.
+        current_subjects = {str(t.subject_uri) for t in current}
+        assert coll["iri"] in current_subjects, (
+            "collection/scheme metadata (unowned triples) must still load into the graph"
+        )
+
+    def test_rebuilt_graph_has_no_history_triple(
+        self, client: TestClient, make_collection, semantic_models_manager
+    ):
+        """Rebuild the in-memory graph from current-only and confirm the old
+        definition literal is absent from the served graph entirely."""
+        coll = make_collection("Gap GraphRebuild")
+        iri = _make_concept(client, coll["iri"], "Margin", "old margin definition")
+        _publish(client, iri, "new margin definition")
+
+        semantic_models_manager.rebuild_graph_from_enabled()
+        graph = semantic_models_manager._graph
+        all_literals = {str(o) for _, _, o in graph}
+        assert "new margin definition" in all_literals
+        assert "old margin definition" not in all_literals, (
+            "superseded (history) triple leaked into the served graph"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Row 18-P — Simple/Advanced contract: version reads always carry a label.
+# ---------------------------------------------------------------------------
+
+
+class TestSimpleViewLabelInvariant:
+    def test_version_info_always_has_label(
+        self, client: TestClient, make_collection
+    ):
+        """The Simple view must never resolve a raw IRI, so the version-info
+        payload MUST carry a human `label` (and version rows exist)."""
+        coll = make_collection("Gap Label")
+        iri = _make_concept(client, coll["iri"], "Revenue", "money in")
+        _publish(client, iri, "money in, recognized")
+
+        r = client.get(
+            f"/api/semantic-models/concepts/version?iri={quote(iri, safe='')}"
+        )
+        assert r.status_code == 200, r.text
+        info = r.json()
+        assert info.get("label"), f"version-info must carry a label, got {info!r}"
+        assert info["label"] != iri, "label should be the human name, not the IRI"
+        assert len(info.get("versions", [])) == 2
+
+    def test_publish_response_has_label(self, client: TestClient, make_collection):
+        """Publish response carries label + integer version (Advanced) — Simple
+        view uses the label, hides the integer; the payload must supply both."""
+        coll = make_collection("Gap PubLabel")
+        iri = _make_concept(client, coll["iri"], "Cost Center", "a cost bucket")
+        r = client.post("/api/semantic-models/concepts/version/publish", json={
+            "iri": iri, "changes": {"definition": "a cost allocation bucket"},
+        })
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body.get("label"), f"publish response must carry a label: {body!r}"
+        assert body.get("new_version") == 2
+
+
+# ---------------------------------------------------------------------------
+# Row 11-N — malformed import is rejected and leaves the store untouched.
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedImportRejected:
+    def test_bad_rdf_returns_400_and_leaves_store_intact(
+        self, client: TestClient, make_collection
+    ):
+        """Uploading malformed RDF into a collection must fail with 400 and NOT
+        partially apply — the collection's concept_count is unchanged."""
+        coll = make_collection("Gap BadImport")
+        # Seed one real concept so we can prove the store is untouched.
+        _make_concept(client, coll["iri"], "Seed", "a seed concept")
+
+        before = client.get(f"/api/knowledge/collections/{quote(coll['iri'], safe='')}")
+        assert before.status_code == 200, before.text
+        count_before = before.json().get("concept_count")
+
+        # Undefined `ex:` prefix on a terminated statement — a hard parse error
+        # that survives the truncated-turtle cleanup (mirrors versioning_invalid.ttl).
+        bad = (
+            "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\n"
+            'ex:Customer a rdfs:Class ;\n    rdfs:label "Customer"@en .\n'
+        )
+        files = {"file": ("bad.ttl", io.BytesIO(bad.encode()), "text/turtle")}
+        r = client.post(
+            f"/api/knowledge/collections/{quote(coll['iri'], safe='')}/import",
+            files=files,
+        )
+        assert r.status_code == 400, f"malformed import must 400, got {r.status_code}: {r.text}"
+
+        after = client.get(f"/api/knowledge/collections/{quote(coll['iri'], safe='')}")
+        assert after.status_code == 200, after.text
+        assert after.json().get("concept_count") == count_before, (
+            "a rejected import must not change the collection's concept_count"
+        )


### PR DESCRIPTION
## What this is

The P0 correctness core of the concept-versioning engine. Version the CONCEPT (`(iri, version)`; the IRI is the stable UC join key). Backend-only; no UI in this PR.

**DRAFT** — not review-ready until the companion versioning UI also passes E2E on top. Opened for early visibility + CI.

## What's included (P0-1/2/3/6/8)

- **P0-1 schema**: `concept_version` table (iri, version, is_current, status, parent_version_id, replaces_iri), `concept_version_id` FK on `rdf_triples`, `scheme_membership`. Partial unique index `UNIQUE(iri) WHERE is_current` makes two-current-per-iri structurally impossible. Backfill stamps existing concepts v1/current by subject-IRI ownership.
- **P0-2 write-time current/history split**: hot graph builds from current-only via `rdf_triples_current` view; reads carry NO version predicate (Lars's hard requirement). History is cold, keyed by (iri, version).
- **P0-3 atomic publish** (`POST /concepts/version/publish`): single-transaction version swap, demote-then-insert so the partial index never sees two current rows; DB-first-then-graph-patch with a rebuild recovery contract. **Snapshots the prior version's triples** so the old definition text is preserved (answers "what was the previous definition"). Migration `m4` widens `rdf_triples` uniqueness to allow per-version snapshots.
- **P0-6 safe transition**: `reference-count` (entity_semantic_links + concept→concept refs) as the retire gate; `deprecate` (writes isReplacedBy/wasRevisionOf on a 2B split); `retire` gated on refs==0 → tombstone, never hard-delete. Prior versions get status `superseded` (distinct from deprecated/retired).
- **P0-8 graph freshness**: `graph/freshness` + `graph/reload`; every write path dual-writes (DB-first-then-patch); UC-sync timing surfaced separately.

## Explicitly out of scope
- **P0-4 diff engine** (file re-upload as a versioning event) — deferred, all-or-nothing decision gated on a real power-user round-tripping ontology files.
- **Release manifests** — P2, gated on a named version-pinning consumer.
- **Versioning UI** — companion track, separate.

## Verification
- All migrations reversible; single alembic head (`m4_rdf_triple_version_uq`); chain resolves from base.
- **API-driven E2E on a deployed app + live Lakebase: 26/26** — publish→v2, history (prior=superseded), snapshot (v1 keeps old definition), read-isolation (no history leak), retire gate (real reference → 409 refused → unlink → succeeds), 2B split (isReplacedBy), tombstone-not-delete, freshness advances.
- Not E2E-testable over REST: concurrent-reader swap atomicity (verified at the repository/transaction level).

This pull request and its description were written by Isaac.