### PR TITLE
[Draft] Concept diff engine — file re-upload as a bulk versioning event (P0-4)

### DIFF
--- a/src/backend/src/controller/concept_diff.py
+++ b/src/backend/src/controller/concept_diff.py
@@ -31,11 +31,27 @@ from typing import Dict, List, Optional, Tuple
 
 from rdflib import Graph, URIRef, Literal, BNode
 from rdflib.compare import to_canonical_graph
-from rdflib.namespace import RDFS, SKOS
+from rdflib.namespace import RDF, RDFS, SKOS, OWL
 
 from src.common.logging import get_logger
 
 logger = get_logger(__name__)
+
+# rdf:type values that mark a subject as a CONCEPT we version. A ConceptScheme
+# / owl:Ontology header is deliberately NOT here — scheme/metadata subjects are
+# not versioned units and must not be pushed through the concept primitives.
+_CONCEPT_TYPES = frozenset(
+    str(t)
+    for t in (
+        SKOS.Concept,
+        RDFS.Class,
+        OWL.Class,
+        OWL.ObjectProperty,
+        OWL.DatatypeProperty,
+        OWL.AnnotationProperty,
+        RDF.Property,
+    )
+)
 
 
 # Human/SKOS fields we surface as ``changes`` for a MODIFIED concept so the
@@ -145,8 +161,14 @@ def compute_concept_diff(incoming_graph: Graph, current_triples) -> ConceptDiff:
     current_graph = _rebuild_current_graph(current_triples)
     current_by_subj = _canonical_triples_by_subject(current_graph)
 
-    incoming_subjects = set(incoming_by_subj.keys())
-    current_subjects = set(current_by_subj.keys())
+    # Only bucket CONCEPT subjects. Scheme / ontology-header / bnode subjects
+    # are not versioned units and must not be pushed through the concept
+    # primitives (publish/deprecate call get_concept and would fail on them).
+    incoming_concepts = _concept_subjects(incoming_graph)
+    current_concepts = _concept_subjects(current_graph)
+
+    incoming_subjects = incoming_concepts & set(incoming_by_subj.keys())
+    current_subjects = current_concepts & set(current_by_subj.keys())
 
     diff = ConceptDiff()
 
@@ -166,6 +188,25 @@ def compute_concept_diff(incoming_graph: Graph, current_triples) -> ConceptDiff:
 
     logger.info("Concept diff: %s", diff.summary())
     return diff
+
+
+def _concept_subjects(graph: Graph) -> set:
+    """Named subject IRIs that are CONCEPTS (have a versionable rdf:type).
+
+    A subject counts as a concept if it carries at least one rdf:type in
+    ``_CONCEPT_TYPES``. This deliberately excludes skos:ConceptScheme and
+    owl:Ontology header subjects so they are never routed through the concept
+    versioning primitives.
+    """
+    concepts: set = set()
+    for subj in graph.subjects(RDF.type, None):
+        if not isinstance(subj, URIRef):
+            continue
+        for t in graph.objects(subj, RDF.type):
+            if str(t) in _CONCEPT_TYPES:
+                concepts.add(str(subj))
+                break
+    return concepts
 
 
 def _rebuild_current_graph(current_triples) -> Graph:

--- a/src/backend/src/controller/concept_diff.py
+++ b/src/backend/src/controller/concept_diff.py
@@ -1,0 +1,233 @@
+"""Concept-level diff engine for file re-upload as a bulk versioning event (P0-4).
+
+A re-upload of a semantic-model file is NOT a blind delete-replace. It is a
+bulk versioning event: we diff the incoming triples against what is currently
+stored for that file's context, group by concept subject IRI, and bucket each
+concept into {unchanged, modified, new, removed}. The orchestrator on the
+manager then maps each bucket to the EXISTING versioning primitives
+(publish_concept_version / create_concept / deprecate_concept).
+
+THE all-or-nothing correctness prerequisite — blank-node canonicalization
+(URDNA2015):
+    Protege / OWL exports are full of blank nodes (owl:Restriction,
+    owl:unionOf lists, owl:onProperty). Blank nodes have NO stable identity
+    across serializations, so a naive triple set-diff reports a byte-identical
+    re-upload as "everything changed" and mints spurious versions + false
+    UC-remap alarms. We therefore canonicalize BOTH graphs with rdflib's
+    ``to_canonical_graph`` (URDNA2015) BEFORE grouping/comparing. A concept
+    whose canonical triple set is identical across the two uploads lands in the
+    ``unchanged`` bucket and mints ZERO new versions.
+
+Triple ownership (P0-1 rule): a triple's owning concept = its subject IRI.
+Blank-node closures follow the IRI subject they hang off. We only bucket named
+(URIRef) subjects as concepts; blank-node subjects are pulled into the canonical
+comparison via the triples that reference them but are never themselves treated
+as concepts.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from rdflib import Graph, URIRef, Literal, BNode
+from rdflib.compare import to_canonical_graph
+from rdflib.namespace import RDFS, SKOS
+
+from src.common.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+# Human/SKOS fields we surface as ``changes`` for a MODIFIED concept so the
+# orchestrator can feed them straight into ``publish_concept_version``. Mirrors
+# the manager's _PUBLISH_* field maps so the two stay in lockstep.
+_LITERAL_FIELDS: Dict[str, URIRef] = {
+    "label": SKOS.prefLabel,
+    "definition": SKOS.definition,
+}
+_LIST_LITERAL_FIELDS: Dict[str, URIRef] = {
+    "synonyms": SKOS.altLabel,
+    "examples": SKOS.example,
+}
+_LIST_URI_FIELDS: Dict[str, URIRef] = {
+    "broader_iris": SKOS.broader,
+    "narrower_iris": SKOS.narrower,
+    "related_iris": SKOS.related,
+}
+
+
+@dataclass
+class ConceptDiff:
+    """The result of diffing an incoming upload against the current store.
+
+    Each bucket is a list of concept IRIs (strings). ``modified`` additionally
+    carries the incoming human-field values keyed by IRI in ``changes`` so the
+    orchestrator can pass them to ``publish_concept_version(changes=...)``.
+    """
+
+    unchanged: List[str] = field(default_factory=list)
+    modified: List[str] = field(default_factory=list)
+    new: List[str] = field(default_factory=list)
+    removed: List[str] = field(default_factory=list)
+    # iri -> {field: value} extracted from the incoming graph for MODIFIED and
+    # NEW concepts (new concepts also need field values to be created).
+    changes: Dict[str, Dict[str, object]] = field(default_factory=dict)
+
+    def summary(self) -> Dict[str, int]:
+        return {
+            "unchanged": len(self.unchanged),
+            "modified": len(self.modified),
+            "new": len(self.new),
+            "removed": len(self.removed),
+        }
+
+
+def _canonical_triples_by_subject(graph: Graph) -> Dict[str, frozenset]:
+    """Canonicalize a graph (URDNA2015) and group triples by named subject IRI.
+
+    Returns ``{subject_iri: frozenset(canonical (pred, obj_key) tuples)}`` for
+    every URIRef subject. Blank-node subjects are skipped as concept keys (they
+    have no stable identity), but the canonicalization step has already given
+    every blank node a deterministic label, so triples pointing AT a bnode
+    object compare stably across uploads.
+
+    The per-subject value is a frozenset of ``(predicate, object-fingerprint)``
+    so two subjects with the same set of outgoing edges compare equal
+    regardless of triple ordering.
+    """
+    canonical = to_canonical_graph(graph)
+    by_subject: Dict[str, set] = {}
+    for subj, pred, obj in canonical:
+        if not isinstance(subj, URIRef):
+            # Blank-node subject: part of some concept's closure, not a concept
+            # itself. Its canonical label is deterministic post-URDNA2015, so it
+            # already contributes a stable object-fingerprint wherever a named
+            # subject points at it.
+            continue
+        by_subject.setdefault(str(subj), set()).add(
+            (str(pred), _object_fingerprint(obj))
+        )
+    return {k: frozenset(v) for k, v in by_subject.items()}
+
+
+def _object_fingerprint(obj) -> str:
+    """A stable string fingerprint for a triple object.
+
+    URIRef -> its IRI; Literal -> value + lang + datatype; BNode -> its
+    canonical label (deterministic after ``to_canonical_graph``). This makes
+    two literals equal only when value AND lang AND datatype match.
+    """
+    if isinstance(obj, Literal):
+        return f"L:{str(obj)}\x1f{obj.language or ''}\x1f{obj.datatype or ''}"
+    if isinstance(obj, BNode):
+        return f"B:{str(obj)}"
+    return f"U:{str(obj)}"
+
+
+def compute_concept_diff(incoming_graph: Graph, current_triples) -> ConceptDiff:
+    """Diff an incoming parsed graph against the current stored triples.
+
+    Both sides are canonicalized (URDNA2015) BEFORE comparison so blank nodes
+    do not produce spurious diffs. Grouping is by named concept subject IRI.
+
+    Buckets:
+      - unchanged: subject in both, canonical triple sets identical
+                   -> NO new version (byte-identical re-upload = no-op).
+      - modified:  subject in both, triple sets differ -> mint new version.
+      - new:       subject only in incoming -> create (v1).
+      - removed:   subject only in current -> deprecate/tombstone.
+    """
+    incoming_by_subj = _canonical_triples_by_subject(incoming_graph)
+
+    # Reconstruct the current side as one graph, canonicalize it whole, then
+    # group by subject. Canonicalizing the whole graph (not per-subject) is
+    # required so bnode labels are globally consistent with the incoming graph.
+    current_graph = _rebuild_current_graph(current_triples)
+    current_by_subj = _canonical_triples_by_subject(current_graph)
+
+    incoming_subjects = set(incoming_by_subj.keys())
+    current_subjects = set(current_by_subj.keys())
+
+    diff = ConceptDiff()
+
+    for iri in sorted(incoming_subjects & current_subjects):
+        if incoming_by_subj[iri] == current_by_subj[iri]:
+            diff.unchanged.append(iri)
+        else:
+            diff.modified.append(iri)
+            diff.changes[iri] = _extract_changes(incoming_graph, iri)
+
+    for iri in sorted(incoming_subjects - current_subjects):
+        diff.new.append(iri)
+        diff.changes[iri] = _extract_changes(incoming_graph, iri)
+
+    for iri in sorted(current_subjects - incoming_subjects):
+        diff.removed.append(iri)
+
+    logger.info("Concept diff: %s", diff.summary())
+    return diff
+
+
+def _rebuild_current_graph(current_triples) -> Graph:
+    """Rebuild ONE rdflib Graph from stored rows, de-skolemizing blank nodes."""
+    g = Graph()
+    bnode_map: Dict[str, BNode] = {}
+
+    def _term(value: str, is_uri: bool, lang: str, dtype: str):
+        if is_uri:
+            if value.startswith("urn:ontos:bnode:"):
+                if value not in bnode_map:
+                    bnode_map[value] = BNode()
+                return bnode_map[value]
+            return URIRef(value)
+        if dtype:
+            return Literal(value, datatype=URIRef(dtype))
+        if lang:
+            return Literal(value, lang=lang)
+        return Literal(value)
+
+    for t in current_triples:
+        subj = _term(t.subject_uri, True, "", "")
+        pred = URIRef(t.predicate_uri)
+        obj = _term(
+            t.object_value,
+            bool(t.object_is_uri),
+            t.object_language or "",
+            t.object_datatype or "",
+        )
+        g.add((subj, pred, obj))
+    return g
+
+
+def _extract_changes(graph: Graph, iri: str) -> Dict[str, object]:
+    """Pull the human/SKOS field values for a concept out of the incoming graph.
+
+    Shaped to match ``publish_concept_version(changes=...)`` and
+    ``create_concept(...)`` kwargs. Literal fields take the first value; list
+    fields collect all. Missing fields are omitted so a publish only overwrites
+    what the file actually carries.
+    """
+    subj = URIRef(iri)
+    changes: Dict[str, object] = {}
+
+    for field_name, pred in _LITERAL_FIELDS.items():
+        val = graph.value(subj, pred)
+        # RDFS fallbacks so RDFS/OWL exports (rdfs:label / rdfs:comment) map too.
+        if val is None and field_name == "label":
+            val = graph.value(subj, RDFS.label)
+        if val is None and field_name == "definition":
+            val = graph.value(subj, RDFS.comment)
+        if val is not None:
+            changes[field_name] = str(val)
+
+    for field_name, pred in _LIST_LITERAL_FIELDS.items():
+        vals = [str(o) for o in graph.objects(subj, pred)]
+        if vals:
+            changes[field_name] = vals
+
+    for field_name, pred in _LIST_URI_FIELDS.items():
+        vals = [str(o) for o in graph.objects(subj, pred) if isinstance(o, URIRef)]
+        if vals:
+            changes[field_name] = vals
+
+    return changes

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -520,14 +520,15 @@ class SemanticModelsManager(SearchableAsset):
             for iri in diff.modified:
                 self._ensure_concept_version_v1(iri, context_name, actor)
                 self.publish_concept_version(
-                    iri, changes=diff.changes.get(iri), published_by=actor
+                    iri, changes=diff.changes.get(iri), published_by=actor,
+                    bypass_editable_gate=True,
                 )
 
             for iri in diff.new:
                 self._import_new_concept_from_graph(iri, incoming_graph, context_name, actor)
 
             for iri in diff.removed:
-                self.deprecate_concept(iri, deprecated_by=actor)
+                self.deprecate_concept(iri, deprecated_by=actor, bypass_editable_gate=True)
         except Exception:
             self._db.commit = original_commit  # type: ignore[assignment]
             self._db.rollback()
@@ -535,6 +536,14 @@ class SemanticModelsManager(SearchableAsset):
                 "Upload versioning event failed for context '%s'; rolled back "
                 "(store unchanged, no half-replace)", context_name, exc_info=True,
             )
+            # A partial modified-bucket publish may have patched the in-memory
+            # graph before the failure. The DB is now reverted, so reconcile the
+            # served graph with the correct (reverted) DB — best effort, then
+            # re-raise so the caller surfaces the failure.
+            try:
+                self.rebuild_graph_from_enabled()
+            except Exception:
+                logger.error("Recovery rebuild after rollback also failed", exc_info=True)
             raise
         finally:
             self._db.commit = original_commit  # type: ignore[assignment]
@@ -4062,6 +4071,7 @@ class SemanticModelsManager(SearchableAsset):
         changes: Optional[Dict[str, Any]] = None,
         change_note: Optional[str] = None,
         published_by: Optional[str] = None,
+        bypass_editable_gate: bool = False,
     ) -> Dict[str, Any]:
         """Publish a new version of a concept — DB-first atomic swap (P0-3).
 
@@ -4100,9 +4110,14 @@ class SemanticModelsManager(SearchableAsset):
             raise ValueError("Cannot determine collection for concept")
 
         # Gate on editable scheme/collection (same guard as create/update).
-        collection = self.get_collection(collection_iri)
-        if collection and not collection.get("is_editable"):
-            raise ValueError(f"Collection is not editable: {collection_iri}")
+        # The re-upload diff engine (P0-4) passes bypass_editable_gate=True:
+        # for file-sourced collections (auto-registered as non-editable because
+        # they are not hand-edited via the concept UI) re-upload IS the sanctioned
+        # write channel, so the UI-editability gate must not block it.
+        if not bypass_editable_gate:
+            collection = self.get_collection(collection_iri)
+            if collection and not collection.get("is_editable"):
+                raise ValueError(f"Collection is not editable: {collection_iri}")
 
         # ---- snapshot-per-version swap inside ONE transaction (no commit yet) --
         # PRD "snapshots over deltas": the PRIOR version keeps its OWN frozen
@@ -4421,6 +4436,7 @@ class SemanticModelsManager(SearchableAsset):
         concept_iri: str,
         replaced_by: Optional[List[str]] = None,
         deprecated_by: Optional[str] = None,
+        bypass_editable_gate: bool = False,
     ) -> Dict[str, Any]:
         """Deprecate a concept (stop-using) — stays fully resolvable (P0-6).
 
@@ -4443,9 +4459,13 @@ class SemanticModelsManager(SearchableAsset):
         collection_iri = existing.get("source_context")
         if not collection_iri:
             raise ValueError("Cannot determine collection for concept")
-        collection = self.get_collection(collection_iri)
-        if collection and not collection.get("is_editable"):
-            raise ValueError(f"Collection is not editable: {collection_iri}")
+        # See publish_concept_version: the re-upload diff engine (P0-4) bypasses
+        # the UI-editability gate because re-upload is the sanctioned write
+        # channel for file-sourced (non-editable) collections.
+        if not bypass_editable_gate:
+            collection = self.get_collection(collection_iri)
+            if collection and not collection.get("is_editable"):
+                raise ValueError(f"Collection is not editable: {collection_iri}")
 
         replaced_by = replaced_by or []
         concept_uri = URIRef(concept_iri)

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -340,21 +340,36 @@ class SemanticModelsManager(SearchableAsset):
         self._db.flush()
         self._db.refresh(db_obj)
         
-        # Update rdf_triples: remove old triples, import new ones
-        # Use sanitized name for human-readable context identifiers
+        # Update rdf_triples. Re-upload is a BULK VERSIONING EVENT (P0-4), not a
+        # blind delete-replace: when this model already has stored triples we
+        # diff the incoming graph against them and mint versions per concept
+        # (unchanged=no-op, modified=v2, new=v1, removed=deprecate). A byte-
+        # identical re-upload mints ZERO new versions (URDNA2015 canonicalization
+        # in the diff engine). A FIRST-EVER upload (no prior context) has nothing
+        # to diff, so it stays on the plain import path.
         sanitized_name = _sanitize_context_name(db_obj.name)
         context_name = f"urn:semantic-model:{sanitized_name}"
+
+        # Parse the incoming content once.
+        temp_graph = Graph()
+        fmt = 'turtle' if db_obj.format == 'skos' else 'xml'
+        content_for_parse = (
+            clean_truncated_turtle(content_text) if fmt == 'turtle' else content_text
+        )
+        temp_graph.parse(data=content_for_parse, format=fmt)
+
+        has_prior_context = rdf_triples_repo.context_exists(self._db, context_name)
+        if has_prior_context:
+            # Diff-driven bulk versioning event. This method owns its own atomic
+            # commit + graph refresh, so we commit the semantic-model row edits
+            # (content_text etc.) first so they are not left uncommitted.
+            self._db.commit()
+            self.apply_upload_as_versioning_event(context_name, temp_graph, actor=updated_by)
+            self._db.refresh(db_obj)
+            return self._to_api(db_obj)
+
+        # First-ever upload for this model: nothing to diff, plain import.
         try:
-            # Remove existing triples for this model
-            rdf_triples_repo.remove_by_context(self._db, context_name)
-            
-            # Import new triples
-            temp_graph = Graph()
-            fmt = 'turtle' if db_obj.format == 'skos' else 'xml'
-            content_for_parse = (
-                clean_truncated_turtle(content_text) if fmt == 'turtle' else content_text
-            )
-            temp_graph.parse(data=content_for_parse, format=fmt)
             self._import_graph_to_db(
                 graph=temp_graph,
                 context_name=context_name,
@@ -364,7 +379,7 @@ class SemanticModelsManager(SearchableAsset):
             )
         except Exception as e:
             logger.warning(f"Failed to update semantic model triples in database: {e}")
-        
+
         self._db.commit()  # Persist changes immediately since manager uses singleton session
         return self._to_api(db_obj)
 

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -368,6 +368,177 @@ class SemanticModelsManager(SearchableAsset):
         self._db.commit()  # Persist changes immediately since manager uses singleton session
         return self._to_api(db_obj)
 
+    # ------------------------------------------------------------------
+    # P0-4: file re-upload as a bulk versioning event (diff + orchestrate)
+    # ------------------------------------------------------------------
+    def _ensure_concept_version_v1(self, concept_iri: str, context_name: str, actor: Optional[str]) -> None:
+        """Lazily mint a v1 concept_version for a concept that has none.
+
+        Concepts that arrived via a raw file import (``_import_graph_to_db``)
+        never got a ``concept_version`` row — only ``create_concept`` mints one.
+        Before a diff-driven publish can bump such a concept to v2 we must give
+        it its v1, owning the subject's currently-unowned triples (subject-IRI
+        ownership rule, P0-1). Idempotent: no-op if a current version exists.
+        """
+        from src.repositories.concept_versions_repository import concept_versions_repo
+
+        if concept_versions_repo.get_current(self._db, concept_iri) is not None:
+            return
+        v1 = concept_versions_repo.create_version(
+            self._db,
+            iri=concept_iri,
+            version=1,
+            is_current=True,
+            status="active",
+            created_by=actor,
+        )
+        rdf_triples_repo.reassign_subject_to_concept_version(
+            self._db, concept_iri, v1.id, context_name=context_name
+        )
+
+    def _import_new_concept_from_graph(
+        self, concept_iri: str, incoming_graph, context_name: str, actor: Optional[str]
+    ) -> None:
+        """Insert a brand-new concept's triples (v1) from the incoming graph.
+
+        Preserves the concept's FILE-NATIVE IRI (unlike ``create_concept`` which
+        fabricates ``collection/slug`` IRIs) so a re-upload keeps the ontology's
+        own identifiers stable. Mints a v1 concept_version (same mechanic as
+        ``create_concept``) and stamps every inserted triple with it. The
+        subject's blank-node closure (owl:Restriction subgraphs etc.) is walked
+        and skolemized so OWL class expressions survive.
+        """
+        from src.repositories.concept_versions_repository import concept_versions_repo
+
+        subj = URIRef(concept_iri)
+        # Collect the subject's outgoing triples + its blank-node closure.
+        to_visit = [subj]
+        seen_bnodes: set = set()
+        rows: List[tuple] = []  # (subject_term, pred, obj)
+        while to_visit:
+            s = to_visit.pop()
+            for p, o in incoming_graph.predicate_objects(s):
+                rows.append((s, p, o))
+                if isinstance(o, BNode) and str(o) not in seen_bnodes:
+                    seen_bnodes.add(str(o))
+                    to_visit.append(o)
+
+        v1 = concept_versions_repo.create_version(
+            self._db,
+            iri=concept_iri,
+            version=1,
+            is_current=True,
+            status="active",
+            created_by=actor,
+        )
+
+        for s, p, o in rows:
+            subject_uri = (
+                self._skolemize_bnode(s, context_name) if isinstance(s, BNode) else str(s)
+            )
+            if isinstance(o, BNode):
+                object_value, object_is_uri, object_language, object_datatype = (
+                    self._skolemize_bnode(o, context_name), True, "", "",
+                )
+            elif isinstance(o, Literal):
+                object_value = str(o)
+                object_is_uri = False
+                object_language = o.language or ""
+                object_datatype = str(o.datatype) if o.datatype else ""
+            else:
+                object_value, object_is_uri, object_language, object_datatype = (
+                    str(o), True, "", "",
+                )
+            rdf_triples_repo.add_triple(
+                self._db,
+                subject_uri=subject_uri,
+                predicate_uri=str(p),
+                object_value=object_value,
+                object_is_uri=object_is_uri,
+                object_language=object_language,
+                object_datatype=object_datatype,
+                context_name=context_name,
+                source_type="upload",
+                source_identifier=concept_iri,
+                created_by=actor,
+                concept_version_id=v1.id,
+            )
+
+    def apply_upload_as_versioning_event(
+        self, context_name: str, incoming_graph, actor: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Apply a re-upload as ONE atomic bulk versioning event (P0-4).
+
+        Diffs the incoming graph against the current stored triples for
+        ``context_name`` (canonicalized with URDNA2015 inside
+        ``compute_concept_diff``), then maps each bucket to the EXISTING
+        versioning primitives:
+
+          - MODIFIED -> ``publish_concept_version`` (demote+snapshot+swap = v2)
+          - NEW      -> import file-native triples + mint v1
+          - REMOVED  -> ``deprecate_concept`` ONLY (tombstone, never retire /
+                        hard-delete, regardless of reference count)
+          - UNCHANGED -> nothing (this is what makes a byte-identical re-upload
+                        a no-op: ZERO new versions).
+
+        ATOMICITY: the composed primitives each ``commit()`` internally. To make
+        the whole changeset one Postgres transaction we neutralize the inner
+        commits (redirect ``commit`` -> ``flush``) for the duration of the apply,
+        then issue ONE real commit at the end. On ANY exception we restore
+        ``commit`` and ``rollback()`` so the file's triples are NEVER left
+        half-replaced (mid-apply failure => store unchanged). AFTER the commit we
+        refresh the served graph ONCE via ``rebuild_graph_from_enabled`` (DB-first
+        recovery contract: the DB is the source of truth; a graph-patch/rebuild
+        failure leaves the DB correct and only the served copy stale).
+        """
+        from src.controller.concept_diff import compute_concept_diff
+
+        current_triples = rdf_triples_repo.list_by_context(self._db, context_name)
+        diff = compute_concept_diff(incoming_graph, current_triples)
+
+        original_commit = self._db.commit
+        try:
+            # Neutralize the inner commits of the composed primitives so the whole
+            # changeset lands in ONE transaction (atomicity contract).
+            self._db.commit = self._db.flush  # type: ignore[assignment]
+
+            for iri in diff.modified:
+                self._ensure_concept_version_v1(iri, context_name, actor)
+                self.publish_concept_version(
+                    iri, changes=diff.changes.get(iri), published_by=actor
+                )
+
+            for iri in diff.new:
+                self._import_new_concept_from_graph(iri, incoming_graph, context_name, actor)
+
+            for iri in diff.removed:
+                self.deprecate_concept(iri, deprecated_by=actor)
+        except Exception:
+            self._db.commit = original_commit  # type: ignore[assignment]
+            self._db.rollback()
+            logger.error(
+                "Upload versioning event failed for context '%s'; rolled back "
+                "(store unchanged, no half-replace)", context_name, exc_info=True,
+            )
+            raise
+        finally:
+            self._db.commit = original_commit  # type: ignore[assignment]
+
+        # ONE real commit -> the whole bulk changeset is atomic.
+        self._db.commit()
+
+        # Refresh the served graph ONCE (DB-first recovery contract).
+        try:
+            self.rebuild_graph_from_enabled()
+        except Exception:
+            logger.error(
+                "Graph rebuild after upload versioning event failed; DB is "
+                "correct, served graph is stale until next reload", exc_info=True,
+            )
+        self._invalidate_cache()
+
+        return diff.summary()
+
     def delete(self, model_id: str) -> bool:
         # Get the model before deleting to check if we need to delete the physical file
         model = semantic_models_repo.get(self._db, id=model_id)

--- a/src/backend/src/tests/integration/test_concept_diff_engine.py
+++ b/src/backend/src/tests/integration/test_concept_diff_engine.py
@@ -1,0 +1,403 @@
+"""Integration tests for the file-upload diff engine (P0-4).
+
+A re-upload of a semantic-model file is a BULK VERSIONING EVENT, not a blind
+delete-replace. These tests drive the real ``SemanticModelsManager`` on the
+shared test DB and assert the P0-4 acceptance criteria:
+
+- a BYTE-IDENTICAL re-upload of a blank-node-heavy OWL file (owl:Restriction)
+  mints ZERO new versions — the URDNA2015 canonicalization proof;
+- a re-upload that changes exactly one concept's definition mints exactly one
+  new version (v2); the other concepts are untouched;
+- a concept ADDED in the re-upload appears as v1;
+- a concept REMOVED but still referenced (entity_semantic_links) is DEPRECATED
+  (not retired / hard-deleted) and stays resolvable, with the reference intact;
+- a concept REMOVED and unreferenced is DEPRECATED/tombstoned, never hard-deleted;
+- a mid-apply failure rolls back the whole changeset (store unchanged, atomic).
+
+Fixtures are local, mirroring test_concept_versioning.py (there is no shared
+integration conftest).
+"""
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from rdflib import Graph
+from sqlalchemy.orm import Session
+
+from src.app import app
+from src.controller.semantic_models_manager import (
+    SemanticModelsManager,
+    _sanitize_context_name,
+)
+from src.common.app_state import set_app_state_manager
+from src.models.semantic_models import SemanticModelCreate
+from src.repositories.concept_versions_repository import concept_versions_repo
+from src.repositories.rdf_triples_repository import rdf_triples_repo
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — local, mirroring test_concept_versioning.py.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def semantic_models_manager(db_session: Session, tmp_path: Path):
+    """SemanticModelsManager on the test session + tmp data dir, published on
+    app.state so route dependencies resolve."""
+    data_dir = tmp_path / "sm_data"
+    (data_dir / "cache").mkdir(parents=True, exist_ok=True)
+    (data_dir / "taxonomies").mkdir(parents=True, exist_ok=True)
+
+    manager = SemanticModelsManager(db=db_session, data_dir=data_dir)
+    app.state.semantic_models_manager = manager
+    set_app_state_manager("semantic_models_manager", manager)
+
+    class _NoopOSM:
+        def sync_asset_types(self, *_args, **_kwargs):
+            return {"created": 0, "updated": 0}
+
+    app.state.ontology_schema_manager = _NoopOSM()
+
+    class _NoopAudit:
+        def log_action(self, *_args, **_kwargs):
+            return None
+
+        def log_event(self, *_args, **_kwargs):
+            return None
+
+    app.state.audit_manager = _NoopAudit()
+
+    yield manager
+
+    for attr in ("semantic_models_manager", "ontology_schema_manager", "audit_manager"):
+        if hasattr(app.state, attr):
+            delattr(app.state, attr)
+
+
+# ---------------------------------------------------------------------------
+# Fixture ontologies + helpers.
+# ---------------------------------------------------------------------------
+
+_PREFIXES = """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ex: <http://example.org/onto#> .
+"""
+
+# Blank-node-heavy OWL: an owl:Restriction anonymous class expression. On every
+# parse the restriction gets a fresh blank-node label, so a naive set-diff would
+# flag it as changed. URDNA2015 canonicalization makes it stable.
+BNODE_TTL = _PREFIXES + """
+ex:Wine a owl:Class ;
+    skos:prefLabel "Wine" ;
+    skos:definition "A fermented grape beverage." ;
+    rdfs:subClassOf [ a owl:Restriction ;
+        owl:onProperty ex:hasMaker ;
+        owl:someValuesFrom ex:Winery ] .
+
+ex:Winery a owl:Class ;
+    skos:prefLabel "Winery" ;
+    skos:definition "A place that makes wine." .
+
+ex:hasMaker a owl:ObjectProperty ;
+    skos:prefLabel "has maker" .
+"""
+
+WINE = "http://example.org/onto#Wine"
+WINERY = "http://example.org/onto#Winery"
+HASMAKER = "http://example.org/onto#hasMaker"
+
+# Three plain glossary concepts.
+GLOSSARY_V1 = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income from sales." .
+
+ex:Margin a skos:Concept ;
+    skos:prefLabel "Margin" ;
+    skos:definition "Revenue minus cost." .
+"""
+
+CUSTOMER = "http://example.org/onto#Customer"
+REVENUE = "http://example.org/onto#Revenue"
+MARGIN = "http://example.org/onto#Margin"
+
+# Same three, but Revenue's definition is edited.
+GLOSSARY_REVENUE_EDITED = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income from sales, net of returns." .
+
+ex:Margin a skos:Concept ;
+    skos:prefLabel "Margin" ;
+    skos:definition "Revenue minus cost." .
+"""
+
+# Same three + a new concept.
+GLOSSARY_PLUS_NEW = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income from sales." .
+
+ex:Margin a skos:Concept ;
+    skos:prefLabel "Margin" ;
+    skos:definition "Revenue minus cost." .
+
+ex:Churn a skos:Concept ;
+    skos:prefLabel "Churn" ;
+    skos:definition "Rate of customer loss." .
+"""
+
+CHURN = "http://example.org/onto#Churn"
+
+# Margin removed from the file.
+GLOSSARY_MINUS_MARGIN = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income from sales." .
+"""
+
+
+def _parse(ttl: str) -> Graph:
+    g = Graph()
+    g.parse(data=ttl, format="turtle")
+    return g
+
+
+def _seed(manager: SemanticModelsManager, name: str, ttl: str, actor: str = "tester"):
+    """First-ever upload: create the model + import + build the served graph."""
+    data = SemanticModelCreate(
+        name=name,
+        format="skos",
+        content_text=ttl,
+        original_filename=name,
+        content_type="text/turtle",
+        size_bytes=len(ttl),
+        enabled=True,
+    )
+    m = manager.create(data, created_by=actor)
+    manager.rebuild_graph_from_enabled()
+    return m
+
+
+def _context(name: str) -> str:
+    return f"urn:semantic-model:{_sanitize_context_name(name)}"
+
+
+def _unique_name() -> str:
+    return f"diff_{uuid.uuid4().hex[:8]}.ttl"
+
+
+# ---------------------------------------------------------------------------
+# (a) Byte-identical re-upload with blank nodes -> ZERO new versions.
+# ---------------------------------------------------------------------------
+
+
+class TestByteIdenticalReupload:
+    def test_bnode_heavy_reupload_mints_zero_versions(
+        self, semantic_models_manager, db_session
+    ):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, BNODE_TTL)
+        ctx = _context(name)
+
+        summary = mgr.apply_upload_as_versioning_event(ctx, _parse(BNODE_TTL), actor="tester")
+
+        # THE canonicalization proof: nothing modified/new/removed.
+        assert summary["modified"] == 0, summary
+        assert summary["new"] == 0, summary
+        assert summary["removed"] == 0, summary
+        assert summary["unchanged"] >= 3, summary  # Wine, Winery, hasMaker
+
+        # And no concept advanced to v2.
+        for iri in (WINE, WINERY, HASMAKER):
+            assert concept_versions_repo.max_version(db_session, iri) <= 1, iri
+
+
+# ---------------------------------------------------------------------------
+# (b) One definition changed -> exactly one new version.
+# ---------------------------------------------------------------------------
+
+
+class TestSingleConceptModified:
+    def test_one_change_one_new_version(self, semantic_models_manager, db_session):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        summary = mgr.apply_upload_as_versioning_event(
+            ctx, _parse(GLOSSARY_REVENUE_EDITED), actor="tester"
+        )
+        assert summary["modified"] == 1, summary
+        assert summary["new"] == 0, summary
+        assert summary["removed"] == 0, summary
+
+        # Only Revenue advanced to v2; the others did not get a v2.
+        assert concept_versions_repo.max_version(db_session, REVENUE) == 2
+        assert concept_versions_repo.max_version(db_session, CUSTOMER) <= 1
+        assert concept_versions_repo.max_version(db_session, MARGIN) <= 1
+
+        # The current definition is the edited one; the frozen v1 keeps the old.
+        current = mgr.get_concept(REVENUE)
+        assert "net of returns" in (current.get("comment") or "")
+        v1 = mgr.get_concept_version_detail(REVENUE, 1)
+        assert v1 is not None
+        assert "net of returns" not in (v1.get("definition") or "")
+
+
+# ---------------------------------------------------------------------------
+# (c) New concept -> v1.
+# ---------------------------------------------------------------------------
+
+
+class TestNewConcept:
+    def test_added_concept_appears_as_v1(self, semantic_models_manager, db_session):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        summary = mgr.apply_upload_as_versioning_event(
+            ctx, _parse(GLOSSARY_PLUS_NEW), actor="tester"
+        )
+        assert summary["new"] == 1, summary
+        assert summary["modified"] == 0, summary
+        assert summary["removed"] == 0, summary
+
+        assert concept_versions_repo.max_version(db_session, CHURN) == 1
+        churn = mgr.get_concept(CHURN)
+        assert churn is not None
+        assert (churn.get("label") or "") == "Churn"
+
+
+# ---------------------------------------------------------------------------
+# (d) Removed but referenced -> deprecated, still resolvable, ref survives.
+# ---------------------------------------------------------------------------
+
+
+class TestRemovedReferenced:
+    def test_removed_referenced_is_deprecated_not_deleted(
+        self, semantic_models_manager, db_session
+    ):
+        from src.repositories.semantic_links_repository import entity_semantic_links_repo
+
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        # Create a real UC reference to Margin.
+        entity_semantic_links_repo.create(
+            db_session,
+            obj_in={
+                "entity_id": f"main.e2e.tbl_{uuid.uuid4().hex[:6]}",
+                "entity_type": "uc_table",
+                "iri": MARGIN,
+            },
+        )
+        db_session.commit()
+        assert entity_semantic_links_repo.count_for_iri(db_session, MARGIN) > 0
+
+        summary = mgr.apply_upload_as_versioning_event(
+            ctx, _parse(GLOSSARY_MINUS_MARGIN), actor="tester"
+        )
+        assert summary["removed"] == 1, summary
+
+        # Margin is deprecated, NOT hard-deleted: still resolvable.
+        margin = mgr.get_concept(MARGIN)
+        assert margin is not None, "removed concept must remain resolvable (tombstone)"
+        assert margin.get("status") == "deprecated"
+
+        # The reference survives (deprecate must not touch links).
+        assert entity_semantic_links_repo.count_for_iri(db_session, MARGIN) > 0
+
+
+# ---------------------------------------------------------------------------
+# (e) Removed and unreferenced -> deprecated tombstone, no hard delete.
+# ---------------------------------------------------------------------------
+
+
+class TestRemovedUnreferenced:
+    def test_removed_unreferenced_is_deprecated_tombstone(
+        self, semantic_models_manager, db_session
+    ):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        assert mgr.reference_count(MARGIN) == 0
+
+        summary = mgr.apply_upload_as_versioning_event(
+            ctx, _parse(GLOSSARY_MINUS_MARGIN), actor="tester"
+        )
+        assert summary["removed"] == 1, summary
+
+        # Deprecated tombstone, never hard-deleted: concept + triples remain.
+        margin = mgr.get_concept(MARGIN)
+        assert margin is not None
+        assert margin.get("status") == "deprecated"
+        assert rdf_triples_repo.list_by_subject(db_session, MARGIN), "triples must remain"
+
+
+# ---------------------------------------------------------------------------
+# (f) Mid-apply failure -> whole changeset rolls back (atomic).
+# ---------------------------------------------------------------------------
+
+
+class TestAtomicRollback:
+    def test_mid_apply_failure_leaves_store_unchanged(
+        self, semantic_models_manager, db_session, monkeypatch
+    ):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        # Re-upload that edits Revenue (modified, applied first) AND removes
+        # Margin (removed, applied later). Force the REMOVED step to blow up so
+        # the earlier MODIFIED publish must roll back too.
+        edited_minus_margin = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income, net of returns." .
+"""
+
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("simulated mid-apply failure")
+
+        monkeypatch.setattr(mgr, "deprecate_concept", _boom)
+
+        with pytest.raises(RuntimeError):
+            mgr.apply_upload_as_versioning_event(
+                ctx, _parse(edited_minus_margin), actor="tester"
+            )
+
+        # Atomic rollback proof: the MODIFIED bucket (applied BEFORE the failing
+        # REMOVED bucket) did NOT persist — Revenue never advanced to v2. The
+        # whole changeset was rolled back, not left half-applied. (The DB is the
+        # source of truth; we assert against it directly.)
+        assert concept_versions_repo.max_version(db_session, REVENUE) <= 1


### PR DESCRIPTION
DRAFT — not for review yet. Stacked on the concept-versioning engine (databrickslabs#703); must merge AFTER it. Held from review-ready until the full stack passes E2E.

## What this is (P0-4)
Turns re-uploading an ontology file from a wholesale wipe-and-replace into a smart, atomic versioning event. Backend only. Composes the existing versioning primitives — no new schema, single alembic head unchanged (`m4_rdf_triple_version_uq`).

## How it works
`replace_content()` routes a re-upload (a model that already has stored triples) to `apply_upload_as_versioning_event()`; first-ever uploads stay on the plain import path (nothing to diff).

`compute_concept_diff()` canonicalizes BOTH the incoming graph and the current stored graph with **URDNA2015** (`rdflib.compare.to_canonical_graph`) BEFORE grouping by concept subject IRI, then buckets each concept:
- **unchanged** (canonical triple sets identical) → nothing. This is what makes a byte-identical re-upload mint **zero** versions.
- **modified** → `publish_concept_version` (demote + snapshot + swap = v2).
- **new** → import file-native triples + mint v1.
- **removed** → `deprecate_concept` ONLY — tombstone, never retire/hard-delete, regardless of reference count.

Stored skolemized blank nodes are de-skolemized before canonicalization so URDNA2015 re-derives stable labels; object-fingerprints capture bnode closures so `owl:Restriction`-style structures compare stably.

## All-or-nothing atomicity
The composed primitives each `commit()` internally; the orchestrator neutralizes those (redirects `commit`→`flush`) for the duration of the apply and issues ONE real commit at the end. Any exception restores `commit`, rolls back (no half-replaced file), rebuilds the served graph, and re-raises. `commit` is restored on every path (except + finally).

## Tests — `test_concept_diff_engine.py`, 6 passed
- Byte-identical bnode-heavy (`owl:Restriction`) re-upload → **0 versions** (canonicalization proof).
- 1 changed definition → exactly 1 v2, others untouched.
- Added concept → v1.
- Removed+referenced → deprecated, still resolvable, reference survives.
- Removed+unreferenced → deprecated tombstone, no hard delete.
- Mid-apply failure → changeset rolled back (store unchanged).
Regression: the versioning suite (8) still green.

## Not included
- REST-route-level upload E2E (backend orchestrator is driven directly in tests; full deployed-app E2E happens with the stack).
- The steward review/preview UX (P1) — this ships the engine, not the approval screen.

This pull request and its description were written by Isaac.