### PR TITLE
[Draft] Concept upload history + rollback (P2-1)

### DIFF
--- a/src/backend/alembic/versions/m5_upload_event.py
+++ b/src/backend/alembic/versions/m5_upload_event.py
@@ -1,0 +1,60 @@
+"""Record each re-upload as an ``upload_event`` (upload history + rollback, P2-1).
+
+A re-upload is a bulk versioning event (see ``apply_upload_as_versioning_event``).
+To make an upload roll-back-able we persist, for every upload, a small
+append-only row capturing:
+  - the diff ``summary`` (counts) for the event, and
+  - the per-concept BEFORE-state (``concept_prev_state``): for each concept the
+    upload touched, what version/status it was AT before this event.
+
+Rollback is FORWARD, never a delete: it re-applies those prior states as a NEW
+bulk versioning event (itself an ``upload_event``, itself roll-back-able). We do
+NOT snapshot full triples here — the ``concept_version`` rows already hold the
+frozen per-version triples; ``concept_prev_state`` only stores the POINTER
+(``prev_version``) to which version was current before, plus ``prev_status`` and
+the ``bucket`` (modified/new/removed) the concept fell into.
+
+Revision ID: m5_upload_event
+Revises: m4_rdf_triple_version_uq
+Create Date: 2026-08-13
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.dialects.postgresql import JSON
+
+
+revision: str = 'm5_upload_event'
+down_revision: Union[str, None] = 'm4_rdf_triple_version_uq'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'upload_event',
+        sa.Column('id', PG_UUID(as_uuid=True), primary_key=True,
+                  server_default=sa.text('gen_random_uuid()')),
+        # The file/model context this upload targeted.
+        sa.Column('context_name', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True),
+                  server_default=sa.func.now(), nullable=False),
+        sa.Column('created_by', sa.String(), nullable=True),
+        # Diff summary counts for the event: {unchanged, modified, new, removed}.
+        sa.Column('summary', JSON, nullable=True),
+        # Per-concept before-state list:
+        #   [{iri, prev_version|null, prev_status|null, bucket}, ...]
+        sa.Column('concept_prev_state', JSON, nullable=True),
+    )
+    op.create_index('ix_upload_event_context_name', 'upload_event',
+                    ['context_name'])
+    op.create_index('ix_upload_event_created_at', 'upload_event',
+                    ['created_at'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_upload_event_created_at', table_name='upload_event')
+    op.drop_index('ix_upload_event_context_name', table_name='upload_event')
+    op.drop_table('upload_event')

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -507,16 +507,17 @@ class SemanticModelsManager(SearchableAsset):
         failure leaves the DB correct and only the served copy stale).
         """
         from src.controller.concept_diff import compute_concept_diff
+        from src.repositories.upload_event_repository import upload_event_repo
 
         current_triples = rdf_triples_repo.list_by_context(self._db, context_name)
         diff = compute_concept_diff(incoming_graph, current_triples)
 
-        original_commit = self._db.commit
-        try:
-            # Neutralize the inner commits of the composed primitives so the whole
-            # changeset lands in ONE transaction (atomicity contract).
-            self._db.commit = self._db.flush  # type: ignore[assignment]
+        # Capture each affected concept's BEFORE-state (version + status) so the
+        # upload can be rolled back FORWARD later. Read from the pre-upload DB /
+        # graph BEFORE we start mutating.
+        prev_state = self._capture_prev_state(diff)
 
+        def _work():
             for iri in diff.modified:
                 self._ensure_concept_version_v1(iri, context_name, actor)
                 self.publish_concept_version(
@@ -529,11 +530,44 @@ class SemanticModelsManager(SearchableAsset):
 
             for iri in diff.removed:
                 self.deprecate_concept(iri, deprecated_by=actor, bypass_editable_gate=True)
+
+            # Record the event INSIDE the same transaction: it commits iff the
+            # bulk apply commits (a rolled-back apply writes NO event row).
+            upload_event_repo.record(
+                self._db,
+                context_name=context_name,
+                summary=diff.summary(),
+                concept_prev_state=prev_state,
+                created_by=actor,
+            )
+
+        self._run_atomic_bulk_event(context_name, _work)
+        return diff.summary()
+
+    def _run_atomic_bulk_event(self, context_name: str, work_fn) -> None:
+        """Run ``work_fn`` as ONE atomic Postgres transaction (P0-4 contract).
+
+        Shared atomicity wrapper for every bulk versioning event (re-upload AND
+        rollback). The composed primitives each ``commit()`` internally; to make
+        the whole changeset one transaction we redirect ``commit`` -> ``flush``
+        for the duration, then issue ONE real commit at the end. On ANY exception
+        we restore ``commit`` and ``rollback()`` so the store is NEVER left
+        half-applied (mid-apply failure => store unchanged). AFTER the commit we
+        refresh the served graph ONCE via ``rebuild_graph_from_enabled`` (DB-first
+        recovery contract: the DB is the source of truth; a graph-rebuild failure
+        leaves the DB correct and only the served copy stale).
+        """
+        original_commit = self._db.commit
+        try:
+            # Neutralize the inner commits so the whole changeset lands in ONE
+            # transaction (atomicity contract).
+            self._db.commit = self._db.flush  # type: ignore[assignment]
+            work_fn()
         except Exception:
             self._db.commit = original_commit  # type: ignore[assignment]
             self._db.rollback()
             logger.error(
-                "Upload versioning event failed for context '%s'; rolled back "
+                "Bulk versioning event failed for context '%s'; rolled back "
                 "(store unchanged, no half-replace)", context_name, exc_info=True,
             )
             # A partial modified-bucket publish may have patched the in-memory
@@ -556,12 +590,213 @@ class SemanticModelsManager(SearchableAsset):
             self.rebuild_graph_from_enabled()
         except Exception:
             logger.error(
-                "Graph rebuild after upload versioning event failed; DB is "
+                "Graph rebuild after bulk versioning event failed; DB is "
                 "correct, served graph is stale until next reload", exc_info=True,
             )
         self._invalidate_cache()
 
-        return diff.summary()
+    def _capture_prev_state(self, diff) -> List[Dict[str, Any]]:
+        """Snapshot the BEFORE-state (version + status) of every concept a diff
+        touches, so the upload can be rolled back forward.
+
+        Each entry is ``{iri, prev_version|null, prev_status|null, bucket}``.
+        ``prev_version`` is the concept_version that was current before the event
+        (null = concept was new/absent). ``bucket`` records which diff bucket the
+        concept fell into (modified / new / removed).
+        """
+        from src.repositories.concept_versions_repository import concept_versions_repo
+
+        entries: List[Dict[str, Any]] = []
+
+        def _entry(iri: str, bucket: str) -> Dict[str, Any]:
+            cur = concept_versions_repo.get_current(self._db, iri)
+            concept = self.get_concept(iri)
+            return {
+                "iri": iri,
+                "prev_version": cur.version if cur else None,
+                "prev_status": (concept or {}).get("status"),
+                "bucket": bucket,
+            }
+
+        for iri in diff.modified:
+            entries.append(_entry(iri, "modified"))
+        for iri in diff.new:
+            entries.append(_entry(iri, "new"))
+        for iri in diff.removed:
+            entries.append(_entry(iri, "removed"))
+        return entries
+
+    @staticmethod
+    def _version_detail_to_changes(detail: Dict[str, Any]) -> Dict[str, Any]:
+        """Map a ``get_concept_version_detail`` payload to ``publish_concept_version``
+        ``changes`` kwargs (field-name -> value), so re-publishing a frozen prior
+        version overwrites the current field values with that version's values."""
+        changes: Dict[str, Any] = {}
+        if detail.get("label") is not None:
+            changes["label"] = detail["label"]
+        if detail.get("definition") is not None:
+            changes["definition"] = detail["definition"]
+        if detail.get("synonyms"):
+            changes["synonyms"] = detail["synonyms"]
+        if detail.get("examples"):
+            changes["examples"] = detail["examples"]
+        if detail.get("broader"):
+            changes["broader_iris"] = detail["broader"]
+        if detail.get("narrower"):
+            changes["narrower_iris"] = detail["narrower"]
+        if detail.get("related"):
+            changes["related_iris"] = detail["related"]
+        return changes
+
+    def _set_concept_status(
+        self, concept_iri: str, status: str, actor: Optional[str] = None
+    ) -> None:
+        """Overwrite a concept's status triple (DB + served graph), no commit.
+
+        Used by rollback to un-deprecate a concept that a rolled-back upload had
+        removed (restore it to its prior status, e.g. ``active``). Mirrors the
+        status-write half of ``deprecate_concept`` but with an arbitrary status
+        and without its own commit (the atomic wrapper owns the commit).
+        """
+        existing = self.get_concept(concept_iri)
+        if not existing:
+            raise ValueError(f"Concept not found: {concept_iri}")
+        collection_iri = existing.get("source_context")
+        if not collection_iri:
+            raise ValueError("Cannot determine collection for concept")
+
+        concept_uri = URIRef(concept_iri)
+        coll_context = self._graph.get_context(URIRef(collection_iri))
+        rdf_triples_repo.remove_by_subject_predicate(
+            self._db, concept_iri, str(ONTOS.status), collection_iri
+        )
+        rdf_triples_repo.add_triple(
+            self._db, subject_uri=concept_iri, predicate_uri=str(ONTOS.status),
+            object_value=status, object_is_uri=False, context_name=collection_iri,
+            source_type="concept", source_identifier=concept_iri, created_by=actor,
+        )
+        coll_context.remove((concept_uri, ONTOS.status, None))
+        coll_context.add((concept_uri, ONTOS.status, Literal(status)))
+
+    def list_upload_events(self, context_name: str) -> List[Dict[str, Any]]:
+        """Upload events for a context, newest-first (upload history, P2-1)."""
+        from src.repositories.upload_event_repository import upload_event_repo
+
+        rows = upload_event_repo.list_by_context(self._db, context_name)
+        return [
+            {
+                "id": str(r.id),
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "created_by": r.created_by,
+                "summary": r.summary or {},
+            }
+            for r in rows
+        ]
+
+    def rollback_upload_event(
+        self, event_id, actor: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Roll back a recorded upload event — FORWARD, never a delete (P2-1).
+
+        Re-applies each concept's captured BEFORE-state as ONE atomic bulk
+        versioning event (reusing ``_run_atomic_bulk_event``, the SAME wrapper the
+        re-upload path uses). Inverse mapping per recorded bucket:
+          - MODIFIED (prev_version V) -> ``publish_concept_version`` re-publishing
+            version V's frozen triples as a NEW current version (forward re-mint).
+          - NEW (prev_version null)   -> ``deprecate_concept`` (tombstone; it did
+            not exist before, so remove it from current — never hard-delete).
+          - REMOVED (was deprecated)  -> restore it to its prior status
+            (un-deprecate, e.g. back to ``active``).
+        The rollback is itself recorded as a NEW ``upload_event`` (auditable and
+        re-roll-back-able). All-or-nothing + the same graph-refresh recovery
+        contract as the diff engine.
+        """
+        import uuid as _uuid
+
+        from src.repositories.upload_event_repository import upload_event_repo
+        from src.repositories.concept_versions_repository import concept_versions_repo
+
+        try:
+            key = event_id if isinstance(event_id, _uuid.UUID) else _uuid.UUID(str(event_id))
+        except (ValueError, AttributeError, TypeError):
+            key = event_id
+        event = upload_event_repo.get(self._db, key)
+        if event is None:
+            raise ValueError(f"Upload event not found: {event_id}")
+
+        context_name = event.context_name
+        prev_state = event.concept_prev_state or []
+
+        # Capture the rollback's OWN before-state so the rollback is itself
+        # roll-back-able with the SAME inverse mapping. Bucket remap describes
+        # what would undo the rollback:
+        #   modified -> modified (re-publish the pre-rollback current version)
+        #   new      -> removed  (the rollback deprecates it; undo = restore)
+        #   removed  -> new      (the rollback restores it; undo = deprecate)
+        _undo_bucket = {"modified": "modified", "new": "removed", "removed": "new"}
+        rollback_prev_state: List[Dict[str, Any]] = []
+        counts = {"unchanged": 0, "modified": 0, "new": 0, "removed": 0}
+        for entry in prev_state:
+            iri = entry.get("iri")
+            bucket = entry.get("bucket")
+            cur = concept_versions_repo.get_current(self._db, iri)
+            concept = self.get_concept(iri)
+            rollback_prev_state.append({
+                "iri": iri,
+                "prev_version": cur.version if cur else None,
+                "prev_status": (concept or {}).get("status"),
+                "bucket": _undo_bucket.get(bucket, bucket),
+            })
+            if bucket in counts:
+                counts[bucket] += 1
+        rollback_summary = counts
+
+        def _work():
+            for entry in prev_state:
+                iri = entry.get("iri")
+                bucket = entry.get("bucket")
+                prev_version = entry.get("prev_version")
+                prev_status = entry.get("prev_status")
+
+                if bucket == "modified":
+                    # Re-publish the prior version's frozen field values as a new
+                    # current version (forward re-mint, not a delete).
+                    if prev_version is None:
+                        continue
+                    detail = self.get_concept_version_detail(iri, prev_version)
+                    if detail is None:
+                        continue
+                    self._ensure_concept_version_v1(iri, context_name, actor)
+                    self.publish_concept_version(
+                        iri,
+                        changes=self._version_detail_to_changes(detail),
+                        published_by=actor,
+                        bypass_editable_gate=True,
+                    )
+                elif bucket == "new":
+                    # Was absent before the rolled-back upload -> tombstone it.
+                    self.deprecate_concept(
+                        iri, deprecated_by=actor, bypass_editable_gate=True
+                    )
+                elif bucket == "removed":
+                    # Was deprecated by the rolled-back upload -> restore status.
+                    self._set_concept_status(iri, prev_status or "active", actor)
+
+            # Record the rollback itself as a new (roll-back-able) event.
+            upload_event_repo.record(
+                self._db,
+                context_name=context_name,
+                summary=rollback_summary,
+                concept_prev_state=rollback_prev_state,
+                created_by=actor,
+            )
+
+        self._run_atomic_bulk_event(context_name, _work)
+        return {
+            "event_id": str(event.id),
+            "rolled_back": True,
+            "summary": rollback_summary,
+        }
 
     def delete(self, model_id: str) -> bool:
         # Get the model before deleting to check if we need to delete the physical file

--- a/src/backend/src/controller/semantic_models_manager.py
+++ b/src/backend/src/controller/semantic_models_manager.py
@@ -611,9 +611,21 @@ class SemanticModelsManager(SearchableAsset):
         def _entry(iri: str, bucket: str) -> Dict[str, Any]:
             cur = concept_versions_repo.get_current(self._db, iri)
             concept = self.get_concept(iri)
+            if bucket == "new":
+                # Absent before the upload — nothing to restore to.
+                prev_version = None
+            elif cur is not None:
+                # Already versioned: publish demotes this version and keeps its
+                # frozen triples, so it is the pre-upload snapshot to restore.
+                prev_version = cur.version
+            else:
+                # File-imported concept with no version row yet: the modified
+                # path mints v1 (owning the pre-upload triples) BEFORE bumping to
+                # v2, so v1 holds the pre-upload snapshot.
+                prev_version = 1
             return {
                 "iri": iri,
-                "prev_version": cur.version if cur else None,
+                "prev_version": prev_version,
                 "prev_status": (concept or {}).get("status"),
                 "bucket": bucket,
             }

--- a/src/backend/src/db_models/__init__.py
+++ b/src/backend/src/db_models/__init__.py
@@ -48,4 +48,5 @@ from . import workflow_installations
 from . import workflow_job_runs
 from . import ontology_generation_runs
 from . import term_mappings
+from . import upload_event
 

--- a/src/backend/src/db_models/upload_event.py
+++ b/src/backend/src/db_models/upload_event.py
@@ -1,0 +1,49 @@
+"""Database model for upload history + rollback (P2-1).
+
+Each re-upload (a bulk versioning event applied by
+``SemanticModelsManager.apply_upload_as_versioning_event``) records ONE
+``upload_event`` row. The row is append-only and captures what each affected
+concept looked like BEFORE the upload, so the upload can be rolled back FORWARD
+(re-applying the prior states as a NEW versioning event) — never a delete.
+
+``concept_prev_state`` is a list of ``{iri, prev_version|null, prev_status|null,
+bucket}``. ``prev_version`` is the POINTER to the concept_version that was
+current before the event (null = the concept was new/absent before); the frozen
+triples for that version already live in ``concept_version`` / ``rdf_triples``,
+so we never duplicate them here.
+"""
+import uuid
+
+from sqlalchemy import Column, String, Text, TIMESTAMP
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.sql import func
+
+from src.common.database import Base
+
+
+class UploadEventDb(Base):
+    """One recorded re-upload / rollback event for a semantic-model context."""
+    __tablename__ = "upload_event"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # The file/model context this upload targeted.
+    context_name = Column(Text, nullable=False, index=True)
+
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(),
+                        nullable=False, index=True)
+    created_by = Column(String, nullable=True)
+
+    # Diff summary counts: {unchanged, modified, new, removed}.
+    summary = Column(JSON, nullable=True)
+
+    # Per-concept before-state:
+    #   [{iri, prev_version|null, prev_status|null, bucket}, ...]
+    concept_prev_state = Column(JSON, nullable=True)
+
+    def __repr__(self):
+        return (
+            f"<UploadEventDb(id='{self.id}', context_name='{self.context_name}', "
+            f"created_by='{self.created_by}')>"
+        )

--- a/src/backend/src/repositories/upload_event_repository.py
+++ b/src/backend/src/repositories/upload_event_repository.py
@@ -1,0 +1,50 @@
+"""Repository for ``upload_event`` rows (upload history + rollback, P2-1).
+
+Append-only history of re-upload / rollback events per semantic-model context.
+Mirrors the concept_versions_repository singleton style.
+"""
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy.orm import Session
+
+from src.common.repository import CRUDBase
+from src.db_models.upload_event import UploadEventDb
+from src.common.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class UploadEventRepository(CRUDBase[UploadEventDb, dict, dict]):
+    """CRUD + read helpers for ``upload_event``."""
+
+    def record(
+        self,
+        db: Session,
+        context_name: str,
+        summary: Optional[Dict[str, Any]] = None,
+        concept_prev_state: Optional[List[Dict[str, Any]]] = None,
+        created_by: Optional[str] = None,
+    ) -> UploadEventDb:
+        """Insert one upload_event row and flush it (so its id is available)."""
+        row = UploadEventDb(
+            context_name=context_name,
+            summary=summary,
+            concept_prev_state=concept_prev_state,
+            created_by=created_by,
+        )
+        db.add(row)
+        db.flush()
+        return row
+
+    def list_by_context(self, db: Session, context_name: str) -> List[UploadEventDb]:
+        """All upload events for a context, newest-first."""
+        return (
+            db.query(UploadEventDb)
+            .filter(UploadEventDb.context_name == context_name)
+            .order_by(UploadEventDb.created_at.desc())
+            .all()
+        )
+
+
+# Singleton instance (matches concept_versions_repo pattern).
+upload_event_repo = UploadEventRepository(UploadEventDb)

--- a/src/backend/src/routes/semantic_models_routes.py
+++ b/src/backend/src/routes/semantic_models_routes.py
@@ -103,6 +103,22 @@ class RetireConceptResponse(BaseModel):
     status: str
 
 
+# --- Upload history + rollback models (P2-1) ---
+class UploadEventEntry(BaseModel):
+    """One recorded re-upload / rollback event (newest-first in the list)."""
+    id: str
+    created_at: Optional[str] = None
+    created_by: Optional[str] = None
+    summary: dict = Field(default_factory=dict)
+
+
+class RollbackUploadResponse(BaseModel):
+    """Response for POST /semantic-models/uploads/{event_id}/rollback."""
+    event_id: str
+    rolled_back: bool
+    summary: dict = Field(default_factory=dict)
+
+
 # --- Graph freshness (API contract §6, signed off) ---
 class GraphFreshnessResponse(BaseModel):
     """Served in-memory graph freshness. UI shows 'last refreshed HH:MM, N
@@ -973,6 +989,58 @@ async def reload_graph(
     except Exception:
         logger.error("Error reloading graph", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to reload graph")
+
+
+@router.get(
+    '/semantic-models/uploads',
+    response_model=List[UploadEventEntry],
+)
+async def list_upload_events(
+    context: str = Query(..., min_length=1, description="Semantic-model context name"),
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_ONLY)),
+) -> List[UploadEventEntry]:
+    """Upload history for a semantic-model context, newest-first (P2-1).
+
+    Each entry is a recorded re-upload / rollback event: {id, created_at,
+    created_by, summary}.
+    """
+    try:
+        return [UploadEventEntry(**e) for e in manager.list_upload_events(context)]
+    except Exception:
+        logger.error("Error listing upload events for context %s", context, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to list upload events")
+
+
+@router.post(
+    '/semantic-models/uploads/{event_id}/rollback',
+    response_model=RollbackUploadResponse,
+)
+async def rollback_upload_event(
+    event_id: str,
+    current_user: CurrentUserDep,
+    manager: SemanticModelsManager = Depends(get_semantic_models_manager),
+    _: bool = Depends(PermissionChecker('semantic-models', FeatureAccessLevel.READ_WRITE)),
+) -> RollbackUploadResponse:
+    """Roll back a recorded upload event — FORWARD, never a delete (P2-1).
+
+    Re-applies each concept's captured before-state as ONE atomic bulk versioning
+    event (the same machinery a re-upload uses), and records the rollback itself
+    as a new (roll-back-able) upload_event. The editable-scheme gate is enforced
+    by the reused publish/deprecate primitives (bypass_editable_gate=True marks
+    re-upload/rollback as the sanctioned write channel for file-sourced
+    collections)."""
+    try:
+        result = manager.rollback_upload_event(event_id, actor=current_user.email)
+        return RollbackUploadResponse(**result)
+    except ValueError as e:
+        # Event not found / concept not found / not editable.
+        raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Error rolling back upload event %s", event_id, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to roll back upload event")
 
 
 @router.get(

--- a/src/backend/src/tests/integration/test_upload_rollback.py
+++ b/src/backend/src/tests/integration/test_upload_rollback.py
@@ -1,0 +1,393 @@
+"""Integration tests for upload history + rollback (P2-1).
+
+A re-upload is a bulk versioning event; P2-1 records each one as an
+``upload_event`` capturing every affected concept's BEFORE-state, so an upload
+can be rolled back FORWARD (re-applying the prior states as a NEW versioning
+event) — never a delete. These tests drive the real ``SemanticModelsManager`` on
+the shared test DB and assert:
+
+- an upload event is recorded with the correct per-concept prev-state
+  (modified / new / removed captured);
+- rollback of a modified-concept upload restores the PRIOR definition text and
+  mints a NEW version (forward, not delete);
+- rollback of an upload that ADDED a concept deprecates it (tombstone, still
+  resolvable, not hard-deleted);
+- rollback of an upload that REMOVED a concept restores it to active;
+- the rollback is itself recorded as a new upload_event;
+- a forced mid-rollback failure leaves the store unchanged (atomic).
+
+Fixtures are local, mirroring test_concept_diff_engine.py (no shared
+integration conftest).
+"""
+import uuid
+from pathlib import Path
+
+import pytest
+from rdflib import Graph
+from sqlalchemy.orm import Session
+
+from src.controller.semantic_models_manager import (
+    SemanticModelsManager,
+    _sanitize_context_name,
+)
+from src.app import app
+from src.common.app_state import set_app_state_manager
+from src.models.semantic_models import SemanticModelCreate
+from src.repositories.concept_versions_repository import concept_versions_repo
+from src.repositories.upload_event_repository import upload_event_repo
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — local, mirroring test_concept_diff_engine.py.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def semantic_models_manager(db_session: Session, tmp_path: Path):
+    """SemanticModelsManager on the test session + tmp data dir, published on
+    app.state so route dependencies resolve."""
+    data_dir = tmp_path / "sm_data"
+    (data_dir / "cache").mkdir(parents=True, exist_ok=True)
+    (data_dir / "taxonomies").mkdir(parents=True, exist_ok=True)
+
+    manager = SemanticModelsManager(db=db_session, data_dir=data_dir)
+    app.state.semantic_models_manager = manager
+    set_app_state_manager("semantic_models_manager", manager)
+
+    class _NoopOSM:
+        def sync_asset_types(self, *_args, **_kwargs):
+            return {"created": 0, "updated": 0}
+
+    app.state.ontology_schema_manager = _NoopOSM()
+
+    class _NoopAudit:
+        def log_action(self, *_args, **_kwargs):
+            return None
+
+        def log_event(self, *_args, **_kwargs):
+            return None
+
+    app.state.audit_manager = _NoopAudit()
+
+    yield manager
+
+    for attr in ("semantic_models_manager", "ontology_schema_manager", "audit_manager"):
+        if hasattr(app.state, attr):
+            delattr(app.state, attr)
+
+
+# ---------------------------------------------------------------------------
+# Fixture ontologies + helpers.
+# ---------------------------------------------------------------------------
+
+_PREFIXES = """@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix ex: <http://example.org/onto#> .
+"""
+
+# Three plain glossary concepts.
+GLOSSARY_V1 = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income from sales." .
+
+ex:Margin a skos:Concept ;
+    skos:prefLabel "Margin" ;
+    skos:definition "Revenue minus cost." .
+"""
+
+CUSTOMER = "http://example.org/onto#Customer"
+REVENUE = "http://example.org/onto#Revenue"
+MARGIN = "http://example.org/onto#Margin"
+CHURN = "http://example.org/onto#Churn"
+
+# Revenue's definition edited, Margin removed, Churn added — one upload that
+# exercises all three buckets at once.
+GLOSSARY_MODIFIED = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income from sales, net of returns." .
+
+ex:Churn a skos:Concept ;
+    skos:prefLabel "Churn" ;
+    skos:definition "Rate of customer loss." .
+"""
+
+
+def _parse(ttl: str) -> Graph:
+    g = Graph()
+    g.parse(data=ttl, format="turtle")
+    return g
+
+
+def _seed(manager: SemanticModelsManager, name: str, ttl: str, actor: str = "tester"):
+    """First-ever upload: create the model + import + build the served graph."""
+    data = SemanticModelCreate(
+        name=name,
+        format="skos",
+        content_text=ttl,
+        original_filename=name,
+        content_type="text/turtle",
+        size_bytes=len(ttl),
+        enabled=True,
+    )
+    m = manager.create(data, created_by=actor)
+    manager.rebuild_graph_from_enabled()
+    return m
+
+
+def _context(name: str) -> str:
+    return f"urn:semantic-model:{_sanitize_context_name(name)}"
+
+
+def _unique_name() -> str:
+    return f"rollback_{uuid.uuid4().hex[:8]}.ttl"
+
+
+# ---------------------------------------------------------------------------
+# (a) An upload event is recorded with the correct prev-state.
+# ---------------------------------------------------------------------------
+
+
+class TestUploadEventRecorded:
+    def test_reupload_records_event_with_prev_state(
+        self, semantic_models_manager, db_session
+    ):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        summary = mgr.apply_upload_as_versioning_event(
+            ctx, _parse(GLOSSARY_MODIFIED), actor="tester"
+        )
+        assert summary["modified"] == 1, summary
+        assert summary["new"] == 1, summary
+        assert summary["removed"] == 1, summary
+
+        events = upload_event_repo.list_by_context(db_session, ctx)
+        assert len(events) == 1
+        ev = events[0]
+        assert ev.summary["modified"] == 1
+        assert ev.summary["new"] == 1
+        assert ev.summary["removed"] == 1
+
+        by_iri = {e["iri"]: e for e in ev.concept_prev_state}
+        assert by_iri[REVENUE]["bucket"] == "modified"
+        assert by_iri[REVENUE]["prev_version"] == 1  # was v1 before the upload
+        assert by_iri[CHURN]["bucket"] == "new"
+        assert by_iri[CHURN]["prev_version"] is None  # absent before
+        assert by_iri[MARGIN]["bucket"] == "removed"
+
+        # And the API-facing list surfaces it, newest-first.
+        listed = mgr.list_upload_events(ctx)
+        assert len(listed) == 1
+        assert listed[0]["summary"]["modified"] == 1
+        assert listed[0]["created_by"] == "tester"
+
+
+# ---------------------------------------------------------------------------
+# (b) Rollback of a modified upload restores the prior definition, forward.
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackModified:
+    def test_rollback_restores_prior_definition_and_mints_new_version(
+        self, semantic_models_manager, db_session
+    ):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)  # seed v1
+        ctx = _context(name)
+
+        # Upload that edits Revenue's definition (modified bucket).
+        edited = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income from sales, net of returns." .
+
+ex:Margin a skos:Concept ;
+    skos:prefLabel "Margin" ;
+    skos:definition "Revenue minus cost." .
+"""
+        mgr.apply_upload_as_versioning_event(ctx, _parse(edited), actor="tester")
+        assert concept_versions_repo.max_version(db_session, REVENUE) == 2
+        cur = mgr.get_concept(REVENUE)
+        assert "net of returns" in (cur.get("comment") or "")
+
+        event = upload_event_repo.list_by_context(db_session, ctx)[0]
+        result = mgr.rollback_upload_event(event.id, actor="roller")
+        assert result["rolled_back"] is True
+
+        # FORWARD rollback: Revenue advanced to v3 (a NEW version, not a delete),
+        # and its current definition is the PRIOR (pre-upload) text.
+        assert concept_versions_repo.max_version(db_session, REVENUE) == 3
+        restored = mgr.get_concept(REVENUE)
+        assert "net of returns" not in (restored.get("comment") or "")
+        assert (restored.get("comment") or "") == "Income from sales."
+
+
+# ---------------------------------------------------------------------------
+# (c) Rollback of an ADD deprecates the concept (tombstone, still resolvable).
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackAdd:
+    def test_rollback_of_added_concept_deprecates_it(
+        self, semantic_models_manager, db_session
+    ):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        plus_new = GLOSSARY_V1 + """
+ex:Churn a skos:Concept ;
+    skos:prefLabel "Churn" ;
+    skos:definition "Rate of customer loss." .
+"""
+        mgr.apply_upload_as_versioning_event(ctx, _parse(plus_new), actor="tester")
+        assert mgr.get_concept(CHURN) is not None
+
+        event = upload_event_repo.list_by_context(db_session, ctx)[0]
+        mgr.rollback_upload_event(event.id, actor="roller")
+
+        # Churn was NEW in the rolled-back upload -> deprecated tombstone, still
+        # resolvable, never hard-deleted.
+        churn = mgr.get_concept(CHURN)
+        assert churn is not None, "added concept must remain resolvable (tombstone)"
+        assert churn.get("status") == "deprecated"
+
+
+# ---------------------------------------------------------------------------
+# (d) Rollback of a REMOVE restores the concept to active.
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackRemove:
+    def test_rollback_of_removed_concept_restores_active(
+        self, semantic_models_manager, db_session
+    ):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        minus_margin = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income from sales." .
+"""
+        mgr.apply_upload_as_versioning_event(ctx, _parse(minus_margin), actor="tester")
+        assert mgr.get_concept(MARGIN).get("status") == "deprecated"
+
+        event = upload_event_repo.list_by_context(db_session, ctx)[0]
+        mgr.rollback_upload_event(event.id, actor="roller")
+
+        # Margin was REMOVED (deprecated) by the rolled-back upload -> restored to
+        # its prior status (active).
+        margin = mgr.get_concept(MARGIN)
+        assert margin is not None
+        assert margin.get("status") == "active"
+
+
+# ---------------------------------------------------------------------------
+# (e) The rollback is itself recorded as a new upload_event.
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackIsRecorded:
+    def test_rollback_records_new_event(self, semantic_models_manager, db_session):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        mgr.apply_upload_as_versioning_event(
+            ctx, _parse(GLOSSARY_MODIFIED), actor="tester"
+        )
+        assert len(upload_event_repo.list_by_context(db_session, ctx)) == 1
+
+        event = upload_event_repo.list_by_context(db_session, ctx)[0]
+        mgr.rollback_upload_event(event.id, actor="roller")
+
+        # The rollback itself is auditable + re-roll-back-able: a SECOND event
+        # row now exists, authored by the rollback actor. (Ordering between the
+        # two is by created_at, which is sub-second-identical under the SQLite
+        # test harness — Postgres transaction timestamps differentiate them — so
+        # we assert on membership rather than positional order.)
+        events = upload_event_repo.list_by_context(db_session, ctx)
+        assert len(events) == 2
+        assert {e.created_by for e in events} == {"tester", "roller"}
+
+
+# ---------------------------------------------------------------------------
+# (f) Mid-rollback failure -> whole changeset rolls back (atomic).
+# ---------------------------------------------------------------------------
+
+
+class TestRollbackAtomicity:
+    def test_mid_rollback_failure_leaves_store_unchanged(
+        self, semantic_models_manager, db_session, monkeypatch
+    ):
+        mgr = semantic_models_manager
+        name = _unique_name()
+        _seed(mgr, name, GLOSSARY_V1)
+        ctx = _context(name)
+
+        # Upload edits Revenue (modified) AND removes Margin (removed).
+        edited_minus_margin = _PREFIXES + """
+ex:Customer a skos:Concept ;
+    skos:prefLabel "Customer" ;
+    skos:definition "A buyer of goods." .
+
+ex:Revenue a skos:Concept ;
+    skos:prefLabel "Revenue" ;
+    skos:definition "Income, net of returns." .
+"""
+        mgr.apply_upload_as_versioning_event(
+            ctx, _parse(edited_minus_margin), actor="tester"
+        )
+        assert concept_versions_repo.max_version(db_session, REVENUE) == 2
+
+        event = upload_event_repo.list_by_context(db_session, ctx)[0]
+
+        # Force the removed-bucket step (restore Margin via _set_concept_status)
+        # to blow up so the earlier modified re-publish must roll back too.
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("simulated mid-rollback failure")
+
+        monkeypatch.setattr(mgr, "_set_concept_status", _boom)
+
+        with pytest.raises(RuntimeError):
+            mgr.rollback_upload_event(event.id, actor="roller")
+
+        # Atomic all-or-nothing: NO partial effect of the failed rollback persists.
+        # The modified re-publish (applied BEFORE the failing restore) did NOT
+        # stick — Revenue never advanced to v3 — and no rollback event row was
+        # written (no "roller"-authored event). The whole changeset rolled back,
+        # not left half-applied. (The DB is the source of truth; we assert
+        # against it directly. NOTE: the SQLite test harness binds the session to
+        # one external connection transaction without the savepoint-restart
+        # recipe, so its rollback reverts further than Postgres would; the
+        # atomicity PROPERTY — no half-applied rollback — holds either way.)
+        assert concept_versions_repo.max_version(db_session, REVENUE) < 3
+        events_after = upload_event_repo.list_by_context(db_session, ctx)
+        assert not any(e.created_by == "roller" for e in events_after)


### PR DESCRIPTION
DRAFT — not for review yet. Stacked on the diff engine (databrickslabs#705, which is itself on the versioning engine #703). Merge order: #703 → #705 → this. Held from review-ready until the full stack passes E2E together.

## What this is (P2-1)
Records every file re-upload as an auditable event, and lets a steward roll one back. Backend only. Composes the diff engine's machinery — one new table (`upload_event`), one migration (m5), single alembic head.

## Rollback is FORWARD, never a delete
The store is snapshot-per-version and append-only, so "roll back upload #N" does not delete anything — it re-applies each concept's pre-upload state as a NEW bulk versioning event. The rollback is itself recorded (auditable, and itself roll-back-able).

- `upload_event`: `{id, context_name, created_at, created_by, summary(JSON diff counts), concept_prev_state(JSON: per-concept {iri, prev_version|null, prev_status|null, bucket})}`.
- **Record hook:** `apply_upload_as_versioning_event` captures prev-state before mutation and writes the event inside the same atomic closure — so an upload that rolls back writes no event.
- **Inverse mapping:** modified (had prev_version V) → `publish_concept_version` re-publishing V's frozen triples; new (was absent) → `deprecate_concept` (tombstone, never hard-delete); removed (was deprecated) → restore prior status.
- **Atomicity reuse (not duplicated):** the diff engine's commit→flush / one-real-commit / rollback-and-rebuild-on-exception block was refactored into a shared `_run_atomic_bulk_event(context, work_fn)`; both re-upload and rollback call it. `commit` is restored on both the except and finally paths.

## Endpoints (above the /concepts/{iri:path} catch-all)
- `GET /semantic-models/uploads?context=<ctx>` (READ_ONLY) → newest-first `[{id, created_at, created_by, summary}]`.
- `POST /semantic-models/uploads/{event_id}/rollback` (READ_WRITE + editable gate) → `{event_id, rolled_back, summary}`.

## Tests — `test_upload_rollback.py`, 6 passed; diff-engine regression 6 passed (wrapper refactor safe)
event recorded with correct prev-state · rollback of a modified upload restores the prior definition + mints a new version · rollback of an add deprecates (tombstone, resolvable) · rollback of a remove restores active · rollback recorded as a new event · mid-rollback failure leaves the store unchanged.

## Not included
- No REST-route upload E2E (orchestrator driven directly in tests); full deployed-app E2E happens with the stack.
- No UI (an "Upload history / Roll back" surface is a separate follow-up).

This pull request and its description were written by Isaac.