### PR TITLE
fix(backend): drop stale domain_id kwarg in Admin Team seeding

### DIFF
--- a/src/backend/src/controller/settings_manager.py
+++ b/src/backend/src/controller/settings_manager.py
@@ -949,7 +949,6 @@ class SettingsManager:
                     name='Admin Team',
                     title='Default Administrator Team',
                     description='Auto-created team for system administrators',
-                    domain_id=None,
                     extra_metadata='{}',
                     created_by='system@startup.ucapp',
                     updated_by='system@startup.ucapp'


### PR DESCRIPTION
## Problem

Startup fails after PR #597 with:

```
TypeError: 'domain_id' is an invalid keyword argument for TeamDb
... StartupSeedError: Default role/team seeding failed
```

PR #597 removed the legacy `domain_id` column from `TeamDb` (domain assignment is now polymorphic via `entity_domain_associations`, `entity_type='team'`), but `SettingsManager.ensure_default_team_and_project` still passed `domain_id=None` to the `TeamDb(...)` constructor. SQLAlchemy's declarative constructor rejects unknown kwargs, so seeding aborts and startup dies.

## Fix

Remove the stale `domain_id=None` kwarg. It was passing `None` anyway, so this is behavior-preserving. `ProjectDb` never had `domain_id`, so it's unaffected.

## Testing

- One-line deletion; startup seeding no longer raises `TypeError`.