### PR TITLE
[Draft] Concept reference-reconciliation worklist — split (1→N) + merge (N→1)

### DIFF
--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -4364,9 +4364,190 @@ class SemanticModelsManager(SearchableAsset):
             "status": "retired",
         }
 
+    # -- P1-6: reference-reconciliation worklist (split 1->N / merge N->1) -----
+
+    def list_references(self, concept_iri: str) -> Dict[str, Any]:
+        """Itemized form of the retire gate (API contract §5b).
+
+        Returns the SAME set ``reference_count`` counts, broken out:
+          - ``asset_refs``: entity_semantic_links rows (physical UC/asset refs);
+          - ``concept_refs``: OTHER concepts pointing at this iri via
+            skos:broader/narrower/related or rdfs:subClassOf in the served graph;
+          - ``successors``: the dct:isReplacedBy targets already recorded by
+            ``deprecate_concept`` (lineage, NOT part of the count).
+
+        ``count`` == len(asset_refs) + len(concept_refs) == reference_count(iri),
+        so the itemized worklist and the retire gate never disagree. Every entry
+        carries a human ``label`` so the Simple view never renders a raw IRI.
+        """
+        from src.repositories.semantic_links_repository import entity_semantic_links_repo
+
+        concept = self.get_concept(concept_iri)
+        label = (concept.get("label") if concept else None) or concept_iri
+
+        # Asset refs: one row per entity_semantic_links row for this iri.
+        asset_refs = []
+        for row in entity_semantic_links_repo.list_for_iri(self._db, concept_iri):
+            entity_label = row.label
+            if not entity_label:
+                tail = (row.entity_id or "").split("#")[-1].split("/")[-1]
+                entity_label = tail.split(".")[-1] if tail else row.entity_id
+            asset_refs.append({
+                "link_id": str(row.id),
+                "entity_type": row.entity_type,
+                "entity_id": row.entity_id,
+                "entity_label": entity_label,
+            })
+
+        # Concept->concept refs: this iri appears as the OBJECT of a relationship
+        # predicate from some OTHER subject (mirrors reference_count exactly).
+        concept_uri = URIRef(concept_iri)
+        ref_predicates = (
+            (SKOS.broader, "broader"),
+            (SKOS.narrower, "narrower"),
+            (SKOS.related, "related"),
+            (RDFS.subClassOf, "subClassOf"),
+        )
+        concept_refs = []
+        for pred, pred_name in ref_predicates:
+            for subj in self._graph.subjects(pred, concept_uri):
+                if str(subj) == concept_iri:  # self-reference doesn't count
+                    continue
+                other = self.get_concept(str(subj))
+                concept_refs.append({
+                    "iri": str(subj),
+                    "label": (other.get("label") if other else None) or str(subj),
+                    "predicate": pred_name,
+                })
+
+        # Successors: recorded isReplacedBy targets (lineage, not part of count).
+        successors = []
+        for o in self._graph.objects(concept_uri, DCT.isReplacedBy):
+            succ = self.get_concept(str(o))
+            successors.append({
+                "iri": str(o),
+                "label": (succ.get("label") if succ else None) or str(o),
+            })
+
+        return {
+            "iri": concept_iri,
+            "label": label,
+            "count": len(asset_refs) + len(concept_refs),
+            "asset_refs": asset_refs,
+            "concept_refs": concept_refs,
+            "successors": successors,
+        }
+
+    def repoint_reference(
+        self,
+        link_id: str,
+        from_iri: str,
+        to_iri: str,
+        actor: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Move ONE entity_semantic_links row from ``from_iri`` to ``to_iri`` (§5b).
+
+        The unit action that composes for both split and merge. Reuses the
+        SemanticLinksManager remove+add path so the graph side-effects fire
+        (``remove_entity_semantic_link_from_graph`` / ``add_...`` + cache
+        invalidation) — the served graph stays fresh, no ref is silently dropped.
+
+        - No-op if ``from_iri == to_iri`` (idempotent-safe).
+        - Raises ValueError (→404) if the link is missing or does not currently
+          point at ``from_iri``.
+        """
+        from uuid import UUID
+        from src.repositories.semantic_links_repository import entity_semantic_links_repo
+        from src.controller.semantic_links_manager import SemanticLinksManager
+        from src.models.semantic_links import EntitySemanticLinkCreate
+
+        try:
+            link_uuid = UUID(str(link_id))
+        except (ValueError, AttributeError):
+            raise ValueError(f"Link not found: {link_id}")
+
+        row = entity_semantic_links_repo.get(self._db, id=link_uuid)
+        if row is None:
+            raise ValueError(f"Link not found: {link_id}")
+        if row.iri != from_iri:
+            raise ValueError(
+                f"Link {link_id} does not point at {from_iri} (points at {row.iri})"
+            )
+
+        # Idempotent no-op: already at the target.
+        if from_iri == to_iri:
+            to_concept = self.get_concept(to_iri)
+            return {
+                "link_id": str(link_id),
+                "to_iri": to_iri,
+                "to_label": (to_concept.get("label") if to_concept else None) or to_iri,
+            }
+
+        entity_id, entity_type = row.entity_id, row.entity_type
+
+        links_manager = SemanticLinksManager(self._db, semantic_models_manager=self)
+        # remove old (graph side-effect + cache invalidation), then add new.
+        links_manager.remove(link_id, removed_by=actor)
+        created = links_manager.add(
+            EntitySemanticLinkCreate(entity_id=entity_id, entity_type=entity_type, iri=to_iri),
+            created_by=actor,
+        )
+
+        to_concept = self.get_concept(to_iri)
+        return {
+            "link_id": created.id,
+            "to_iri": to_iri,
+            "to_label": (to_concept.get("label") if to_concept else None) or to_iri,
+        }
+
+    def merge_concepts(
+        self,
+        source_iris: List[str],
+        target_iri: str,
+        repoint_refs: bool = True,
+        actor: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Merge N sources into one target (API contract §5b, N->1 convenience).
+
+        For each source: if ``repoint_refs``, repoint ALL its asset refs to the
+        target; then ``deprecate_concept(source, replaced_by=[target])``. This is
+        purely a composition of the repoint + deprecate primitives — it invents NO
+        new lineage predicates. Sources become resolvable deprecated tombstones-in-
+        waiting (retire still gated on 0 refs).
+        """
+        from src.repositories.semantic_links_repository import entity_semantic_links_repo
+
+        merged = []
+        for source_iri in source_iris:
+            if source_iri == target_iri:
+                continue  # a concept can't merge into itself
+            refs_repointed = 0
+            if repoint_refs:
+                # Snapshot the link ids first; repoint mutates the row set.
+                link_ids = [
+                    str(r.id)
+                    for r in entity_semantic_links_repo.list_for_iri(self._db, source_iri)
+                ]
+                for lid in link_ids:
+                    self.repoint_reference(lid, source_iri, target_iri, actor=actor)
+                    refs_repointed += 1
+            self.deprecate_concept(
+                concept_iri=source_iri,
+                replaced_by=[target_iri],
+                deprecated_by=actor,
+            )
+            merged.append({"source_iri": source_iri, "refs_repointed": refs_repointed})
+
+        target = self.get_concept(target_iri)
+        return {
+            "target_iri": target_iri,
+            "target_label": (target.get("label") if target else None) or target_iri,
+            "merged": merged,
+        }
+
     def delete_concept(self, concept_iri: str, deleted_by: Optional[str] = None) -> bool:
         """Delete a concept.
-        
+
         Only concepts with status 'draft' can be deleted.
         Published concepts should be deprecated instead.
         """

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -4499,11 +4499,31 @@ class SemanticModelsManager(SearchableAsset):
         # remove old (graph side-effect + cache invalidation), then add new.
         # Pass the UUID object (not the str) so the GUID column's SQLite emulation
         # can bind it — the delete route's string path only works on Postgres.
+        #
+        # Safety: this is remove-then-add across two operations (no single txn).
+        # The whole point of this feature is "never silently drop a reference",
+        # so if the add fails after the remove we restore the original link
+        # (pointing back at from_iri) and re-raise, rather than leave the ref
+        # orphaned. A repoint either fully moves or fully rolls back.
         links_manager.remove(link_uuid, removed_by=actor)
-        created = links_manager.add(
-            EntitySemanticLinkCreate(entity_id=entity_id, entity_type=entity_type, iri=to_iri),
-            created_by=actor,
-        )
+        try:
+            created = links_manager.add(
+                EntitySemanticLinkCreate(entity_id=entity_id, entity_type=entity_type, iri=to_iri),
+                created_by=actor,
+            )
+        except Exception:
+            logger.error(
+                "repoint_reference: add to %s failed after removing link from %s; "
+                "restoring the original reference", to_iri, from_iri, exc_info=True,
+            )
+            try:
+                links_manager.add(
+                    EntitySemanticLinkCreate(entity_id=entity_id, entity_type=entity_type, iri=from_iri),
+                    created_by=actor,
+                )
+            except Exception:
+                logger.error("repoint_reference: restore of original link ALSO failed", exc_info=True)
+            raise
 
         to_concept = self.get_concept(to_iri)
         return {

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -4497,7 +4497,9 @@ class SemanticModelsManager(SearchableAsset):
 
         links_manager = SemanticLinksManager(self._db, semantic_models_manager=self)
         # remove old (graph side-effect + cache invalidation), then add new.
-        links_manager.remove(link_id, removed_by=actor)
+        # Pass the UUID object (not the str) so the GUID column's SQLite emulation
+        # can bind it — the delete route's string path only works on Postgres.
+        links_manager.remove(link_uuid, removed_by=actor)
         created = links_manager.add(
             EntitySemanticLinkCreate(entity_id=entity_id, entity_type=entity_type, iri=to_iri),
             created_by=actor,

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -4483,6 +4483,16 @@ class SemanticModelsManager(SearchableAsset):
                 "to_label": (to_concept.get("label") if to_concept else None) or to_iri,
             }
 
+        # Editable-scheme gate: the target concept's collection must be editable.
+        to_concept_pre = self.get_concept(to_iri)
+        if not to_concept_pre:
+            raise ValueError(f"Target concept not found: {to_iri}")
+        to_collection_iri = to_concept_pre.get("source_context")
+        if to_collection_iri:
+            to_collection = self.get_collection(to_collection_iri)
+            if to_collection and not to_collection.get("is_editable"):
+                raise ValueError(f"Target collection is not editable: {to_collection_iri}")
+
         entity_id, entity_type = row.entity_id, row.entity_type
 
         links_manager = SemanticLinksManager(self._db, semantic_models_manager=self)

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -103,6 +103,72 @@ class RetireConceptResponse(BaseModel):
     status: str
 
 
+# --- Reference-reconciliation worklist models (API contract §5b, split + merge) ---
+class AssetRefEntry(BaseModel):
+    """One entity_semantic_links row referencing a concept."""
+    link_id: str
+    entity_type: str
+    entity_id: str
+    entity_label: Optional[str] = None
+
+
+class ConceptRefEntry(BaseModel):
+    """Another concept pointing at this concept in the served graph."""
+    iri: str
+    label: str
+    predicate: str
+
+
+class SuccessorEntry(BaseModel):
+    """A recorded isReplacedBy target (successor) of this concept."""
+    iri: str
+    label: str
+
+
+class ConceptReferencesResponse(BaseModel):
+    """GET /semantic-models/concepts/references — itemized retire-gate set (§5b).
+
+    ``count`` equals reference_count(iri): the same asset + concept->concept set
+    the retire gate counts. label present so Simple never shows a raw IRI."""
+    iri: str
+    label: str
+    count: int
+    asset_refs: List[AssetRefEntry] = Field(default_factory=list)
+    concept_refs: List[ConceptRefEntry] = Field(default_factory=list)
+    successors: List[SuccessorEntry] = Field(default_factory=list)
+
+
+class RepointReferenceRequest(BaseModel):
+    """POST /semantic-models/concepts/references/repoint."""
+    link_id: str = Field(..., min_length=1)
+    from_iri: str = Field(..., min_length=1)
+    to_iri: str = Field(..., min_length=1)
+
+
+class RepointReferenceResponse(BaseModel):
+    link_id: str
+    to_iri: str
+    to_label: Optional[str] = None
+
+
+class MergeConceptsRequest(BaseModel):
+    """POST /semantic-models/concepts/merge (N->1 convenience: repoint + deprecate)."""
+    source_iris: List[str] = Field(..., min_length=1)
+    target_iri: str = Field(..., min_length=1)
+    repoint_refs: bool = Field(True, description="Repoint each source's asset refs to target before deprecating")
+
+
+class MergedSourceEntry(BaseModel):
+    source_iri: str
+    refs_repointed: int
+
+
+class MergeConceptsResponse(BaseModel):
+    target_iri: str
+    target_label: Optional[str] = None
+    merged: List[MergedSourceEntry] = Field(default_factory=list)
+
+
 # --- Graph freshness (API contract §6, signed off) ---
 class GraphFreshnessResponse(BaseModel):
     """Served in-memory graph freshness. UI shows 'last refreshed HH:MM, N

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -1006,6 +1006,98 @@ async def retire_concept(
         raise HTTPException(status_code=500, detail="Failed to retire concept")
 
 
+# --- Reference-reconciliation worklist routes (API contract §5b) ---
+@router.get(
+    '/semantic-models/concepts/references',
+    response_model=ConceptReferencesResponse,
+)
+async def list_concept_references(
+    concept_iri: str = Query(..., alias="iri", min_length=1, description="Concept IRI"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY)),
+) -> ConceptReferencesResponse:
+    """Itemized references to a concept — the split/merge worklist source (§5b).
+
+    Same set the retire gate counts (asset_refs + concept_refs), plus the
+    recorded successors. ``count`` equals reference-count.
+    """
+    try:
+        return ConceptReferencesResponse(**manager.list_references(concept_iri))
+    except Exception:
+        logger.error("Error listing references for %s", concept_iri, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to list concept references")
+
+
+@router.post(
+    '/semantic-models/concepts/references/repoint',
+    response_model=RepointReferenceResponse,
+)
+async def repoint_concept_reference(
+    body: RepointReferenceRequest,
+    current_user: CurrentUserDep,
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE)),
+) -> RepointReferenceResponse:
+    """Move one entity_semantic_links row from from_iri to to_iri (§5b).
+
+    Remove old + add new via the links manager so graph side-effects fire; no ref
+    silently dropped. Idempotent if from_iri == to_iri. 404 if the link is missing
+    or does not point at from_iri. Gated on to_iri's collection being editable.
+    """
+    try:
+        result = manager.repoint_reference(
+            link_id=body.link_id,
+            from_iri=body.from_iri,
+            to_iri=body.to_iri,
+            actor=current_user.email,
+        )
+        return RepointReferenceResponse(**result)
+    except ValueError as e:
+        msg = str(e)
+        if "not found" in msg.lower() or "does not point" in msg.lower():
+            raise HTTPException(status_code=404, detail=msg)
+        raise HTTPException(status_code=400, detail=msg)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Error repointing reference %s", body.link_id, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to repoint reference")
+
+
+@router.post(
+    '/semantic-models/concepts/merge',
+    response_model=MergeConceptsResponse,
+)
+async def merge_concepts(
+    body: MergeConceptsRequest,
+    current_user: CurrentUserDep,
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE)),
+) -> MergeConceptsResponse:
+    """Merge N sources into one target (§5b): repoint each source's refs to target
+    (if repoint_refs), then deprecate the source with replaced_by=[target].
+
+    Convenience composing the repoint + deprecate primitives; no new lineage
+    semantics. Editable gate enforced per-repoint (target collection) and by
+    deprecate (source collection).
+    """
+    try:
+        result = manager.merge_concepts(
+            source_iris=body.source_iris,
+            target_iri=body.target_iri,
+            repoint_refs=body.repoint_refs,
+            actor=current_user.email,
+        )
+        return MergeConceptsResponse(**result)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Error merging concepts into %s", body.target_iri, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to merge concepts")
+
+
 @router.get(
     '/semantic-models/graph/freshness',
     response_model=GraphFreshnessResponse,

--- a/src/backend/src/tests/integration/test_concept_reconciliation.py
+++ b/src/backend/src/tests/integration/test_concept_reconciliation.py
@@ -231,6 +231,43 @@ class TestRepoint:
         assert r.json()["link_id"] == link_id
         assert _reference_count(client, a) == 1
 
+    def test_repoint_restores_original_link_if_add_fails(
+        self, client: TestClient, make_collection, monkeypatch
+    ):
+        """Safety: repoint is remove-then-add across two ops. If the add fails
+        after the remove, the original reference (at from_iri) must be restored,
+        never left orphaned — the whole promise of this feature."""
+        from src.controller.semantic_links_manager import SemanticLinksManager
+
+        coll = make_collection("Recon RepointRollback")
+        old = _make_concept(client, coll["iri"], "OldC", "a buyer")
+        new = _make_concept(client, coll["iri"], "NewC", "a current buyer")
+        link_id = _add_link(client, old)
+        assert _reference_count(client, old) == 1
+
+        # Force the FIRST add (the move to `new`) to blow up; the restore add
+        # (back to `old`) must still run.
+        real_add = SemanticLinksManager.add
+        calls = {"n": 0}
+
+        def flaky_add(self, payload, created_by=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("simulated add failure mid-repoint")
+            return real_add(self, payload, created_by=created_by)
+
+        monkeypatch.setattr(SemanticLinksManager, "add", flaky_add)
+
+        r = client.post("/api/semantic-models/concepts/references/repoint", json={
+            "link_id": link_id, "from_iri": old, "to_iri": new,
+        })
+        assert r.status_code == 500, r.text  # the failure surfaces, not a silent success
+
+        monkeypatch.undo()
+        # The reference was NOT dropped: it is back on `old`, and `new` has none.
+        assert _reference_count(client, old) == 1, "original reference must be restored"
+        assert _reference_count(client, new) == 0
+
 
 class TestMerge:
     def test_merge_two_sources_into_one(self, client: TestClient, make_collection):

--- a/src/backend/src/tests/integration/test_concept_reconciliation.py
+++ b/src/backend/src/tests/integration/test_concept_reconciliation.py
@@ -1,0 +1,280 @@
+"""Integration tests for the reference-reconciliation worklist (P1-6).
+
+Exercises split (1->N) + merge (N->1) reconciliation through the real REST
+routes + a real SemanticModelsManager on the shared test DB, mirroring
+test_concept_versioning.py (there is no shared integration conftest, so this
+file defines its OWN client-backed fixtures).
+
+Covers the API contract §5b Accept bullets:
+  - the references endpoint itemizes asset refs + concept refs + successors, and
+    its ``count`` equals reference_count(iri) (same set the retire gate counts);
+  - repointing the only ref off a deprecated concept drops its reference-count to
+    0 so retire then succeeds (tombstone);
+  - merging 2 sources -> 1 target leaves both sources deprecated with
+    isReplacedBy->target and 0 remaining asset refs, and the target gains them;
+  - no reference is silently dropped: every repoint is remove+add, so the target
+    ends holding the link.
+"""
+import uuid
+from pathlib import Path
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from src.app import app
+from src.controller.semantic_models_manager import SemanticModelsManager
+from src.common.app_state import set_app_state_manager
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — local, mirroring test_concept_versioning.py.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def semantic_models_manager(db_session: Session, tmp_path: Path):
+    data_dir = tmp_path / "sm_data"
+    (data_dir / "cache").mkdir(parents=True, exist_ok=True)
+    (data_dir / "taxonomies").mkdir(parents=True, exist_ok=True)
+
+    manager = SemanticModelsManager(db=db_session, data_dir=data_dir)
+    app.state.semantic_models_manager = manager
+    set_app_state_manager("semantic_models_manager", manager)
+
+    class _NoopOSM:
+        def sync_asset_types(self, *_args, **_kwargs):
+            return {"created": 0, "updated": 0}
+
+    app.state.ontology_schema_manager = _NoopOSM()
+
+    class _NoopAudit:
+        def log_action(self, *_args, **_kwargs):
+            return None
+
+        def log_event(self, *_args, **_kwargs):
+            return None
+
+    app.state.audit_manager = _NoopAudit()
+
+    yield manager
+
+    for attr in ("semantic_models_manager", "ontology_schema_manager", "audit_manager"):
+        if hasattr(app.state, attr):
+            delattr(app.state, attr)
+
+
+@pytest.fixture
+def make_collection(client: TestClient, semantic_models_manager):
+    def _make(label_prefix: str = "Recon Coll", collection_type: str = "glossary",
+              description: str = "made by reconciliation test"):
+        label = f"{label_prefix} {uuid.uuid4().hex[:8]}"
+        r = client.post("/api/knowledge/collections", json={
+            "label": label,
+            "collection_type": collection_type,
+            "scope_level": "enterprise",
+            "description": description,
+        })
+        assert r.status_code == 200, r.text
+        return r.json()
+
+    return _make
+
+
+def _make_concept(
+    client: TestClient, collection_iri: str, label: str, definition: str,
+    broader_iris: list | None = None,
+) -> str:
+    payload = {
+        "collection_iri": collection_iri,
+        "label": label,
+        "definition": definition,
+    }
+    if broader_iris:
+        payload["broader_iris"] = broader_iris
+    r = client.post("/api/knowledge/concepts", json=payload)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    iri = body.get("iri") or (body.get("concept") or {}).get("iri")
+    assert iri, f"could not resolve created concept IRI from {body}"
+    return iri
+
+
+def _add_link(client: TestClient, iri: str, entity_type: str = "uc_table") -> str:
+    entity_id = f"main.recon.tbl_{uuid.uuid4().hex[:6]}"
+    r = client.post("/api/semantic-links/", json={
+        "entity_id": entity_id,
+        "entity_type": entity_type,
+        "iri": iri,
+    })
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+def _references(client: TestClient, iri: str) -> dict:
+    r = client.get(f"/api/semantic-models/concepts/references?iri={quote(iri, safe='')}")
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _reference_count(client: TestClient, iri: str) -> int:
+    r = client.get(f"/api/semantic-models/concepts/reference-count?iri={quote(iri, safe='')}")
+    assert r.status_code == 200, r.text
+    return r.json()["count"]
+
+
+class TestListReferences:
+    def test_references_itemizes_and_count_matches_reference_count(
+        self, client: TestClient, make_collection
+    ):
+        coll = make_collection("Recon List")
+        target = _make_concept(client, coll["iri"], "Customer", "a buyer")
+        succ = _make_concept(client, coll["iri"], "Active Customer", "a current buyer")
+
+        # An asset ref on the concept.
+        link_id = _add_link(client, target)
+
+        # Deprecate WITH a successor so the response carries a successor entry.
+        dep = client.post("/api/semantic-models/concepts/deprecate", json={
+            "iri": target, "replaced_by": [succ],
+        })
+        assert dep.status_code == 200, dep.text
+
+        refs = _references(client, target)
+        assert refs["iri"] == target
+        assert refs["label"]  # human label, never a raw IRI for Simple view
+        # asset ref itemized
+        assert any(a["link_id"] == link_id for a in refs["asset_refs"]), refs
+        # successor recorded by deprecate
+        assert any(s["iri"] == succ for s in refs["successors"]), refs
+        assert all(s["label"] for s in refs["successors"])
+        # count == reference_count (same set the retire gate counts)
+        assert refs["count"] == _reference_count(client, target)
+        assert refs["count"] == len(refs["asset_refs"]) + len(refs["concept_refs"])
+
+    def test_concept_refs_itemized(self, client: TestClient, make_collection):
+        """A concept pointing at the target via broader shows up in concept_refs
+        and is included in count."""
+        coll = make_collection("Recon ConceptRef")
+        parent = _make_concept(client, coll["iri"], "Party", "an actor")
+        # child --broader--> parent (set at creation)
+        child = _make_concept(
+            client, coll["iri"], "Customer", "a buyer", broader_iris=[parent]
+        )
+
+        refs = _references(client, parent)
+        assert any(c["iri"] == child for c in refs["concept_refs"]), refs
+        assert all(c["label"] and c["predicate"] for c in refs["concept_refs"])
+        assert refs["count"] == _reference_count(client, parent)
+
+
+class TestRepoint:
+    def test_repoint_drops_ref_and_enables_retire(self, client: TestClient, make_collection):
+        """Repoint the only ref off a deprecated concept -> reference-count hits 0
+        and retire succeeds (tombstone). No ref silently dropped: target holds it."""
+        coll = make_collection("Recon Repoint")
+        old = _make_concept(client, coll["iri"], "Cust", "a buyer")
+        new = _make_concept(client, coll["iri"], "Active Cust", "a current buyer")
+
+        link_id = _add_link(client, old)
+        assert _reference_count(client, old) == 1
+
+        # Deprecate old with new as successor (the worklist entry-point).
+        client.post("/api/semantic-models/concepts/deprecate", json={
+            "iri": old, "replaced_by": [new],
+        }).raise_for_status()
+
+        # Repoint the one ref old -> new.
+        rp = client.post("/api/semantic-models/concepts/references/repoint", json={
+            "link_id": link_id, "from_iri": old, "to_iri": new,
+        })
+        assert rp.status_code == 200, rp.text
+        body = rp.json()
+        assert body["to_iri"] == new
+        assert body["to_label"]
+
+        # Old now has 0 refs; new has the ref (nothing dropped).
+        assert _reference_count(client, old) == 0
+        new_refs = _references(client, new)
+        assert len(new_refs["asset_refs"]) == 1, new_refs
+        old_refs = _references(client, old)
+        assert len(old_refs["asset_refs"]) == 0, old_refs
+
+        # Retire now succeeds (tombstone).
+        retired = client.post("/api/semantic-models/concepts/retire", json={"iri": old})
+        assert retired.status_code == 200, retired.text
+        assert retired.json()["status"] == "retired"
+
+    def test_repoint_validates_from_iri(self, client: TestClient, make_collection):
+        """A link that does not point at from_iri yields 404."""
+        coll = make_collection("Recon RepointGuard")
+        a = _make_concept(client, coll["iri"], "A", "a")
+        b = _make_concept(client, coll["iri"], "B", "b")
+        c = _make_concept(client, coll["iri"], "C", "c")
+        link_id = _add_link(client, a)  # points at A, not B
+
+        r = client.post("/api/semantic-models/concepts/references/repoint", json={
+            "link_id": link_id, "from_iri": b, "to_iri": c,
+        })
+        assert r.status_code == 404, r.text
+
+    def test_repoint_same_iri_is_noop(self, client: TestClient, make_collection):
+        coll = make_collection("Recon RepointNoop")
+        a = _make_concept(client, coll["iri"], "A", "a")
+        link_id = _add_link(client, a)
+
+        r = client.post("/api/semantic-models/concepts/references/repoint", json={
+            "link_id": link_id, "from_iri": a, "to_iri": a,
+        })
+        assert r.status_code == 200, r.text
+        assert r.json()["link_id"] == link_id
+        assert _reference_count(client, a) == 1
+
+
+class TestMerge:
+    def test_merge_two_sources_into_one(self, client: TestClient, make_collection):
+        """Merge 2 sources -> 1 target: both sources deprecated with
+        isReplacedBy->target and 0 remaining asset refs; target gains them."""
+        coll = make_collection("Recon Merge")
+        s1 = _make_concept(client, coll["iri"], "Client", "a buyer (variant 1)")
+        s2 = _make_concept(client, coll["iri"], "Buyer", "a buyer (variant 2)")
+        target = _make_concept(client, coll["iri"], "Customer", "the canonical buyer")
+
+        l1 = _add_link(client, s1)
+        l2 = _add_link(client, s2)
+        assert _reference_count(client, s1) == 1
+        assert _reference_count(client, s2) == 1
+
+        m = client.post("/api/semantic-models/concepts/merge", json={
+            "source_iris": [s1, s2], "target_iri": target, "repoint_refs": True,
+        })
+        assert m.status_code == 200, m.text
+        body = m.json()
+        assert body["target_iri"] == target
+        merged = {e["source_iri"]: e["refs_repointed"] for e in body["merged"]}
+        assert merged.get(s1) == 1 and merged.get(s2) == 1, body
+
+        # Both sources: 0 asset refs remaining, deprecated, isReplacedBy->target.
+        for s in (s1, s2):
+            assert len(_references(client, s)["asset_refs"]) == 0
+            # Concept-level status (ONTOS.status triple) is 'deprecated'. This is a
+            # different axis than the version-row lifecycle (active/superseded), so
+            # read it from the concept detail, not the version endpoint.
+            detail = client.get(
+                f"/api/semantic-models/concepts/by-iri?iri={quote(s, safe='')}"
+            ).json()
+            detail_status = detail.get("status") or (detail.get("concept") or {}).get("status")
+            assert detail_status == "deprecated", detail
+            # isReplacedBy->target lineage is recorded (version endpoint surfaces it).
+            info = client.get(
+                f"/api/semantic-models/concepts/version?iri={quote(s, safe='')}"
+            ).json()
+            assert target in (info.get("replaced_by_iris") or []), info
+
+        # Target gained both refs (nothing dropped).
+        target_refs = _references(client, target)
+        target_link_iris = {a["link_id"] for a in target_refs["asset_refs"]}
+        assert len(target_refs["asset_refs"]) == 2, target_refs
+        # the two new links (repoint = remove+add mints fresh ids) both present
+        assert len(target_link_iris) == 2


### PR DESCRIPTION
DRAFT — not for review yet. Stacked on the concept-versioning engine (databrickslabs#703); must merge AFTER it. Held from review-ready until the full stack passes E2E.

## What this is (P1-6)
The human migration surface that turns "retirement is blocked, N things still point here" into "here is exactly what to move." Backend only. Built ON TOP of the P0-6 primitives (reference-count, deprecate-with-successors, retire gate) — no new schema, no migration. General over BOTH split (1→N) and merge (N→1), per the product call: the engine's `replaced_by` was already a list, so split works; merge is the same repoint, many sources → one target.

## Endpoints (API contract §5b)
- `GET /semantic-models/concepts/references?iri=` → itemized retire-gate set: `{iri, label, count, asset_refs[], concept_refs[], successors[]}`. `count` equals the P0-6 `reference-count` (same set, asserted in a test). READ_ONLY.
- `POST /semantic-models/concepts/references/repoint` `{link_id, from_iri, to_iri}` → moves ONE reference via the links manager (remove+add, so graph side-effects fire). Validates the link points at from_iri (404 otherwise); no-op if from==to. **Rolls back** (restores the original link) if the add fails — never orphans a reference. READ_WRITE + editable-scheme gate.
- `POST /semantic-models/concepts/merge` `{source_iris[], target_iri, repoint_refs}` → N→1 convenience composing repoint + `deprecate_concept(source, replaced_by=[target])`. No new lineage predicates. READ_WRITE.

## Tests
`src/tests/integration/test_concept_reconciliation.py` — 7 tests, all green: references itemization + count-parity, repoint drops-ref-then-retire-succeeds, from_iri validation (404), no-op, merge 2→1 (both sources deprecated w/ isReplacedBy→target, refs repointed), and the repoint rollback safety case.

## Not included
- The Enrich worklist UI (separate, rides the CB v2 UI track).
- Single alembic head unchanged (`m4_rdf_triple_version_uq`); no migration.

This pull request and its description were written by Isaac.