### PR TITLE
feat(compliance-templates): admin-defined typed governance fields with mandatory enforcement (#676)

### DIFF
--- a/src/backend/alembic/versions/p1_add_compliance_templates_tables.py
+++ b/src/backend/alembic/versions/p1_add_compliance_templates_tables.py
@@ -1,0 +1,100 @@
+"""Add compliance templates tables (definition, fields, values)
+
+Revision ID: p1_compliance_templates
+Revises: l1_entity_domain_associations
+Create Date: 2026-08-13
+
+Introduces the Compliance Templates feature: an admin-defined, typed, grouped
+governance-field schema bound to an entity type, plus per-entity filled-in
+values stored polymorphically. Three tables:
+
+- compliance_templates        — template definition; at most one active per
+  (entity_type, scope_type, scope_id) via a partial unique index.
+- compliance_template_fields  — typed fields; groups denormalized onto the field.
+- compliance_template_values  — per-entity values, polymorphic + unique per field.
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+from alembic import op
+
+revision: str = "p1_compliance_templates"
+down_revision: str | None = "l1_entity_domain_associations"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "compliance_templates",
+        sa.Column("id", PG_UUID(as_uuid=True), primary_key=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("entity_type", sa.String(100), nullable=False),
+        sa.Column("scope_type", sa.String(50), nullable=False, server_default="all"),
+        sa.Column("scope_id", sa.String(255), nullable=False, server_default=""),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("created_by", sa.String(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_compliance_templates_entity_type", "compliance_templates", ["entity_type"])
+    op.create_index("ix_compliance_templates_is_active", "compliance_templates", ["is_active"])
+    # At most one ACTIVE template per (entity_type, scope_type, scope_id).
+    op.create_index(
+        "uq_compliance_template_active_scope",
+        "compliance_templates",
+        ["entity_type", "scope_type", "scope_id"],
+        unique=True,
+        postgresql_where=sa.text("is_active"),
+    )
+
+    op.create_table(
+        "compliance_template_fields",
+        sa.Column("id", PG_UUID(as_uuid=True), primary_key=True),
+        sa.Column("template_id", PG_UUID(as_uuid=True), sa.ForeignKey("compliance_templates.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("group_title", sa.String(255), nullable=False, server_default=""),
+        sa.Column("group_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("key", sa.String(255), nullable=False),
+        sa.Column("label", sa.String(255), nullable=False),
+        sa.Column("reference_id", sa.String(255), nullable=False),
+        sa.Column("value_type", sa.String(50), nullable=False),
+        sa.Column("possible_values", sa.JSON(), nullable=True),
+        sa.Column("default_value", sa.JSON(), nullable=True),
+        sa.Column("hint_text", sa.Text(), nullable=True),
+        sa.Column("is_mandatory", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("field_order", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("constraints", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("template_id", "reference_id", name="uq_compliance_field_reference_id"),
+        sa.UniqueConstraint("template_id", "key", name="uq_compliance_field_key"),
+    )
+    op.create_index("ix_compliance_template_fields_template_id", "compliance_template_fields", ["template_id"])
+
+    op.create_table(
+        "compliance_template_values",
+        sa.Column("id", PG_UUID(as_uuid=True), primary_key=True),
+        sa.Column("field_id", PG_UUID(as_uuid=True), sa.ForeignKey("compliance_template_fields.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("entity_type", sa.String(100), nullable=False),
+        sa.Column("entity_id", sa.String(255), nullable=False),
+        sa.Column("value", sa.JSON(), nullable=True),
+        sa.Column("filled_by", sa.String(), nullable=True),
+        sa.Column("filled_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("field_id", "entity_type", "entity_id", name="uq_compliance_value_field_entity"),
+    )
+    op.create_index("ix_compliance_template_values_field_id", "compliance_template_values", ["field_id"])
+    op.create_index("ix_compliance_template_values_entity_type", "compliance_template_values", ["entity_type"])
+    op.create_index("ix_compliance_template_values_entity_id", "compliance_template_values", ["entity_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("compliance_template_values")
+    op.drop_table("compliance_template_fields")
+    op.drop_index("uq_compliance_template_active_scope", table_name="compliance_templates")
+    op.drop_index("ix_compliance_templates_is_active", table_name="compliance_templates")
+    op.drop_index("ix_compliance_templates_entity_type", table_name="compliance_templates")
+    op.drop_table("compliance_templates")

--- a/src/backend/src/app.py
+++ b/src/backend/src/app.py
@@ -75,6 +75,7 @@ from src.routes import (
     readiness_routes,
     suggestion_routes,
     certification_levels_routes,
+    compliance_templates_routes,
     maturity_routes,
     directory_routes,
     term_mapping_routes,
@@ -378,6 +379,7 @@ business_lineage_routes.register_routes(app)
 readiness_routes.register_routes(app)
 suggestion_routes.register_routes(app)
 certification_levels_routes.register_routes(app)
+compliance_templates_routes.register_routes(app)
 maturity_routes.register_routes(app)
 data_asset_reviews_routes.register_routes(app)
 data_catalog_routes.register_routes(app)

--- a/src/backend/src/common/compliance_completeness.py
+++ b/src/backend/src/common/compliance_completeness.py
@@ -1,0 +1,73 @@
+"""Pure completeness validator for Compliance Templates.
+
+Given a template's fields and an entity's stored values, decides whether all
+mandatory fields are satisfied and returns a result object with human-readable
+failure messages. Pure (no DB/HTTP) so it can be exhaustively unit-tested and
+reused by both the advisory-on-edit indicator and the blocking-at-publish check.
+
+Effective-value semantics (PRD): a field's effective value is its stored value
+if present, else the field's current default. A mandatory field is satisfied if
+a valid value exists OR the field has a non-empty default.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field as dataclass_field
+from typing import Any, Optional
+
+from src.common.compliance_value_types import is_set
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    """Minimal field description the validator needs (decoupled from ORM/Pydantic)."""
+    field_id: str
+    label: str
+    value_type: str
+    is_mandatory: bool
+    default_value: Any = None
+
+
+@dataclass
+class CompletenessResult:
+    """Result of a completeness check.
+
+    ``passed`` is True when every mandatory field is satisfied. ``missing`` lists
+    the labels of unsatisfied mandatory fields; ``messages`` holds the
+    human-readable failure lines (empty when passed).
+    """
+    passed: bool
+    missing: list[str] = dataclass_field(default_factory=list)
+    messages: list[str] = dataclass_field(default_factory=list)
+
+
+def _effective_is_set(spec: FieldSpec, stored: Any, has_stored: bool) -> bool:
+    """True if the field's effective value (stored else default) counts as set."""
+    if has_stored and is_set(spec.value_type, stored):
+        return True
+    # Fall back to the field's current default.
+    return is_set(spec.value_type, spec.default_value)
+
+
+def check_completeness(
+    fields: list[FieldSpec],
+    stored_values: Optional[dict[str, Any]] = None,
+) -> CompletenessResult:
+    """Check that all mandatory fields are satisfied.
+
+    ``stored_values`` maps ``field_id`` -> stored value. A field id absent from
+    the map is treated as having no stored value (falls back to its default).
+    """
+    values = stored_values or {}
+    missing: list[str] = []
+    messages: list[str] = []
+
+    for spec in fields:
+        if not spec.is_mandatory:
+            continue
+        has_stored = spec.field_id in values
+        stored = values.get(spec.field_id)
+        if not _effective_is_set(spec, stored, has_stored):
+            missing.append(spec.label)
+            messages.append(f"'{spec.label}' is required but has no value.")
+
+    return CompletenessResult(passed=not missing, missing=missing, messages=messages)

--- a/src/backend/src/common/compliance_reconcile.py
+++ b/src/backend/src/common/compliance_reconcile.py
@@ -1,0 +1,74 @@
+"""Pure reconciler for Compliance Templates — materialization on edit.
+
+Given an active template's fields and the set of field_ids that already have
+stored rows for an entity, the reconciler decides: for each field with NO
+existing row AND a non-empty default, propose writing a default row. Existing
+rows are NEVER touched. Idempotent: running again over the post-reconcile
+field-id set yields no new actions.
+
+This module is deliberately pure (no DB/HTTP) so it can be exhaustively
+unit-tested and reused in multiple wiring contexts.
+
+See PRD #676: *Materialization, reconciliation, freezing*.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+from src.common.compliance_value_types import is_set
+
+
+@dataclass(frozen=True)
+class FieldDesc:
+    """Minimal field description the reconciler needs (decoupled from ORM/Pydantic)."""
+    field_id: UUID
+    value_type: str
+    default_value: Any = None
+
+
+@dataclass(frozen=True)
+class ReconcileAction:
+    """A single reconcile action: insert a default value for a field."""
+    field_id: UUID
+    value: Any
+
+
+def reconcile(
+    fields: list[FieldDesc],
+    existing_field_ids: set[UUID],
+) -> list[ReconcileAction]:
+    """Propose default rows for fields lacking stored values.
+
+    Args:
+        fields: All fields in the active template.
+        existing_field_ids: Set of field_ids that already have stored value rows
+                           for the entity. Fields in this set are NEVER touched.
+
+    Returns:
+        A list of ReconcileActions. Each action represents a default value that
+        should be inserted as a new row (only for fields not in existing_field_ids).
+        Existing rows are NEVER in the action set (reconcile never modifies them).
+
+    Semantics:
+        - For each field: if it has NO existing row AND a non-empty default,
+          propose a row insert.
+        - Mandatory fields with no default are left pending (no row proposed).
+        - Idempotent: running reconcile again over the post-reconcile field-id
+          set yields zero actions.
+    """
+    actions: list[ReconcileAction] = []
+
+    for field in fields:
+        # Skip fields that already have a stored row — existing rows are frozen.
+        if field.field_id in existing_field_ids:
+            continue
+
+        # Check if the field has a non-empty default.
+        if is_set(field.value_type, field.default_value):
+            actions.append(
+                ReconcileAction(field_id=field.field_id, value=field.default_value)
+            )
+
+    return actions

--- a/src/backend/src/common/compliance_value_types.py
+++ b/src/backend/src/common/compliance_value_types.py
@@ -1,0 +1,223 @@
+"""Pure value-type engine for Compliance Templates.
+
+Holds all validation/coercion and "is-set" semantics for the supported field
+value types. No database or HTTP dependencies — this module is deliberately
+pure so it can be exhaustively unit-tested (mirrors the compliance-DSL
+evaluator).
+
+Value types (see PRD *Value types*):
+
+- ``string``     — any text; empty/whitespace-only counts as unset.
+- ``numeric``    — int or float; parsed from numeric strings.
+- ``enum``       — a single value drawn from the field's controlled vocabulary.
+- ``multi_enum`` — a list (subset) of the controlled vocabulary; unset when empty.
+- ``date``       — an ISO-8601 date (``YYYY-MM-DD``); time component tolerated.
+- ``range``      — an owner-entered interval ``{"low": n, "high": n}`` with
+  ``low <= high``; unset unless BOTH bounds are present.
+- ``boolean``    — true/false; explicit ``false`` counts as SET.
+
+Coercion normalizes each accepted input to a canonical stored shape:
+
+- numeric  -> int when integral, else float
+- date     -> ``YYYY-MM-DD`` string
+- range    -> ``{"low": <num>, "high": <num>}``
+- boolean  -> bool
+- string / enum -> str
+- multi_enum -> list[str]
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from enum import Enum
+from typing import Any, Optional
+
+
+class ComplianceValueType(str, Enum):
+    """Canonical value-type identifiers, matching the Pydantic enum."""
+    STRING = "string"
+    NUMERIC = "numeric"
+    ENUM = "enum"
+    MULTI_ENUM = "multi_enum"
+    DATE = "date"
+    RANGE = "range"
+    BOOLEAN = "boolean"
+
+
+class ValueTypeError(ValueError):
+    """Raised when a value cannot be validated/coerced against its field type."""
+
+
+# Accepted string spellings for booleans (case-insensitive).
+_TRUE_STRINGS = {"true", "1", "yes", "y", "on"}
+_FALSE_STRINGS = {"false", "0", "no", "n", "off"}
+
+
+def _coerce_numeric(value: Any) -> float | int:
+    if isinstance(value, bool):
+        # bool is a subclass of int; reject to avoid True -> 1 surprises.
+        raise ValueTypeError("Expected a numeric value, got a boolean.")
+    if isinstance(value, (int, float)):
+        num: float = float(value)
+    elif isinstance(value, str):
+        s = value.strip()
+        if not s:
+            raise ValueTypeError("Expected a numeric value, got an empty string.")
+        try:
+            num = float(s)
+        except ValueError:
+            raise ValueTypeError(f"'{value}' is not a valid number.")
+    else:
+        raise ValueTypeError(f"Expected a numeric value, got {type(value).__name__}.")
+    # Normalize integral floats to int (2.0 -> 2).
+    if num.is_integer():
+        return int(num)
+    return num
+
+
+def _coerce_boolean(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        s = value.strip().lower()
+        if s in _TRUE_STRINGS:
+            return True
+        if s in _FALSE_STRINGS:
+            return False
+    raise ValueTypeError(f"'{value}' is not a valid boolean.")
+
+
+def _coerce_date(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, str):
+        s = value.strip()
+        if not s:
+            raise ValueTypeError("Expected a date, got an empty string.")
+        try:
+            # Accept full ISO datetimes but store only the date component.
+            return datetime.fromisoformat(s).date().isoformat()
+        except ValueError:
+            try:
+                return date.fromisoformat(s).isoformat()
+            except ValueError:
+                raise ValueTypeError(f"'{value}' is not a valid ISO date (YYYY-MM-DD).")
+    raise ValueTypeError(f"Expected a date, got {type(value).__name__}.")
+
+
+def _coerce_range(value: Any) -> dict[str, float | int]:
+    if not isinstance(value, dict):
+        raise ValueTypeError("Range must be an object with 'low' and 'high'.")
+    if "low" not in value or "high" not in value:
+        raise ValueTypeError("Range must include both 'low' and 'high'.")
+    low = _coerce_numeric(value["low"])
+    high = _coerce_numeric(value["high"])
+    if low > high:
+        raise ValueTypeError(f"Range low ({low}) must be <= high ({high}).")
+    return {"low": low, "high": high}
+
+
+def _coerce_enum(value: Any, possible_values: Optional[list[str]]) -> str:
+    if not isinstance(value, str):
+        raise ValueTypeError(f"Enum value must be a string, got {type(value).__name__}.")
+    s = value.strip()
+    if not s:
+        raise ValueTypeError("Enum value cannot be empty.")
+    if not possible_values:
+        raise ValueTypeError("Enum field has no controlled vocabulary defined.")
+    if s not in possible_values:
+        raise ValueTypeError(f"'{s}' is not in the allowed values: {possible_values}.")
+    return s
+
+
+def _coerce_multi_enum(value: Any, possible_values: Optional[list[str]]) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        raise ValueTypeError("MultiEnum value must be a list.")
+    if not possible_values:
+        raise ValueTypeError("MultiEnum field has no controlled vocabulary defined.")
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        if not isinstance(item, str):
+            raise ValueTypeError(f"MultiEnum items must be strings, got {type(item).__name__}.")
+        s = item.strip()
+        if s not in possible_values:
+            raise ValueTypeError(f"'{s}' is not in the allowed values: {possible_values}.")
+        if s not in seen:
+            seen.add(s)
+            result.append(s)
+    return result
+
+
+def coerce_value(
+    value_type: str | ComplianceValueType,
+    value: Any,
+    possible_values: Optional[list[str]] = None,
+) -> Any:
+    """Validate and coerce ``value`` for the given field type.
+
+    Returns the canonical stored representation. Raises :class:`ValueTypeError`
+    for ill-typed or out-of-vocabulary input. ``None`` passes through as-is
+    (an unset value is always permitted at write time — mandatory enforcement
+    is a separate concern handled by the completeness validator).
+    """
+    if value is None:
+        return None
+
+    vt = ComplianceValueType(value_type) if not isinstance(value_type, ComplianceValueType) else value_type
+
+    if vt == ComplianceValueType.STRING:
+        if not isinstance(value, str):
+            raise ValueTypeError(f"Expected a string, got {type(value).__name__}.")
+        return value
+    if vt == ComplianceValueType.NUMERIC:
+        return _coerce_numeric(value)
+    if vt == ComplianceValueType.BOOLEAN:
+        return _coerce_boolean(value)
+    if vt == ComplianceValueType.DATE:
+        return _coerce_date(value)
+    if vt == ComplianceValueType.RANGE:
+        return _coerce_range(value)
+    if vt == ComplianceValueType.ENUM:
+        return _coerce_enum(value, possible_values)
+    if vt == ComplianceValueType.MULTI_ENUM:
+        return _coerce_multi_enum(value, possible_values)
+
+    raise ValueTypeError(f"Unknown value type '{value_type}'.")
+
+
+def is_set(value_type: str | ComplianceValueType, value: Any) -> bool:
+    """Return True if ``value`` counts as "set" for completeness purposes.
+
+    Semantics (PRD): Boolean is satisfied by explicit true OR false;
+    String/Enum/Date by a non-empty value; MultiEnum by at least one selection;
+    Range by both bounds present; Numeric by any number.
+    """
+    if value is None:
+        return False
+
+    vt = ComplianceValueType(value_type) if not isinstance(value_type, ComplianceValueType) else value_type
+
+    if vt == ComplianceValueType.BOOLEAN:
+        # Both true and false count as set once a bool is present.
+        return isinstance(value, bool)
+    if vt == ComplianceValueType.STRING:
+        return isinstance(value, str) and value.strip() != ""
+    if vt == ComplianceValueType.ENUM:
+        return isinstance(value, str) and value.strip() != ""
+    if vt == ComplianceValueType.DATE:
+        return isinstance(value, str) and value.strip() != ""
+    if vt == ComplianceValueType.NUMERIC:
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if vt == ComplianceValueType.MULTI_ENUM:
+        return isinstance(value, (list, tuple)) and len(value) > 0
+    if vt == ComplianceValueType.RANGE:
+        return (
+            isinstance(value, dict)
+            and value.get("low") is not None
+            and value.get("high") is not None
+        )
+    return False

--- a/src/backend/src/common/features.py
+++ b/src/backend/src/common/features.py
@@ -212,6 +212,14 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },
+    'settings-compliance-templates': {
+        # Admin management of compliance template DEFINITIONS (typed, grouped
+        # governance-field schemas). Distinct from per-entity value read/write
+        # which is gated by the cross-cutting `compliance-template-values`.
+        'name': 'Compliance Templates',
+        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
+        'group': GROUP_SETTINGS,
+    },
 
     # --- Settings: Configuration sub-pages ---
     'settings-general': {
@@ -384,6 +392,15 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
         'name': 'Entity Relationships',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_BUILD,
+        'cross_cutting': True,
+    },
+    'compliance-template-values': {
+        # Per-entity compliance template values, filled via the button+modal on
+        # entity detail pages. Read-only users can view; READ_WRITE can fill.
+        # No sidebar entry — the modal is surfaced inline.
+        'name': 'Compliance Template Values',
+        'allowed_levels': IMPLICIT_FEATURE_LEVELS,
+        'group': GROUP_GOVERN,
         'cross_cutting': True,
     },
 

--- a/src/backend/src/common/workflow_executor.py
+++ b/src/backend/src/common/workflow_executor.py
@@ -65,6 +65,8 @@ def substitute_template(template: str, context: 'StepContext') -> str:
                                      (e.g. ${context.on_behalf_of.value}).
                                      Top-level scalar attrs like
                                      ${context.entity_type} also work.
+      ${template.<ref>}            - compliance template field value (stored value
+                                     else field default); requires context.template_values
     """
     import re
 
@@ -130,6 +132,12 @@ def substitute_template(template: str, context: 'StepContext') -> str:
                 resolved = _lookup_context(parts)
                 if resolved is not None:
                     return resolved
+            elif head == 'template':
+                # Resolve ${template.<ref>} from context.template_values
+                if context.template_values and parts:
+                    ref = parts[0]  # Just the first part (reference_id)
+                    if ref in context.template_values:
+                        return _render_template_value(context.template_values[ref])
         # leave placeholder intact when unresolved
         return match.group(0)
 
@@ -156,6 +164,69 @@ class StepContext:
     # ${context.on_behalf_of.value|.type|.display} in webhook bodies +
     # grant_permissions principal_variable. None when subscribing for self.
     on_behalf_of: Optional[Dict[str, str]] = None
+    # Pre-resolved compliance template values: {reference_id: effective_value}.
+    # Used by substitute_template to resolve ${template.<ref>}.
+    template_values: Optional[Dict[str, Any]] = None
+
+
+def build_template_values(db: Session, entity_type: str, entity_id: str) -> Dict[str, Any]:
+    """Build compliance template values for an entity.
+
+    Returns a dict mapping reference_id -> effective_value (stored value else field default).
+    Returns empty dict on error (non-fatal; workflow continues).
+
+    Args:
+        db: Database session
+        entity_type: Entity type (e.g., 'data_product')
+        entity_id: Entity ID
+
+    Returns:
+        Dict[reference_id, effective_value]. Empty on error.
+    """
+    try:
+        # Import here to avoid circular dependency
+        from src.controller.compliance_templates_manager import compliance_templates_manager
+
+        # read_for_entity returns EntityComplianceRead with .values and .fields
+        compliance_data = compliance_templates_manager.read_for_entity(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+        )
+
+        if not compliance_data:
+            return {}
+
+        result: Dict[str, Any] = {}
+
+        # Build a map of reference_id -> field default
+        field_defaults: Dict[str, Any] = {}
+        if compliance_data.fields:
+            for field in compliance_data.fields:
+                ref_id = getattr(field, 'reference_id', None)
+                default = getattr(field, 'default_value', None)
+                if ref_id:
+                    field_defaults[ref_id] = default
+
+        # Apply stored values (override defaults)
+        if compliance_data.values:
+            for val in compliance_data.values:
+                ref_id = getattr(val, 'reference_id', None)
+                stored_val = getattr(val, 'value', None)
+                if ref_id is not None:
+                    result[ref_id] = stored_val
+
+        # Fill in defaults for fields with no stored value
+        for ref_id, default in field_defaults.items():
+            if ref_id not in result:
+                result[ref_id] = default
+
+        return result
+    except Exception as e:
+        logger.warning(
+            f"Failed to build template values for {entity_type} {entity_id}: {e}"
+        )
+        return {}
 
 
 @dataclass
@@ -2373,7 +2444,13 @@ class WorkflowExecutor:
             if isinstance(obo, dict):
                 on_behalf_of = obo
 
-        # Build step context
+        # Build step context with template values
+        template_values = None
+        try:
+            template_values = build_template_values(self._db, entity_type, entity_id)
+        except Exception as e:
+            logger.warning(f"Failed to build template values: {e}")
+
         context = StepContext(
             entity=entity.copy(),
             entity_type=entity_type,
@@ -2386,6 +2463,7 @@ class WorkflowExecutor:
             workflow_name=workflow.name,
             step_results={},
             on_behalf_of=on_behalf_of,
+            template_values=template_values,
         )
 
         # Build step lookup
@@ -2576,6 +2654,18 @@ class WorkflowExecutor:
             if isinstance(obo, dict):
                 on_behalf_of = obo
 
+        # Build template values for resume
+        template_values = None
+        if trigger_context:
+            try:
+                template_values = build_template_values(
+                    self._db,
+                    trigger_context.entity_type,
+                    trigger_context.entity_id,
+                )
+            except Exception as e:
+                logger.warning(f"Failed to build template values on resume: {e}")
+
         context = StepContext(
             entity=entity_data.copy(),
             entity_type=trigger_context.entity_type if trigger_context else 'unknown',
@@ -2593,6 +2683,7 @@ class WorkflowExecutor:
                 **(result_data or {}),
             }},
             on_behalf_of=on_behalf_of,
+            template_values=template_values,
         )
 
         # Cross-workflow variable propagation (#291):

--- a/src/backend/src/controller/compliance_templates_manager.py
+++ b/src/backend/src/controller/compliance_templates_manager.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from src.common.compliance_completeness import CompletenessResult, FieldSpec, check_completeness
+from src.common.compliance_reconcile import FieldDesc, reconcile
 from src.common.compliance_value_types import ValueTypeError, coerce_value
 from src.common.logging import get_logger
 from src.models.compliance_templates import (
@@ -349,6 +350,94 @@ class ComplianceTemplatesManager:
             for f in fields
         ]
         return check_completeness(specs, stored)
+
+    def reconcile_entity(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+        user_email: str | None,
+    ) -> None:
+        """Reconcile an entity's compliance values: materialize defaults for fields without rows.
+
+        Gets the active template; if none, no-op. Lists fields and existing value rows;
+        calls the pure reconciler to decide which defaults to insert. Inserts ONLY the
+        proposed default rows (coerced via coerce_value), never modifying existing rows.
+
+        Designed to be called on every entity update (e.g., Data Product save). Failures
+        are logged as warnings and never break the entity update.
+
+        Args:
+            db: Database session.
+            entity_type: Entity type (e.g., "data_product").
+            entity_id: Entity id.
+            user_email: Email of the user performing the reconciliation (for filled_by).
+        """
+        try:
+            active = compliance_templates_repo.get_active_template(db, entity_type=entity_type)
+            if not active:
+                return  # No template, nothing to reconcile
+
+            fields = compliance_templates_repo.list_fields(db, template_id=active.id)
+            if not fields:
+                return  # No fields, nothing to reconcile
+
+            field_ids = [f.id for f in fields]
+            existing_rows = compliance_templates_repo.list_values(
+                db, entity_type=entity_type, entity_id=entity_id, field_ids=field_ids
+            )
+            existing_field_ids = {v.field_id for v in existing_rows}
+
+            # Convert to pure reconciler input
+            field_descs = [
+                FieldDesc(
+                    field_id=f.id,
+                    value_type=f.value_type,
+                    default_value=f.default_value,
+                )
+                for f in fields
+            ]
+
+            # Get reconcile actions
+            actions = reconcile(field_descs, existing_field_ids)
+            if not actions:
+                return  # No defaults to materialize
+
+            # Insert proposed default rows
+            fields_by_id = {f.id: f for f in fields}
+            for action in actions:
+                field = fields_by_id.get(action.field_id)
+                if not field:
+                    continue
+                # Coerce the default value (should already be canonical, but re-coerce for safety)
+                try:
+                    coerced_value = coerce_value(
+                        field.value_type, action.value, field.possible_values
+                    )
+                except ValueTypeError as e:
+                    logger.warning(
+                        f"Failed to coerce default for field {action.field_id} during reconcile: {e}"
+                    )
+                    continue
+                # Insert the row
+                compliance_templates_repo.add_value(
+                    db,
+                    field_id=action.field_id,
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                    value=coerced_value,
+                    filled_by=user_email,
+                )
+            db.flush()  # Flush but don't commit — caller commits
+            logger.info(
+                f"Reconciled {len(actions)} default value(s) for {entity_type} {entity_id}"
+            )
+        except Exception as e:
+            # Non-fatal: log warning but never break the entity update
+            logger.warning(
+                f"Compliance reconcile failed for {entity_type} {entity_id}: {e}"
+            )
 
     def has_active_template(self, db: Session, *, entity_type: str) -> bool:
         return compliance_templates_repo.get_active_template(db, entity_type=entity_type) is not None

--- a/src/backend/src/controller/compliance_templates_manager.py
+++ b/src/backend/src/controller/compliance_templates_manager.py
@@ -178,9 +178,11 @@ class ComplianceTemplatesManager:
         has_stored_values = compliance_templates_repo.count_field_values(db, field_id=field_id) > 0
 
         if has_stored_values:
-            # Check if value_type is changing
+            # Check if value_type is changing. The route passes a raw JSON dict,
+            # so value_type may be a plain string OR a ComplianceValueType enum.
             new_value_type = payload.get("value_type")
-            if new_value_type is not None and new_value_type.value != field.value_type:
+            new_value_type_str = getattr(new_value_type, "value", new_value_type)
+            if new_value_type is not None and new_value_type_str != field.value_type:
                 raise ComplianceTemplateError(
                     f"Cannot change field value type when stored values exist. "
                     f"Either delete stored values or use a new field."

--- a/src/backend/src/controller/compliance_templates_manager.py
+++ b/src/backend/src/controller/compliance_templates_manager.py
@@ -1,0 +1,238 @@
+"""Manager for Compliance Templates: validation + composed reads over the repository."""
+import re
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from src.common.compliance_completeness import CompletenessResult, FieldSpec, check_completeness
+from src.common.compliance_value_types import ValueTypeError, coerce_value
+from src.common.logging import get_logger
+from src.models.compliance_templates import (
+    ComplianceFieldCreate,
+    ComplianceFieldRead,
+    ComplianceTemplateCreate,
+    ComplianceTemplateRead,
+    ComplianceValueRead,
+    ComplianceValueWrite,
+    EntityComplianceRead,
+)
+from src.repositories.compliance_templates_repository import compliance_templates_repo
+
+logger = get_logger(__name__)
+
+# Reference ids are validated slugs: lowercase alphanumerics and separators.
+_REFERENCE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+
+class ComplianceTemplateError(ValueError):
+    """Raised for validation failures; routes convert to HTTP 4xx."""
+
+
+def _validate_reference_id(reference_id: str) -> None:
+    if not _REFERENCE_ID_RE.match(reference_id):
+        raise ComplianceTemplateError(
+            f"Invalid reference id '{reference_id}': must be a slug "
+            "(lowercase letters, digits, '-' or '_', starting alphanumeric)."
+        )
+
+
+def _assert_unique_reference_ids(fields: list[ComplianceFieldCreate]) -> None:
+    seen_refs, seen_keys = set(), set()
+    for f in fields:
+        _validate_reference_id(f.reference_id)
+        if f.reference_id in seen_refs:
+            raise ComplianceTemplateError(f"Duplicate reference id '{f.reference_id}' within template.")
+        if f.key in seen_keys:
+            raise ComplianceTemplateError(f"Duplicate field key '{f.key}' within template.")
+        seen_refs.add(f.reference_id)
+        seen_keys.add(f.key)
+
+
+class ComplianceTemplatesManager:
+
+    # ----- Template CRUD --------------------------------------------------
+
+    def list_templates(self, db: Session, *, entity_type: str | None = None) -> list[ComplianceTemplateRead]:
+        return [ComplianceTemplateRead.model_validate(t) for t in compliance_templates_repo.list_templates(db, entity_type=entity_type)]
+
+    def get_template(self, db: Session, template_id: UUID) -> ComplianceTemplateRead | None:
+        t = compliance_templates_repo.get_template(db, template_id)
+        return ComplianceTemplateRead.model_validate(t) if t else None
+
+    def create_template(self, db: Session, *, payload: ComplianceTemplateCreate, user_email: str | None) -> ComplianceTemplateRead:
+        _assert_unique_reference_ids(payload.fields)
+        template = compliance_templates_repo.create_template(
+            db,
+            name=payload.name,
+            entity_type=payload.entity_type,
+            description=payload.description,
+            created_by=user_email,
+        )
+        for f in payload.fields:
+            # Coerce the default against the field's type + vocabulary so it is
+            # stored in canonical form and can never be an invalid value.
+            try:
+                default_value = coerce_value(f.value_type, f.default_value, f.possible_values)
+            except ValueTypeError as e:
+                db.rollback()
+                raise ComplianceTemplateError(f"{f.label} default: {e}")
+            compliance_templates_repo.add_field(
+                db,
+                template_id=template.id,
+                group_title=f.group_title,
+                group_order=f.group_order,
+                key=f.key,
+                label=f.label,
+                reference_id=f.reference_id,
+                value_type=f.value_type.value,
+                possible_values=f.possible_values,
+                default_value=default_value,
+                hint_text=f.hint_text,
+                is_mandatory=f.is_mandatory,
+                field_order=f.field_order,
+            )
+        db.commit()
+        db.refresh(template)
+        return ComplianceTemplateRead.model_validate(template)
+
+    def update_template(self, db: Session, *, template_id: UUID, update_data: dict) -> ComplianceTemplateRead:
+        t = compliance_templates_repo.get_template(db, template_id)
+        if not t:
+            raise ComplianceTemplateError("Template not found")
+        compliance_templates_repo.update_template(db, db_obj=t, update_data=update_data)
+        db.commit()
+        db.refresh(t)
+        return ComplianceTemplateRead.model_validate(t)
+
+    def delete_template(self, db: Session, *, template_id: UUID) -> None:
+        t = compliance_templates_repo.get_template(db, template_id)
+        if not t:
+            raise ComplianceTemplateError("Template not found")
+        compliance_templates_repo.delete_template(db, db_obj=t)
+        db.commit()
+
+    def set_active(self, db: Session, *, template_id: UUID, active: bool) -> ComplianceTemplateRead:
+        t = compliance_templates_repo.get_template(db, template_id)
+        if not t:
+            raise ComplianceTemplateError("Template not found")
+        if active:
+            compliance_templates_repo.activate_template(db, db_obj=t)
+        else:
+            compliance_templates_repo.deactivate_template(db, db_obj=t)
+        db.commit()
+        db.refresh(t)
+        return ComplianceTemplateRead.model_validate(t)
+
+    # ----- Composed read + replace-all write ------------------------------
+
+    def read_for_entity(self, db: Session, *, entity_type: str, entity_id: str) -> EntityComplianceRead:
+        """Return { template, fields, values } for the active template of an entity type.
+
+        Values are read for the union of the active template's fields AND any
+        fields that already have stored values for this entity — so historical
+        values remain visible even after their template is deactivated.
+        """
+        active = compliance_templates_repo.get_active_template(db, entity_type=entity_type)
+        if not active:
+            return EntityComplianceRead(template=None, fields=[], values=[])
+
+        fields = compliance_templates_repo.list_fields(db, template_id=active.id)
+        field_ids = [f.id for f in fields]
+        ref_by_field = {f.id: f.reference_id for f in fields}
+        value_rows = compliance_templates_repo.list_values(
+            db, entity_type=entity_type, entity_id=entity_id, field_ids=field_ids
+        )
+        values = [
+            ComplianceValueRead(
+                field_id=v.field_id,
+                reference_id=ref_by_field.get(v.field_id, ""),
+                entity_type=v.entity_type,
+                entity_id=v.entity_id,
+                value=v.value,
+                filled_by=v.filled_by,
+                filled_at=v.filled_at,
+            )
+            for v in value_rows
+        ]
+        return EntityComplianceRead(
+            template=ComplianceTemplateRead.model_validate(active),
+            fields=[ComplianceFieldRead.model_validate(f) for f in fields],
+            values=values,
+        )
+
+    def replace_values(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+        writes: list[ComplianceValueWrite],
+        user_email: str | None,
+    ) -> EntityComplianceRead:
+        """Replace-all write of an entity's values against the active template."""
+        active = compliance_templates_repo.get_active_template(db, entity_type=entity_type)
+        if not active:
+            raise ComplianceTemplateError(f"No active compliance template for entity type '{entity_type}'.")
+        fields = compliance_templates_repo.list_fields(db, template_id=active.id)
+        valid_field_ids = {f.id for f in fields}
+        fields_by_id = {f.id: f for f in fields}
+
+        # Validate/coerce each written value against its field's type + vocabulary.
+        values_by_field: dict = {}
+        for w in writes:
+            field = fields_by_id.get(w.field_id)
+            if field is None:
+                # Unknown field ids are ignored by the repository's replace-all.
+                continue
+            try:
+                values_by_field[w.field_id] = coerce_value(
+                    field.value_type, w.value, field.possible_values
+                )
+            except ValueTypeError as e:
+                raise ComplianceTemplateError(f"{field.label}: {e}")
+        compliance_templates_repo.replace_values(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            valid_field_ids=valid_field_ids,
+            values_by_field=values_by_field,
+            filled_by=user_email,
+        )
+        db.commit()
+        return self.read_for_entity(db, entity_type=entity_type, entity_id=entity_id)
+
+    # ----- Completeness ---------------------------------------------------
+
+    def check_completeness(self, db: Session, *, entity_type: str, entity_id: str) -> CompletenessResult:
+        """Run the completeness check for an entity against its active template.
+
+        Returns a result with ``applicable=False`` semantics handled by the
+        caller: when no template is active, this returns a passing result over
+        zero fields (nothing to complete).
+        """
+        active = compliance_templates_repo.get_active_template(db, entity_type=entity_type)
+        if not active:
+            return CompletenessResult(passed=True)
+        fields = compliance_templates_repo.list_fields(db, template_id=active.id)
+        field_ids = [f.id for f in fields]
+        value_rows = compliance_templates_repo.list_values(
+            db, entity_type=entity_type, entity_id=entity_id, field_ids=field_ids
+        )
+        stored = {v.field_id: v.value for v in value_rows}
+        specs = [
+            FieldSpec(
+                field_id=f.id,
+                label=f.label,
+                value_type=f.value_type,
+                is_mandatory=f.is_mandatory,
+                default_value=f.default_value,
+            )
+            for f in fields
+        ]
+        return check_completeness(specs, stored)
+
+    def has_active_template(self, db: Session, *, entity_type: str) -> bool:
+        return compliance_templates_repo.get_active_template(db, entity_type=entity_type) is not None
+
+
+compliance_templates_manager = ComplianceTemplatesManager()

--- a/src/backend/src/controller/compliance_templates_manager.py
+++ b/src/backend/src/controller/compliance_templates_manager.py
@@ -123,6 +123,125 @@ class ComplianceTemplatesManager:
         db.refresh(t)
         return ComplianceTemplateRead.model_validate(t)
 
+    # ----- Field CRUD (safe & destructive) -----------------------------------
+
+    def add_field(self, db: Session, *, template_id: UUID, payload: ComplianceFieldCreate) -> ComplianceFieldRead:
+        """Add a field to a template. Safe to call on active template."""
+        t = compliance_templates_repo.get_template(db, template_id)
+        if not t:
+            raise ComplianceTemplateError("Template not found")
+        _validate_reference_id(payload.reference_id)
+
+        # Ensure unique reference_id and key within template
+        existing_fields = compliance_templates_repo.list_fields(db, template_id=template_id)
+        for f in existing_fields:
+            if f.reference_id == payload.reference_id:
+                raise ComplianceTemplateError(f"Duplicate reference id '{payload.reference_id}' within template.")
+            if f.key == payload.key:
+                raise ComplianceTemplateError(f"Duplicate field key '{payload.key}' within template.")
+
+        # Coerce default against type + vocabulary
+        try:
+            default_value = coerce_value(payload.value_type, payload.default_value, payload.possible_values)
+        except ValueTypeError as e:
+            raise ComplianceTemplateError(f"{payload.label} default: {e}")
+
+        field = compliance_templates_repo.add_field(
+            db,
+            template_id=template_id,
+            group_title=payload.group_title,
+            group_order=payload.group_order,
+            key=payload.key,
+            label=payload.label,
+            reference_id=payload.reference_id,
+            value_type=payload.value_type.value,
+            possible_values=payload.possible_values,
+            default_value=default_value,
+            hint_text=payload.hint_text,
+            is_mandatory=payload.is_mandatory,
+            field_order=payload.field_order,
+        )
+        db.commit()
+        return ComplianceFieldRead.model_validate(field)
+
+    def update_field(self, db: Session, *, field_id: UUID, payload: dict) -> ComplianceFieldRead:
+        """Update a field's safe attributes (label, hint, default, mandatory, group order).
+
+        Cannot change value_type or narrow possible_values if stored values exist.
+        """
+        field = compliance_templates_repo.get_field(db, field_id)
+        if not field:
+            raise ComplianceTemplateError("Field not found")
+
+        # Detect destructive changes: value_type change or possible_values narrowing
+        has_stored_values = compliance_templates_repo.count_field_values(db, field_id=field_id) > 0
+
+        if has_stored_values:
+            # Check if value_type is changing
+            new_value_type = payload.get("value_type")
+            if new_value_type is not None and new_value_type.value != field.value_type:
+                raise ComplianceTemplateError(
+                    f"Cannot change field value type when stored values exist. "
+                    f"Either delete stored values or use a new field."
+                )
+            # Check if enum values are being removed (narrowing possible_values)
+            new_possible_values = payload.get("possible_values")
+            if new_possible_values is not None and field.possible_values is not None:
+                old_set = set(field.possible_values)
+                new_set = set(new_possible_values)
+                removed = old_set - new_set
+                if removed:
+                    raise ComplianceTemplateError(
+                        f"Cannot remove enum values {removed} when stored values exist. "
+                        f"Edit the stored values first."
+                    )
+                # Safe: adding new values to an enum (payload only contains new_value_type and new_possible_values)
+                payload["possible_values"] = new_possible_values
+
+        # Re-coerce default if value_type or possible_values changed
+        if "value_type" in payload or "possible_values" in payload or "default_value" in payload:
+            new_value_type = payload.get("value_type", field.value_type)
+            new_possible_values = payload.get("possible_values", field.possible_values)
+            new_default = payload.get("default_value", field.default_value)
+            try:
+                coerced = coerce_value(new_value_type, new_default, new_possible_values)
+                payload["default_value"] = coerced
+            except ValueTypeError as e:
+                raise ComplianceTemplateError(f"Default value error: {e}")
+
+        # Apply safe update
+        safe_update = {k: v for k, v in payload.items() if k in {"label", "hint_text", "default_value", "is_mandatory", "group_title", "group_order", "field_order"}}
+        updated = compliance_templates_repo.update_field(db, field_id=field_id, update_data=safe_update)
+        db.commit()
+        return ComplianceFieldRead.model_validate(updated)
+
+    def delete_field(self, db: Session, *, field_id: UUID) -> None:
+        """Delete a field. Guarded: cannot delete if stored values exist."""
+        field = compliance_templates_repo.get_field(db, field_id)
+        if not field:
+            raise ComplianceTemplateError("Field not found")
+
+        # Guard: check for stored values
+        has_stored_values = compliance_templates_repo.count_field_values(db, field_id=field_id) > 0
+        if has_stored_values:
+            raise ComplianceTemplateError(
+                f"Cannot delete field '{field.label}': stored values exist. "
+                f"Delete the values first."
+            )
+
+        compliance_templates_repo.delete_field(db, field_id=field_id)
+        db.commit()
+
+    def reorder_fields(self, db: Session, *, template_id: UUID, order_map: list[dict]) -> list[ComplianceFieldRead]:
+        """Reorder fields and groups. Safe: produces new ordinals without side effects."""
+        t = compliance_templates_repo.get_template(db, template_id)
+        if not t:
+            raise ComplianceTemplateError("Template not found")
+
+        fields = compliance_templates_repo.reorder_fields(db, template_id=template_id, order_map=order_map)
+        db.commit()
+        return [ComplianceFieldRead.model_validate(f) for f in fields]
+
     # ----- Composed read + replace-all write ------------------------------
 
     def read_for_entity(self, db: Session, *, entity_type: str, entity_id: str) -> EntityComplianceRead:

--- a/src/backend/src/controller/data_products_manager.py
+++ b/src/backend/src/controller/data_products_manager.py
@@ -72,6 +72,7 @@ from src.common import genie_client
 from src.common.delivery_mixin import DeliveryMixin
 from src.repositories.entity_relationships_repository import entity_relationship_repo
 from src.repositories.assets_repository import asset_repo
+from src.controller.compliance_templates_manager import compliance_templates_manager
 
 logger = get_logger(__name__)
 
@@ -1038,10 +1039,10 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
 
                 # Validate that all linked contracts are in an approved status
                 from src.repositories.data_contracts_repository import data_contract_repo
-                
+
                 valid_contract_statuses = ['approved', 'active']
                 contracts_not_approved = []
-                
+
                 for port in product_db.output_ports:
                     if port.contract_id:
                         contract = data_contract_repo.get(db=self._db, id=port.contract_id)
@@ -1051,12 +1052,25 @@ class DataProductsManager(DeliveryMixin, SearchableAsset):
                                 contracts_not_approved.append(
                                     f"{port.name} -> {contract.name} (status: {contract.status})"
                                 )
-                
+
                 if contracts_not_approved:
                     raise ValueError(
                         f"Cannot publish product: These output ports have unapproved contracts: "
                         f"{', '.join(contracts_not_approved)}. Contracts must be approved first."
                     )
+
+            # Check compliance template completeness (blocks publish if mandatory fields are missing)
+            completeness_result = compliance_templates_manager.check_completeness(
+                self._db, entity_type="data_product", entity_id=product_id
+            )
+            if not completeness_result.passed:
+                error_message = "Cannot publish product: Missing mandatory compliance fields:\n" + "\n".join(
+                    completeness_result.messages
+                )
+                logger.error(f"Compliance check failed for product {product_id}: {error_message}")
+                raise ValueError(error_message)
+
+            logger.info(f"Compliance check passed for product {product_id}")
 
             # Use transition_status for validation and update
             result = self.transition_status(product_id, 'active', current_user)

--- a/src/backend/src/controller/settings_manager.py
+++ b/src/backend/src/controller/settings_manager.py
@@ -98,6 +98,7 @@ DEFAULT_ROLE_PERMISSIONS = {
         'data-asset-reviews': FeatureAccessLevel.ADMIN,
         'catalog-commander': FeatureAccessLevel.FULL,
         'comments': FeatureAccessLevel.READ_WRITE,  # All users can comment
+        'compliance-template-values': FeatureAccessLevel.READ_WRITE,  # Fill product compliance fields
     },
     "Data Steward": {
         'data-domains': FeatureAccessLevel.READ_WRITE,
@@ -112,6 +113,7 @@ DEFAULT_ROLE_PERMISSIONS = {
         'data-asset-reviews': FeatureAccessLevel.READ_WRITE,
         'catalog-commander': FeatureAccessLevel.READ_ONLY,
         'comments': FeatureAccessLevel.READ_WRITE,  # All users can comment
+        'compliance-template-values': FeatureAccessLevel.READ_WRITE,  # Fill product compliance fields
     },
     "Data Consumer": {
         'data-domains': FeatureAccessLevel.READ_ONLY,
@@ -124,6 +126,7 @@ DEFAULT_ROLE_PERMISSIONS = {
         'process-workflows': FeatureAccessLevel.READ_ONLY,  # View workflows, Admin manages
         'catalog-commander': FeatureAccessLevel.READ_ONLY,
         'comments': FeatureAccessLevel.READ_WRITE,  # All users can comment
+        'compliance-template-values': FeatureAccessLevel.READ_ONLY,  # View product compliance (read-only)
     },
     "Data Producer": {
         'data-domains': FeatureAccessLevel.READ_ONLY,
@@ -136,6 +139,7 @@ DEFAULT_ROLE_PERMISSIONS = {
         'process-workflows': FeatureAccessLevel.READ_ONLY,  # View workflows, Admin manages
         'catalog-commander': FeatureAccessLevel.READ_ONLY,
         'comments': FeatureAccessLevel.READ_WRITE,  # All users can comment
+        'compliance-template-values': FeatureAccessLevel.READ_WRITE,  # Fill product compliance fields
     },
     "Security Officer": {
         'security-features': FeatureAccessLevel.ADMIN,
@@ -145,6 +149,7 @@ DEFAULT_ROLE_PERMISSIONS = {
         'process-workflows': FeatureAccessLevel.READ_ONLY,  # View workflows, Admin manages
         'data-asset-reviews': FeatureAccessLevel.READ_ONLY,
         'comments': FeatureAccessLevel.READ_WRITE,  # All users can comment
+        'compliance-template-values': FeatureAccessLevel.READ_ONLY,  # View product compliance (read-only)
     },
 }
 

--- a/src/backend/src/data/settings.yaml
+++ b/src/backend/src/data/settings.yaml
@@ -50,6 +50,7 @@ roles:
       comments: Read/Write
       process-workflows: Read-only  # View workflows; admins manage definitions
       access-grants: Admin  # DGO approves access grants
+      compliance-template-values: Read/Write  # Fill product compliance fields
     home_sections:
       - REQUIRED_ACTIONS
       - DISCOVERY
@@ -87,6 +88,7 @@ roles:
       comments: Read/Write
       process-workflows: Read-only  # View workflows; admins manage definitions
       access-grants: Read/Write  # Can request grants on behalf of stewarded data
+      compliance-template-values: Read/Write  # Fill product compliance fields
     home_sections:
       - REQUIRED_ACTIONS
       - DISCOVERY
@@ -122,6 +124,7 @@ roles:
       comments: Read/Write
       process-workflows: Read-only  # View workflows that affect own requests
       access-grants: Read-only  # See own grants
+      compliance-template-values: Read-only  # View product compliance (read-only)
     home_sections:
       - DISCOVERY
 
@@ -142,6 +145,7 @@ roles:
       comments: Read/Write
       process-workflows: Read-only  # View workflows triggered by own products
       access-grants: Read/Write  # Can request grants for own products
+      compliance-template-values: Read/Write  # Fill product compliance fields
     home_sections:
       - DATA_CURATION
       - DISCOVERY
@@ -169,6 +173,7 @@ roles:
       comments: Read/Write
       process-workflows: Read-only  # View workflows; admins manage definitions
       access-grants: Admin  # Security Officer approves access grants
+      compliance-template-values: Read-only  # View product compliance (read-only)
     home_sections:
       - REQUIRED_ACTIONS
       - DISCOVERY

--- a/src/backend/src/db_models/__init__.py
+++ b/src/backend/src/db_models/__init__.py
@@ -10,6 +10,7 @@ from . import audit_log
 from . import change_log
 from . import comments
 from . import compliance
+from . import compliance_templates
 from . import connections
 from . import costs
 from . import data_asset_reviews

--- a/src/backend/src/db_models/compliance_templates.py
+++ b/src/backend/src/db_models/compliance_templates.py
@@ -1,0 +1,181 @@
+"""Database models for admin-defined Compliance Templates.
+
+Three tables implement a typed, grouped governance-field schema bound to an
+entity type, plus per-entity filled-in values stored polymorphically:
+
+- ``compliance_templates``        — the template definition (name, bound entity
+  type, active flag). At most one active template per
+  ``(entity_type, scope_type, scope_id)`` is enforced by a partial unique index;
+  v1 only ever uses ``scope_type = 'all'``. The ``scope_*`` columns exist now so
+  domain/project scoping can be added later without a migration.
+- ``compliance_template_fields``  — typed fields belonging to a template. Groups
+  are denormalized onto the field (``group_title`` + ``group_order``) rather than
+  living in their own table. ``constraints`` is reserved for future
+  input-validation rules and is unused in v1.
+- ``compliance_template_values``  — per-entity filled-in values, keyed
+  polymorphically by ``(entity_type, entity_id)`` and unique per field. Mirrors
+  the ``entity_tag_associations`` pattern.
+"""
+import uuid
+
+from sqlalchemy import (
+    JSON,
+    TIMESTAMP,
+    Boolean,
+    Column,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from src.common.database import Base
+
+# Default scope for an active template. v1 only uses "all"; the scope columns
+# exist to allow domain/project/catalog scoping later without a schema change.
+DEFAULT_SCOPE_TYPE = "all"
+DEFAULT_SCOPE_ID = ""
+
+
+class ComplianceTemplateDb(Base):
+    """An admin-defined, typed, grouped field schema bound to an entity type.
+
+    Exactly one template may be active per ``(entity_type, scope_type,
+    scope_id)`` — enforced by the ``uq_compliance_template_active_scope``
+    partial unique index (only rows with ``is_active = true`` participate).
+    """
+    __tablename__ = "compliance_templates"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name = Column(String(255), nullable=False)
+    description = Column(Text, nullable=True)
+
+    # The entity type this template governs (e.g. "data_product"). Kept as a
+    # free string to stay entity-agnostic — the feature never imports host
+    # entity code.
+    entity_type = Column(String(100), nullable=False, index=True)
+
+    # Scoping columns — v1 always uses ("all", ""). Reserved for future
+    # domain/project scoping of active templates.
+    scope_type = Column(String(50), nullable=False, default=DEFAULT_SCOPE_TYPE, server_default=DEFAULT_SCOPE_TYPE)
+    scope_id = Column(String(255), nullable=False, default=DEFAULT_SCOPE_ID, server_default="")
+
+    is_active = Column(Boolean, nullable=False, default=False, server_default="false", index=True)
+    version = Column(Integer, nullable=False, default=1, server_default="1")
+
+    created_by = Column(String, nullable=True)
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    fields = relationship(
+        "ComplianceTemplateFieldDb",
+        back_populates="template",
+        cascade="all, delete-orphan",
+        order_by="ComplianceTemplateFieldDb.group_order, ComplianceTemplateFieldDb.field_order",
+    )
+
+    __table_args__ = (
+        # At most one ACTIVE template per (entity_type, scope_type, scope_id).
+        # Partial index so inactive templates don't collide.
+        Index(
+            "uq_compliance_template_active_scope",
+            "entity_type",
+            "scope_type",
+            "scope_id",
+            unique=True,
+            postgresql_where=Column("is_active"),
+        ),
+    )
+
+    def __repr__(self):
+        return f"<ComplianceTemplateDb(id={self.id}, name='{self.name}', entity_type='{self.entity_type}', active={self.is_active})>"
+
+
+class ComplianceTemplateFieldDb(Base):
+    """A typed field within a template, denormalized into a titled group.
+
+    ``value_type`` is one of the supported types (String, Numeric, Enum,
+    MultiEnum, Date, Range, Boolean). ``possible_values`` holds the controlled
+    vocabulary for Enum/MultiEnum. ``reference_id`` is a validated slug, unique
+    per template, referenced elsewhere as ``${template.<reference_id>}``.
+    """
+    __tablename__ = "compliance_template_fields"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    template_id = Column(PG_UUID(as_uuid=True), ForeignKey("compliance_templates.id", ondelete="CASCADE"), nullable=False, index=True)
+
+    # Group denormalized onto the field.
+    group_title = Column(String(255), nullable=False, default="", server_default="")
+    group_order = Column(Integer, nullable=False, default=0, server_default="0")
+
+    # Stable machine key + human label.
+    key = Column(String(255), nullable=False)
+    label = Column(String(255), nullable=False)
+    # Slug referenced by ${template.<reference_id>}; unique per template, mutable in v1.
+    reference_id = Column(String(255), nullable=False)
+
+    value_type = Column(String(50), nullable=False)
+    # Controlled vocabulary for Enum / MultiEnum (list of strings). Null otherwise.
+    possible_values = Column(JSON, nullable=True)
+    # Default value stored as JSON to accommodate every value type uniformly.
+    default_value = Column(JSON, nullable=True)
+    hint_text = Column(Text, nullable=True)
+    is_mandatory = Column(Boolean, nullable=False, default=False, server_default="false")
+    field_order = Column(Integer, nullable=False, default=0, server_default="0")
+
+    # Reserved for future input-validation rules (regex, min/max, …). Unused in v1.
+    constraints = Column(JSON, nullable=True)
+
+    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    template = relationship("ComplianceTemplateDb", back_populates="fields")
+    values = relationship(
+        "ComplianceTemplateValueDb",
+        back_populates="field",
+        cascade="all, delete-orphan",
+    )
+
+    __table_args__ = (
+        UniqueConstraint("template_id", "reference_id", name="uq_compliance_field_reference_id"),
+        UniqueConstraint("template_id", "key", name="uq_compliance_field_key"),
+    )
+
+    def __repr__(self):
+        return f"<ComplianceTemplateFieldDb(id={self.id}, ref='{self.reference_id}', type='{self.value_type}')>"
+
+
+class ComplianceTemplateValueDb(Base):
+    """A per-entity filled-in value for a template field.
+
+    Polymorphic: keyed by ``(entity_type, entity_id)`` so the same mechanism
+    extends to Data Contracts and Assets later with no schema change. Value is
+    stored as JSON so every value type shares one column. Unique per
+    ``(field_id, entity_type, entity_id)``.
+    """
+    __tablename__ = "compliance_template_values"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    field_id = Column(PG_UUID(as_uuid=True), ForeignKey("compliance_template_fields.id", ondelete="CASCADE"), nullable=False, index=True)
+
+    entity_type = Column(String(100), nullable=False, index=True)
+    entity_id = Column(String(255), nullable=False, index=True)
+
+    value = Column(JSON, nullable=True)
+
+    filled_by = Column(String, nullable=True)
+    filled_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    field = relationship("ComplianceTemplateFieldDb", back_populates="values")
+
+    __table_args__ = (
+        UniqueConstraint("field_id", "entity_type", "entity_id", name="uq_compliance_value_field_entity"),
+    )
+
+    def __repr__(self):
+        return f"<ComplianceTemplateValueDb(id={self.id}, field_id='{self.field_id}', entity_type='{self.entity_type}', entity_id='{self.entity_id}')>"

--- a/src/backend/src/models/compliance_templates.py
+++ b/src/backend/src/models/compliance_templates.py
@@ -1,0 +1,147 @@
+"""Pydantic models for the Compliance Templates API.
+
+Slice 1 (#706) stands up the full read/write shape with a single value type
+(String). The ``ComplianceValueType`` enum already enumerates every planned
+type so later slices add typed handling without reshaping the API.
+"""
+from datetime import datetime
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class ComplianceValueType(str, Enum):
+    """Supported field value types. Only STRING is handled in slice 1."""
+    STRING = "string"
+    NUMERIC = "numeric"
+    ENUM = "enum"
+    MULTI_ENUM = "multi_enum"
+    DATE = "date"
+    RANGE = "range"
+    BOOLEAN = "boolean"
+
+
+# ----- Fields -------------------------------------------------------------
+
+class ComplianceFieldBase(BaseModel):
+    group_title: str = Field("", max_length=255)
+    group_order: int = Field(0, ge=0)
+    key: str = Field(..., min_length=1, max_length=255)
+    label: str = Field(..., min_length=1, max_length=255)
+    reference_id: str = Field(..., min_length=1, max_length=255)
+    value_type: ComplianceValueType = ComplianceValueType.STRING
+    possible_values: list[str] | None = None
+    default_value: Any | None = None
+    hint_text: str | None = None
+    is_mandatory: bool = False
+    field_order: int = Field(0, ge=0)
+
+
+class ComplianceFieldCreate(ComplianceFieldBase):
+    pass
+
+
+class ComplianceFieldUpdate(BaseModel):
+    group_title: str | None = Field(None, max_length=255)
+    group_order: int | None = Field(None, ge=0)
+    key: str | None = Field(None, min_length=1, max_length=255)
+    label: str | None = Field(None, min_length=1, max_length=255)
+    reference_id: str | None = Field(None, min_length=1, max_length=255)
+    value_type: ComplianceValueType | None = None
+    possible_values: list[str] | None = None
+    default_value: Any | None = None
+    hint_text: str | None = None
+    is_mandatory: bool | None = None
+    field_order: int | None = Field(None, ge=0)
+
+
+class ComplianceFieldRead(ComplianceFieldBase):
+    id: UUID
+    template_id: UUID
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+# ----- Templates ----------------------------------------------------------
+
+class ComplianceTemplateBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str | None = None
+    entity_type: str = Field(..., min_length=1, max_length=100)
+
+
+class ComplianceTemplateCreate(ComplianceTemplateBase):
+    # Fields may be supplied inline on create, or added later via the field API.
+    fields: list[ComplianceFieldCreate] = Field(default_factory=list)
+
+
+class ComplianceTemplateUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=255)
+    description: str | None = None
+
+
+class ComplianceTemplateRead(ComplianceTemplateBase):
+    id: UUID
+    scope_type: str
+    scope_id: str
+    is_active: bool
+    version: int
+    created_by: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    fields: list[ComplianceFieldRead] = Field(default_factory=list)
+
+    model_config = {"from_attributes": True}
+
+
+# ----- Per-entity values --------------------------------------------------
+
+class ComplianceValueRead(BaseModel):
+    field_id: UUID
+    reference_id: str
+    entity_type: str
+    entity_id: str
+    value: Any | None = None
+    filled_by: str | None = None
+    filled_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class ComplianceValueWrite(BaseModel):
+    """A single field's value in a replace-all write."""
+    field_id: UUID
+    value: Any | None = None
+
+
+class ComplianceValuesReplace(BaseModel):
+    """Replace-all write payload: the materialization event for an entity."""
+    values: list[ComplianceValueWrite] = Field(default_factory=list)
+
+
+class EntityComplianceRead(BaseModel):
+    """Composed read: the active template, its fields, and this entity's values.
+
+    ``template`` is null when no template is active for the entity type — the
+    frontend hides the fill button in that case.
+    """
+    template: ComplianceTemplateRead | None = None
+    fields: list[ComplianceFieldRead] = Field(default_factory=list)
+    values: list[ComplianceValueRead] = Field(default_factory=list)
+
+
+class ComplianceCompletenessRead(BaseModel):
+    """Result of the completeness check for an entity.
+
+    ``applicable`` is False when no template is active (nothing to complete).
+    ``passed`` is True when all mandatory fields are satisfied; ``missing`` and
+    ``messages`` describe unsatisfied mandatory fields.
+    """
+    applicable: bool
+    passed: bool
+    missing: list[str] = Field(default_factory=list)
+    messages: list[str] = Field(default_factory=list)

--- a/src/backend/src/models/compliance_templates.py
+++ b/src/backend/src/models/compliance_templates.py
@@ -66,6 +66,19 @@ class ComplianceFieldRead(ComplianceFieldBase):
     model_config = {"from_attributes": True}
 
 
+class ComplianceFieldReorderItem(BaseModel):
+    """A field's reorder instruction: new ordinal and group assignment."""
+    id: UUID
+    group_title: str = Field("", max_length=255)
+    group_order: int = Field(0, ge=0)
+    field_order: int = Field(0, ge=0)
+
+
+class ComplianceFieldsReorder(BaseModel):
+    """Bulk field reorder payload."""
+    fields: list[ComplianceFieldReorderItem] = Field(default_factory=list)
+
+
 # ----- Templates ----------------------------------------------------------
 
 class ComplianceTemplateBase(BaseModel):

--- a/src/backend/src/repositories/compliance_templates_repository.py
+++ b/src/backend/src/repositories/compliance_templates_repository.py
@@ -213,6 +213,33 @@ class ComplianceTemplatesRepository:
 
     # ----- Values (polymorphic, per-entity) -------------------------------
 
+    def add_value(
+        self,
+        db: Session,
+        *,
+        field_id: UUID,
+        entity_type: str,
+        entity_id: str,
+        value: object,
+        filled_by: str | None,
+    ) -> ComplianceTemplateValueDb:
+        """Insert a new value row for a field/entity. Does NOT upsert; assumes row doesn't exist.
+
+        Used by the reconciler to materialize defaults. Caller is responsible for
+        verifying the row doesn't already exist.
+        """
+        row = ComplianceTemplateValueDb(
+            field_id=field_id,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            value=value,
+            filled_by=filled_by,
+        )
+        db.add(row)
+        db.flush()
+        db.refresh(row)
+        return row
+
     def list_values(self, db: Session, *, entity_type: str, entity_id: str, field_ids: list[UUID]) -> list[ComplianceTemplateValueDb]:
         if not field_ids:
             return []

--- a/src/backend/src/repositories/compliance_templates_repository.py
+++ b/src/backend/src/repositories/compliance_templates_repository.py
@@ -1,0 +1,210 @@
+"""Repository for Compliance Templates: definitions, fields, and per-entity values."""
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from src.common.logging import get_logger
+from src.db_models.compliance_templates import (
+    DEFAULT_SCOPE_ID,
+    DEFAULT_SCOPE_TYPE,
+    ComplianceTemplateDb,
+    ComplianceTemplateFieldDb,
+    ComplianceTemplateValueDb,
+)
+
+logger = get_logger(__name__)
+
+
+class ComplianceTemplatesRepository:
+
+    # ----- Templates ------------------------------------------------------
+
+    def list_templates(self, db: Session, *, entity_type: str | None = None) -> list[ComplianceTemplateDb]:
+        q = db.query(ComplianceTemplateDb)
+        if entity_type:
+            q = q.filter(ComplianceTemplateDb.entity_type == entity_type)
+        return q.order_by(ComplianceTemplateDb.created_at).all()
+
+    def get_template(self, db: Session, template_id: UUID) -> ComplianceTemplateDb | None:
+        return db.query(ComplianceTemplateDb).filter(ComplianceTemplateDb.id == template_id).first()
+
+    def get_active_template(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        scope_type: str = DEFAULT_SCOPE_TYPE,
+        scope_id: str = DEFAULT_SCOPE_ID,
+    ) -> ComplianceTemplateDb | None:
+        return (
+            db.query(ComplianceTemplateDb)
+            .filter(
+                ComplianceTemplateDb.entity_type == entity_type,
+                ComplianceTemplateDb.scope_type == scope_type,
+                ComplianceTemplateDb.scope_id == scope_id,
+                ComplianceTemplateDb.is_active.is_(True),
+            )
+            .first()
+        )
+
+    def create_template(
+        self,
+        db: Session,
+        *,
+        name: str,
+        entity_type: str,
+        description: str | None = None,
+        created_by: str | None = None,
+    ) -> ComplianceTemplateDb:
+        obj = ComplianceTemplateDb(
+            name=name,
+            entity_type=entity_type,
+            description=description,
+            scope_type=DEFAULT_SCOPE_TYPE,
+            scope_id=DEFAULT_SCOPE_ID,
+            is_active=False,
+            created_by=created_by,
+        )
+        db.add(obj)
+        db.flush()
+        db.refresh(obj)
+        logger.info(f"Created compliance template '{name}' for entity_type '{entity_type}'")
+        return obj
+
+    def update_template(self, db: Session, *, db_obj: ComplianceTemplateDb, update_data: dict) -> ComplianceTemplateDb:
+        for field, value in update_data.items():
+            if hasattr(db_obj, field) and field not in ("id", "is_active", "entity_type"):
+                setattr(db_obj, field, value)
+        db.add(db_obj)
+        db.flush()
+        db.refresh(db_obj)
+        return db_obj
+
+    def delete_template(self, db: Session, *, db_obj: ComplianceTemplateDb) -> None:
+        db.delete(db_obj)
+        db.flush()
+        logger.info(f"Deleted compliance template '{db_obj.name}'")
+
+    def activate_template(self, db: Session, *, db_obj: ComplianceTemplateDb) -> ComplianceTemplateDb:
+        """Activate a template, deactivating any currently-active one for the same scope.
+
+        Deactivation happens first (and is flushed) so the partial unique index
+        on (entity_type, scope_type, scope_id) is never violated.
+        """
+        current = self.get_active_template(
+            db,
+            entity_type=db_obj.entity_type,
+            scope_type=db_obj.scope_type,
+            scope_id=db_obj.scope_id,
+        )
+        if current and current.id != db_obj.id:
+            current.is_active = False
+            db.add(current)
+            db.flush()
+        db_obj.is_active = True
+        db.add(db_obj)
+        db.flush()
+        db.refresh(db_obj)
+        logger.info(f"Activated compliance template '{db_obj.name}' ({db_obj.entity_type})")
+        return db_obj
+
+    def deactivate_template(self, db: Session, *, db_obj: ComplianceTemplateDb) -> ComplianceTemplateDb:
+        db_obj.is_active = False
+        db.add(db_obj)
+        db.flush()
+        db.refresh(db_obj)
+        return db_obj
+
+    # ----- Fields ---------------------------------------------------------
+
+    def add_field(self, db: Session, *, template_id: UUID, **field_data) -> ComplianceTemplateFieldDb:
+        obj = ComplianceTemplateFieldDb(template_id=template_id, **field_data)
+        db.add(obj)
+        db.flush()
+        db.refresh(obj)
+        return obj
+
+    def get_field(self, db: Session, field_id: UUID) -> ComplianceTemplateFieldDb | None:
+        return db.query(ComplianceTemplateFieldDb).filter(ComplianceTemplateFieldDb.id == field_id).first()
+
+    def list_fields(self, db: Session, *, template_id: UUID) -> list[ComplianceTemplateFieldDb]:
+        return (
+            db.query(ComplianceTemplateFieldDb)
+            .filter(ComplianceTemplateFieldDb.template_id == template_id)
+            .order_by(ComplianceTemplateFieldDb.group_order, ComplianceTemplateFieldDb.field_order)
+            .all()
+        )
+
+    # ----- Values (polymorphic, per-entity) -------------------------------
+
+    def list_values(self, db: Session, *, entity_type: str, entity_id: str, field_ids: list[UUID]) -> list[ComplianceTemplateValueDb]:
+        if not field_ids:
+            return []
+        return (
+            db.query(ComplianceTemplateValueDb)
+            .filter(
+                ComplianceTemplateValueDb.entity_type == entity_type,
+                ComplianceTemplateValueDb.entity_id == entity_id,
+                ComplianceTemplateValueDb.field_id.in_(field_ids),
+            )
+            .all()
+        )
+
+    def replace_values(
+        self,
+        db: Session,
+        *,
+        entity_type: str,
+        entity_id: str,
+        valid_field_ids: set[UUID],
+        values_by_field: dict[UUID, object],
+        filled_by: str | None,
+    ) -> list[ComplianceTemplateValueDb]:
+        """Replace-all write: upsert the given field values, delete omitted ones.
+
+        Only fields in ``valid_field_ids`` (the active template's fields) are
+        written; unknown field ids in the payload are ignored. This is the
+        materialization event. Mirrors ``set_tags_for_entity``.
+        """
+        current = (
+            db.query(ComplianceTemplateValueDb)
+            .filter(
+                ComplianceTemplateValueDb.entity_type == entity_type,
+                ComplianceTemplateValueDb.entity_id == entity_id,
+                ComplianceTemplateValueDb.field_id.in_(valid_field_ids),
+            )
+            .all()
+        )
+        current_by_field = {v.field_id: v for v in current}
+        written_field_ids: set[UUID] = set()
+
+        for field_id, value in values_by_field.items():
+            if field_id not in valid_field_ids:
+                continue
+            written_field_ids.add(field_id)
+            existing = current_by_field.get(field_id)
+            if existing:
+                existing.value = value
+                existing.filled_by = filled_by
+                db.add(existing)
+            else:
+                db.add(
+                    ComplianceTemplateValueDb(
+                        field_id=field_id,
+                        entity_type=entity_type,
+                        entity_id=entity_id,
+                        value=value,
+                        filled_by=filled_by,
+                    )
+                )
+
+        # Remove rows for template fields omitted from the replace-all payload.
+        for field_id, existing in current_by_field.items():
+            if field_id not in written_field_ids:
+                db.delete(existing)
+
+        db.flush()
+        return self.list_values(db, entity_type=entity_type, entity_id=entity_id, field_ids=list(valid_field_ids))
+
+
+compliance_templates_repo = ComplianceTemplatesRepository()

--- a/src/backend/src/repositories/compliance_templates_repository.py
+++ b/src/backend/src/repositories/compliance_templates_repository.py
@@ -135,6 +135,82 @@ class ComplianceTemplatesRepository:
             .all()
         )
 
+    def update_field(self, db: Session, *, field_id: UUID, update_data: dict) -> ComplianceTemplateFieldDb | None:
+        """Update a field's safe attributes (label, hint_text, default_value, is_mandatory, group metadata).
+
+        Does NOT support value_type or possible_values changes — those are destructive
+        edits guarded by the manager.
+        """
+        field = self.get_field(db, field_id)
+        if not field:
+            return None
+        # Whitelist safe fields: label, hint_text, default_value, is_mandatory, group_title, group_order, field_order
+        safe_fields = {"label", "hint_text", "default_value", "is_mandatory", "group_title", "group_order", "field_order"}
+        for key, value in update_data.items():
+            if key in safe_fields and hasattr(field, key):
+                setattr(field, key, value)
+        db.add(field)
+        db.flush()
+        db.refresh(field)
+        return field
+
+    def delete_field(self, db: Session, *, field_id: UUID) -> None:
+        """Delete a field and its values."""
+        field = self.get_field(db, field_id)
+        if field:
+            db.delete(field)
+            db.flush()
+            logger.info(f"Deleted compliance field '{field.label}' (id={field_id})")
+
+    def count_field_values(self, db: Session, *, field_id: UUID) -> int:
+        """Count how many entities have stored values for this field."""
+        return db.query(ComplianceTemplateValueDb).filter(ComplianceTemplateValueDb.field_id == field_id).count()
+
+    def reorder_fields(self, db: Session, *, template_id: UUID, order_map: list[dict]) -> list[ComplianceTemplateFieldDb]:
+        """Bulk reorder fields and groups: order_map = [{id, group_title, group_order, field_order}, ...].
+
+        Uses two-pass approach to avoid unique constraint violations on field_order:
+        first sets all changing rows to negative temp values, then to final values.
+        """
+        fields = self.list_fields(db, template_id=template_id)
+        field_by_id = {f.id: f for f in fields}
+        changed = []
+
+        for item in order_map:
+            field_id = item["id"]
+            field = field_by_id.get(field_id)
+            if not field:
+                continue
+            # Check if any field is actually changing
+            new_group_title = item.get("group_title", field.group_title)
+            new_group_order = item.get("group_order", field.group_order)
+            new_field_order = item.get("field_order", field.field_order)
+            if (
+                new_group_title != field.group_title
+                or new_group_order != field.group_order
+                or new_field_order != field.field_order
+            ):
+                changed.append((field, item))
+
+        if not changed:
+            return fields
+
+        # Pass 1: set to temp negative values
+        for i, (field, _) in enumerate(changed):
+            field.field_order = -(i + 1)
+            db.add(field)
+        db.flush()
+
+        # Pass 2: set to final values
+        for field, item in changed:
+            field.group_title = item.get("group_title", field.group_title)
+            field.group_order = item.get("group_order", field.group_order)
+            field.field_order = item.get("field_order", field.field_order)
+            db.add(field)
+        db.flush()
+
+        return self.list_fields(db, template_id=template_id)
+
     # ----- Values (polymorphic, per-entity) -------------------------------
 
     def list_values(self, db: Session, *, entity_type: str, entity_id: str, field_ids: list[UUID]) -> list[ComplianceTemplateValueDb]:

--- a/src/backend/src/routes/compliance_templates_routes.py
+++ b/src/backend/src/routes/compliance_templates_routes.py
@@ -1,0 +1,188 @@
+"""API routes for Compliance Templates.
+
+Two RBAC surfaces:
+- ``settings-compliance-templates`` gates admin template *definition* management.
+- ``compliance-template-values`` gates per-entity value read (READ_ONLY) vs
+  write (READ_WRITE).
+"""
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from src.common.authorization import PermissionChecker
+from src.common.dependencies import CurrentUserDep, DBSessionDep
+from src.common.features import FeatureAccessLevel
+from src.common.logging import get_logger
+from src.controller.compliance_templates_manager import (
+    ComplianceTemplateError,
+    compliance_templates_manager,
+)
+from src.models.compliance_templates import (
+    ComplianceCompletenessRead,
+    ComplianceTemplateCreate,
+    ComplianceTemplateRead,
+    ComplianceTemplateUpdate,
+    ComplianceValuesReplace,
+    EntityComplianceRead,
+)
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/compliance-templates", tags=["Compliance Templates"])
+
+ADMIN_FEATURE_ID = "settings-compliance-templates"
+VALUES_FEATURE_ID = "compliance-template-values"
+
+
+# ----- Admin: template definitions ----------------------------------------
+
+@router.get("", response_model=list[ComplianceTemplateRead])
+async def list_templates(
+    db: DBSessionDep,
+    entity_type: str | None = None,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
+):
+    """List templates, optionally filtered by bound entity type. Admin surface."""
+    return compliance_templates_manager.list_templates(db, entity_type=entity_type)
+
+
+@router.post("", response_model=ComplianceTemplateRead, status_code=status.HTTP_201_CREATED)
+async def create_template(
+    body: ComplianceTemplateCreate,
+    db: DBSessionDep,
+    current_user: CurrentUserDep,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Create a template (optionally with inline fields). Admin only."""
+    try:
+        return compliance_templates_manager.create_template(
+            db, payload=body, user_email=current_user.email if current_user else None
+        )
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error creating compliance template: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to create compliance template")
+
+
+@router.put("/{template_id}", response_model=ComplianceTemplateRead)
+async def update_template(
+    template_id: UUID,
+    body: ComplianceTemplateUpdate,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Update a template's safe attributes (name, description). Admin only."""
+    update_data = body.model_dump(exclude_unset=True)
+    try:
+        return compliance_templates_manager.update_template(db, template_id=template_id, update_data=update_data)
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.post("/{template_id}/activate", response_model=ComplianceTemplateRead)
+async def activate_template(
+    template_id: UUID,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Activate a template, deactivating any currently-active one for its entity type."""
+    try:
+        return compliance_templates_manager.set_active(db, template_id=template_id, active=True)
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.post("/{template_id}/deactivate", response_model=ComplianceTemplateRead)
+async def deactivate_template(
+    template_id: UUID,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Deactivate a template."""
+    try:
+        return compliance_templates_manager.set_active(db, template_id=template_id, active=False)
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+@router.delete("/{template_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_template(
+    template_id: UUID,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Delete a template and its fields/values. Admin only."""
+    try:
+        compliance_templates_manager.delete_template(db, template_id=template_id)
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+# ----- Per-entity: composed read + replace-all write -----------------------
+
+@router.get("/entities/{entity_type}/{entity_id}", response_model=EntityComplianceRead)
+async def read_entity_compliance(
+    entity_type: str,
+    entity_id: str,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(VALUES_FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
+):
+    """Composed read: { template, fields, values } for an entity. Read-only allowed."""
+    return compliance_templates_manager.read_for_entity(db, entity_type=entity_type, entity_id=entity_id)
+
+
+@router.get("/entities/{entity_type}/{entity_id}/completeness", response_model=ComplianceCompletenessRead)
+async def entity_completeness(
+    entity_type: str,
+    entity_id: str,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(VALUES_FEATURE_ID, FeatureAccessLevel.READ_ONLY)),
+):
+    """Advisory completeness result for an entity. Never blocks; read-only allowed."""
+    applicable = compliance_templates_manager.has_active_template(db, entity_type=entity_type)
+    result = compliance_templates_manager.check_completeness(db, entity_type=entity_type, entity_id=entity_id)
+    return ComplianceCompletenessRead(
+        applicable=applicable,
+        passed=result.passed,
+        missing=result.missing,
+        messages=result.messages,
+    )
+
+
+@router.put("/entities/{entity_type}/{entity_id}/values", response_model=EntityComplianceRead)
+async def replace_entity_values(
+    entity_type: str,
+    entity_id: str,
+    body: ComplianceValuesReplace,
+    db: DBSessionDep,
+    current_user: CurrentUserDep,
+    _: None = Depends(PermissionChecker(VALUES_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Replace-all write of an entity's values (the materialization event)."""
+    try:
+        return compliance_templates_manager.replace_values(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            writes=body.values,
+            user_email=current_user.email if current_user else None,
+        )
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error writing compliance values: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to write compliance values")
+
+
+def register_routes(app):
+    app.include_router(router)
+    logger.info("Compliance templates routes registered")

--- a/src/backend/src/routes/compliance_templates_routes.py
+++ b/src/backend/src/routes/compliance_templates_routes.py
@@ -19,6 +19,9 @@ from src.controller.compliance_templates_manager import (
 )
 from src.models.compliance_templates import (
     ComplianceCompletenessRead,
+    ComplianceFieldCreate,
+    ComplianceFieldRead,
+    ComplianceFieldsReorder,
     ComplianceTemplateCreate,
     ComplianceTemplateRead,
     ComplianceTemplateUpdate,
@@ -123,6 +126,86 @@ async def delete_template(
     except ComplianceTemplateError as e:
         db.rollback()
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+
+
+# ----- Admin: field management (safe & destructive) -------------------------
+
+@router.post("/{template_id}/fields", response_model=ComplianceFieldRead, status_code=status.HTTP_201_CREATED)
+async def add_template_field(
+    template_id: UUID,
+    body: ComplianceFieldCreate,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Add a field to a template. Safe to call on active template."""
+    try:
+        return compliance_templates_manager.add_field(db, template_id=template_id, payload=body)
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error adding compliance field: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to add field")
+
+
+@router.put("/{template_id}/fields/reorder", response_model=list[ComplianceFieldRead])
+async def reorder_template_fields(
+    template_id: UUID,
+    body: ComplianceFieldsReorder,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Reorder fields and reassign groups. Admin only."""
+    try:
+        order_map = [{"id": f.id, "group_title": f.group_title, "group_order": f.group_order, "field_order": f.field_order} for f in body.fields]
+        return compliance_templates_manager.reorder_fields(db, template_id=template_id, order_map=order_map)
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error reordering fields: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to reorder fields")
+
+
+@router.put("/{template_id}/fields/{field_id}", response_model=ComplianceFieldRead)
+async def update_template_field(
+    template_id: UUID,
+    field_id: UUID,
+    body: dict,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Update a field's safe attributes or add an enum value. Guards against destructive edits."""
+    try:
+        return compliance_templates_manager.update_field(db, field_id=field_id, payload=body)
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error updating field: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to update field")
+
+
+@router.delete("/{template_id}/fields/{field_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_template_field(
+    template_id: UUID,
+    field_id: UUID,
+    db: DBSessionDep,
+    _: None = Depends(PermissionChecker(ADMIN_FEATURE_ID, FeatureAccessLevel.READ_WRITE)),
+):
+    """Delete a field. Guarded: cannot delete if stored values exist."""
+    try:
+        compliance_templates_manager.delete_field(db, field_id=field_id)
+    except ComplianceTemplateError as e:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except Exception as e:
+        db.rollback()
+        logger.error(f"Error deleting field: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to delete field")
 
 
 # ----- Per-entity: composed read + replace-all write -----------------------

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -43,6 +43,7 @@ from src.common.workflow_triggers import get_trigger_registry, fire_trigger_safe
 from src.models.process_workflows import EntityType
 from src.models.notifications import NotificationType
 from src.common.dependencies import NotificationsManagerDep, CurrentUserDep, DBSessionDep
+from src.controller.compliance_templates_manager import compliance_templates_manager
 
 from src.common.logging import get_logger
 logger = get_logger(__name__)
@@ -2333,6 +2334,18 @@ async def update_data_product(
 
         success = True
         response_status_code = 200
+
+        # Reconcile compliance template values: materialize defaults for fields without rows.
+        # Wrapped in try/except so reconcile failure never breaks the product update.
+        try:
+            compliance_templates_manager.reconcile_entity(
+                db,
+                entity_type="data_product",
+                entity_id=product_id,
+                user_email=current_user.email if current_user else None,
+            )
+        except Exception as e:
+            logger.warning(f"Compliance reconcile failed for product {product_id}: {e}")
 
         # Fire on_update workflow trigger
         fire_trigger_safe(

--- a/src/backend/src/routes/data_product_routes.py
+++ b/src/backend/src/routes/data_product_routes.py
@@ -387,6 +387,20 @@ async def set_publication_scope(
                 detail=f"Product must be active to publish. Current status: {product_db.status}"
             )
 
+        # Compliance Templates (#712): block publishing to any non-none scope
+        # when mandatory compliance fields are incomplete. Advisory on edit,
+        # blocking here at publish. No-op when no template is active.
+        if scope != "none":
+            completeness = compliance_templates_manager.check_completeness(
+                db, entity_type="data_product", entity_id=product_id
+            )
+            if not completeness.passed:
+                raise HTTPException(
+                    status_code=409,
+                    detail="Cannot publish: required compliance fields are incomplete. "
+                    + " ".join(completeness.messages),
+                )
+
         product_db.publication_scope = scope
         if scope != "none":
             product_db.published_at = datetime.now(timezone.utc)

--- a/src/backend/src/tests/unit/test_compliance_completeness.py
+++ b/src/backend/src/tests/unit/test_compliance_completeness.py
@@ -1,0 +1,121 @@
+"""Unit tests for the Compliance Templates completeness validator.
+
+Pure-function, table-driven coverage of the mandatory-satisfaction logic and
+effective-value fallback (mirrors the compliance-DSL evaluator tests).
+"""
+import pytest
+
+from src.common.compliance_completeness import (
+    FieldSpec,
+    check_completeness,
+)
+
+
+def _field(fid, *, mandatory, value_type="string", default=None, label=None):
+    return FieldSpec(
+        field_id=fid,
+        label=label or fid,
+        value_type=value_type,
+        is_mandatory=mandatory,
+        default_value=default,
+    )
+
+
+class TestMandatorySatisfaction:
+    def test_mandatory_with_value_passes(self):
+        fields = [_field("a", mandatory=True)]
+        result = check_completeness(fields, {"a": "filled"})
+        assert result.passed is True
+        assert result.missing == []
+        assert result.messages == []
+
+    def test_mandatory_unfilled_no_default_fails(self):
+        fields = [_field("a", mandatory=True, label="Purpose")]
+        result = check_completeness(fields, {})
+        assert result.passed is False
+        assert result.missing == ["Purpose"]
+        assert result.messages == ["'Purpose' is required but has no value."]
+
+    def test_mandatory_with_default_passes_even_when_unfilled(self):
+        fields = [_field("a", mandatory=True, default="90 days")]
+        result = check_completeness(fields, {})
+        assert result.passed is True
+
+    def test_non_mandatory_unfilled_passes(self):
+        fields = [_field("a", mandatory=False)]
+        result = check_completeness(fields, {})
+        assert result.passed is True
+
+    def test_empty_string_value_does_not_satisfy(self):
+        fields = [_field("a", mandatory=True, label="Purpose")]
+        result = check_completeness(fields, {"a": "   "})
+        assert result.passed is False
+        assert "Purpose" in result.missing
+
+    def test_stored_value_overrides_missing_default(self):
+        # No default, but a real stored value satisfies.
+        fields = [_field("a", mandatory=True, default=None)]
+        assert check_completeness(fields, {"a": "x"}).passed is True
+
+
+class TestEffectiveValueFallback:
+    def test_falls_back_to_default_when_unstored(self):
+        fields = [_field("a", mandatory=True, value_type="numeric", default=5)]
+        assert check_completeness(fields, {}).passed is True
+
+    def test_empty_default_does_not_satisfy(self):
+        fields = [_field("a", mandatory=True, value_type="string", default="")]
+        assert check_completeness(fields, {}).passed is False
+
+
+class TestTypeEdgeCases:
+    def test_boolean_false_satisfies(self):
+        # Boolean false counts as set.
+        fields = [_field("a", mandatory=True, value_type="boolean")]
+        assert check_completeness(fields, {"a": False}).passed is True
+
+    def test_multi_enum_empty_list_fails(self):
+        fields = [_field("a", mandatory=True, value_type="multi_enum", label="Cats")]
+        result = check_completeness(fields, {"a": []})
+        assert result.passed is False
+        assert result.missing == ["Cats"]
+
+    def test_multi_enum_with_selection_passes(self):
+        fields = [_field("a", mandatory=True, value_type="multi_enum")]
+        assert check_completeness(fields, {"a": ["pii"]}).passed is True
+
+    def test_range_partial_bounds_fails(self):
+        fields = [_field("a", mandatory=True, value_type="range", label="Band")]
+        result = check_completeness(fields, {"a": {"low": 1, "high": None}})
+        assert result.passed is False
+        assert result.missing == ["Band"]
+
+    def test_range_both_bounds_passes(self):
+        fields = [_field("a", mandatory=True, value_type="range")]
+        assert check_completeness(fields, {"a": {"low": 1, "high": 2}}).passed is True
+
+    def test_numeric_zero_satisfies(self):
+        fields = [_field("a", mandatory=True, value_type="numeric")]
+        assert check_completeness(fields, {"a": 0}).passed is True
+
+
+class TestMultipleFields:
+    def test_reports_all_missing_in_order(self):
+        fields = [
+            _field("a", mandatory=True, label="A"),
+            _field("b", mandatory=False, label="B"),
+            _field("c", mandatory=True, label="C"),
+        ]
+        result = check_completeness(fields, {"a": ""})
+        assert result.passed is False
+        assert result.missing == ["A", "C"]
+
+    def test_all_satisfied_passes(self):
+        fields = [
+            _field("a", mandatory=True, default="x"),
+            _field("c", mandatory=True),
+        ]
+        assert check_completeness(fields, {"c": "y"}).passed is True
+
+    def test_no_fields_passes(self):
+        assert check_completeness([], {}).passed is True

--- a/src/backend/src/tests/unit/test_compliance_field_admin.py
+++ b/src/backend/src/tests/unit/test_compliance_field_admin.py
@@ -1,0 +1,328 @@
+"""Unit tests for compliance template field admin operations (slices #709, #711).
+
+Tests cover:
+- Field reorder with two-pass ordinal assignment
+- Destructive edit guards (delete when values exist, value_type change, enum narrowing)
+- Safe edits take effect immediately (label, hint, default, mandatory, group order)
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from src.controller.compliance_templates_manager import (
+    ComplianceTemplateError,
+    ComplianceTemplatesManager,
+)
+from src.db_models.compliance_templates import ComplianceTemplateFieldDb, ComplianceTemplateDb
+from src.models.compliance_templates import ComplianceValueType
+from src.repositories.compliance_templates_repository import compliance_templates_repo
+
+
+class TestComplianceFieldAdmin(unittest.TestCase):
+    """Test destructive edit guards and field reordering."""
+
+    def setUp(self):
+        self.manager = ComplianceTemplatesManager()
+        self.template_id = uuid4()
+        self.field_id_1 = uuid4()
+        self.field_id_2 = uuid4()
+
+    # ----- SLICE #711: Destructive Edit Guards -----
+
+    def test_delete_field_succeeds_when_no_values_exist(self):
+        """DELETE succeeds when no stored values exist."""
+        db = MagicMock()
+        field = ComplianceTemplateFieldDb(
+            id=self.field_id_1,
+            template_id=self.template_id,
+            key="test_field",
+            label="Test Field",
+            reference_id="test_field",
+            value_type="string",
+            is_mandatory=False,
+        )
+
+        with patch.object(
+            compliance_templates_repo, "get_field", return_value=field
+        ):
+            with patch.object(
+                compliance_templates_repo, "count_field_values", return_value=0
+            ):
+                with patch.object(
+                    compliance_templates_repo, "delete_field"
+                ):
+                    # Should not raise
+                    self.manager.delete_field(db, field_id=self.field_id_1)
+                    db.commit.assert_called_once()
+
+    def test_delete_field_fails_when_values_exist(self):
+        """DELETE fails with 409 when stored values exist."""
+        db = MagicMock()
+        field = ComplianceTemplateFieldDb(
+            id=self.field_id_1,
+            template_id=self.template_id,
+            key="test_field",
+            label="Test Field",
+            reference_id="test_field",
+            value_type="string",
+        )
+
+        with patch.object(
+            compliance_templates_repo, "get_field", return_value=field
+        ):
+            with patch.object(
+                compliance_templates_repo, "count_field_values", return_value=5
+            ):
+                with self.assertRaises(ComplianceTemplateError) as ctx:
+                    self.manager.delete_field(db, field_id=self.field_id_1)
+                self.assertIn("Cannot delete field", str(ctx.exception))
+
+    def test_update_field_rejects_value_type_change_when_values_exist(self):
+        """UPDATE rejects value_type change when stored values exist."""
+        db = MagicMock()
+        field = ComplianceTemplateFieldDb(
+            id=self.field_id_1,
+            template_id=self.template_id,
+            key="test_field",
+            label="Test Field",
+            reference_id="test_field",
+            value_type="string",
+            is_mandatory=False,
+        )
+        payload = {
+            "value_type": ComplianceValueType.NUMERIC,
+            "label": "New Label",
+        }
+
+        with patch.object(
+            compliance_templates_repo, "get_field", return_value=field
+        ):
+            with patch.object(
+                compliance_templates_repo, "count_field_values", return_value=3
+            ):
+                with self.assertRaises(ComplianceTemplateError) as ctx:
+                    self.manager.update_field(db, field_id=self.field_id_1, payload=payload)
+                self.assertIn("Cannot change field value type", str(ctx.exception))
+
+    def test_update_field_rejects_enum_narrowing_when_values_exist(self):
+        """UPDATE rejects removing enum values when stored values exist."""
+        db = MagicMock()
+        field = ComplianceTemplateFieldDb(
+            id=self.field_id_1,
+            template_id=self.template_id,
+            key="test_field",
+            label="Test Field",
+            reference_id="test_field",
+            value_type="enum",
+            possible_values=["red", "green", "blue"],
+            is_mandatory=False,
+        )
+        # Try to narrow possible_values by removing "blue"
+        payload = {
+            "possible_values": ["red", "green"],
+        }
+
+        with patch.object(
+            compliance_templates_repo, "get_field", return_value=field
+        ):
+            with patch.object(
+                compliance_templates_repo, "count_field_values", return_value=2
+            ):
+                with self.assertRaises(ComplianceTemplateError) as ctx:
+                    self.manager.update_field(db, field_id=self.field_id_1, payload=payload)
+                self.assertIn("Cannot remove enum values", str(ctx.exception))
+
+    def test_update_field_allows_enum_expansion_when_values_exist(self):
+        """UPDATE allows adding new enum values (safe)."""
+        db = MagicMock()
+        field = ComplianceTemplateFieldDb(
+            id=self.field_id_1,
+            template_id=self.template_id,
+            key="test_field",
+            label="Test Field",
+            reference_id="test_field",
+            value_type="enum",
+            possible_values=["red", "green"],
+            default_value="red",
+            is_mandatory=False,
+            group_title="",
+            group_order=0,
+            field_order=0,
+        )
+        # Add a new color (safe)
+        payload = {
+            "possible_values": ["red", "green", "blue"],
+        }
+
+        with patch.object(
+            compliance_templates_repo, "get_field", return_value=field
+        ):
+            with patch.object(
+                compliance_templates_repo, "count_field_values", return_value=2
+            ):
+                with patch.object(
+                    compliance_templates_repo, "update_field", return_value=field
+                ):
+                    # Should not raise
+                    self.manager.update_field(db, field_id=self.field_id_1, payload=payload)
+                    db.commit.assert_called_once()
+
+    def test_update_field_safe_attributes_when_no_values_exist(self):
+        """UPDATE succeeds on safe attributes (label, hint, mandatory) when no values."""
+        db = MagicMock()
+        field = ComplianceTemplateFieldDb(
+            id=self.field_id_1,
+            template_id=self.template_id,
+            key="test_field",
+            label="Old Label",
+            hint_text="Old hint",
+            reference_id="test_field",
+            value_type="string",
+            is_mandatory=False,
+        )
+        payload = {
+            "label": "New Label",
+            "hint_text": "New hint",
+            "is_mandatory": True,
+        }
+
+        updated_field = ComplianceTemplateFieldDb(
+            id=self.field_id_1,
+            template_id=self.template_id,
+            key="test_field",
+            label="New Label",
+            hint_text="New hint",
+            reference_id="test_field",
+            value_type="string",
+            is_mandatory=True,
+            group_title="",
+            group_order=0,
+            field_order=0,
+        )
+
+        with patch.object(
+            compliance_templates_repo, "get_field", return_value=field
+        ):
+            with patch.object(
+                compliance_templates_repo, "count_field_values", return_value=0
+            ):
+                with patch.object(
+                    compliance_templates_repo, "update_field", return_value=updated_field
+                ):
+                    result = self.manager.update_field(db, field_id=self.field_id_1, payload=payload)
+                    self.assertEqual(result.label, "New Label")
+                    self.assertEqual(result.hint_text, "New hint")
+                    self.assertTrue(result.is_mandatory)
+                    db.commit.assert_called_once()
+
+    # ----- SLICE #709: Field Reorder -----
+
+    def test_reorder_fields_two_pass_approach(self):
+        """REORDER uses two-pass approach: temp negatives, then finals."""
+        db = MagicMock()
+        template = ComplianceTemplateDb(
+            id=self.template_id,
+            name="Test Template",
+            entity_type="data_product",
+        )
+
+        order_map = [
+            {"id": self.field_id_1, "group_title": "Group A", "group_order": 0, "field_order": 1},
+            {"id": self.field_id_2, "group_title": "Group A", "group_order": 0, "field_order": 0},
+        ]
+
+        fields_result = [
+            ComplianceTemplateFieldDb(
+                id=self.field_id_1,
+                template_id=self.template_id,
+                key="field_1",
+                label="Field 1",
+                reference_id="field_1",
+                value_type="string",
+                group_title="Group A",
+                group_order=0,
+                field_order=1,
+                is_mandatory=False,
+            ),
+            ComplianceTemplateFieldDb(
+                id=self.field_id_2,
+                template_id=self.template_id,
+                key="field_2",
+                label="Field 2",
+                reference_id="field_2",
+                value_type="string",
+                group_title="Group A",
+                group_order=0,
+                field_order=0,
+                is_mandatory=False,
+            ),
+        ]
+
+        with patch.object(
+            compliance_templates_repo, "get_template", return_value=template
+        ):
+            with patch.object(
+                compliance_templates_repo, "reorder_fields", return_value=fields_result
+            ):
+                result = self.manager.reorder_fields(db, template_id=self.template_id, order_map=order_map)
+                self.assertEqual(len(result), 2)
+                db.commit.assert_called_once()
+
+    def test_reorder_fields_template_not_found(self):
+        """REORDER fails if template doesn't exist."""
+        db = MagicMock()
+        order_map = [
+            {"id": self.field_id_1, "group_title": "Group A", "group_order": 0, "field_order": 0},
+        ]
+
+        with patch.object(
+            compliance_templates_repo, "get_template", return_value=None
+        ):
+            with self.assertRaises(ComplianceTemplateError) as ctx:
+                self.manager.reorder_fields(db, template_id=self.template_id, order_map=order_map)
+            self.assertIn("Template not found", str(ctx.exception))
+
+
+class TestReorderFieldsRepositoryLogic(unittest.TestCase):
+    """Test the two-pass reorder logic at the repository level (pure function test)."""
+
+    def test_reorder_two_pass_avoids_unique_constraint(self):
+        """Two-pass reorder temporarily uses negative values to avoid constraint violations."""
+        # Simulate field_order unique constraint by checking no duplicates mid-process
+        fields_by_id = {
+            "f1": {"id": "f1", "field_order": 0},
+            "f2": {"id": "f2", "field_order": 1},
+        }
+        order_map = [
+            {"id": "f1", "field_order": 1},
+            {"id": "f2", "field_order": 0},
+        ]
+
+        # Pass 1: assign temp negatives
+        changed = []
+        for item in order_map:
+            if fields_by_id[item["id"]]["field_order"] != item["field_order"]:
+                changed.append(item)
+        self.assertEqual(len(changed), 2)
+
+        for i, item in enumerate(changed):
+            fields_by_id[item["id"]]["field_order"] = -(i + 1)
+
+        # Check no duplicates after pass 1
+        orders = [f["field_order"] for f in fields_by_id.values()]
+        self.assertEqual(len(orders), len(set(orders)), "Pass 1 should have no duplicates")
+
+        # Pass 2: assign finals
+        for item in changed:
+            fields_by_id[item["id"]]["field_order"] = item["field_order"]
+
+        # Check no duplicates after pass 2
+        orders = [f["field_order"] for f in fields_by_id.values()]
+        self.assertEqual(len(orders), len(set(orders)), "Pass 2 should have no duplicates")
+        # Check order swapped
+        self.assertEqual(fields_by_id["f1"]["field_order"], 1)
+        self.assertEqual(fields_by_id["f2"]["field_order"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/backend/src/tests/unit/test_compliance_publish_gate.py
+++ b/src/backend/src/tests/unit/test_compliance_publish_gate.py
@@ -1,0 +1,191 @@
+"""Unit tests for the compliance publish gate (Slice #712).
+
+Tests the decision logic for blocking publish when mandatory compliance fields
+are incomplete, using mocks to isolate the gate from the full database.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from src.controller.data_products_manager import DataProductsManager
+from src.common.compliance_completeness import CompletenessResult
+
+
+@pytest.fixture
+def mock_db():
+    """Mock database session."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_product_db():
+    """Mock data product database object."""
+    product = MagicMock()
+    product.id = "prod-123"
+    product.name = "Test Product"
+    product.output_ports = []
+    return product
+
+
+@pytest.fixture
+def data_products_manager(mock_db):
+    """DataProductsManager with mocked dependencies."""
+    manager = DataProductsManager(mock_db)
+    return manager
+
+
+class TestPublishWithCompliance:
+    """Tests for publish_product with compliance gate."""
+
+    def test_publish_succeeds_when_no_template_active(self, data_products_manager, mock_db, mock_product_db):
+        """Publish succeeds when no compliance template is active (no gate applies)."""
+        # Mock the product lookup
+        data_products_manager._repo.get = MagicMock(return_value=mock_product_db)
+
+        # Mock compliance_templates_manager to return passing (no template active)
+        with patch("src.controller.data_products_manager.compliance_templates_manager") as mock_mgr:
+            mock_mgr.check_completeness.return_value = CompletenessResult(passed=True)
+
+            # Mock transition_status to succeed
+            with patch.object(data_products_manager, "transition_status") as mock_transition:
+                mock_transition.return_value = MagicMock(status="active")
+
+                # Mock trigger and other post-transition operations
+                with patch("src.common.workflow_triggers.get_trigger_registry"):
+                    result = data_products_manager.publish_product("prod-123", current_user="user@example.com")
+
+                    # Verify transition_status was called (gate did not block)
+                    mock_transition.assert_called_once_with("prod-123", "active", "user@example.com")
+                    assert result.status == "active"
+
+    def test_publish_blocks_when_mandatory_fields_missing(self, data_products_manager, mock_db, mock_product_db):
+        """Publish fails with ValueError when mandatory compliance fields are missing."""
+        # Mock the product lookup
+        data_products_manager._repo.get = MagicMock(return_value=mock_product_db)
+
+        # Mock compliance_templates_manager to return failing
+        with patch("src.controller.data_products_manager.compliance_templates_manager") as mock_mgr:
+            mock_mgr.check_completeness.return_value = CompletenessResult(
+                passed=False,
+                missing=["Data Owner", "Retention Policy"],
+                messages=[
+                    "'Data Owner' is required but has no value.",
+                    "'Retention Policy' is required but has no value.",
+                ],
+            )
+
+            # Publish should raise ValueError before reaching transition_status
+            with pytest.raises(ValueError) as exc_info:
+                data_products_manager.publish_product("prod-123", current_user="user@example.com")
+
+            # Verify the error message contains the missing fields
+            error_msg = str(exc_info.value)
+            assert "Cannot publish product: Missing mandatory compliance fields" in error_msg
+            assert "Data Owner" in error_msg
+            assert "Retention Policy" in error_msg
+
+    def test_publish_succeeds_when_all_mandatory_fields_satisfied(self, data_products_manager, mock_db, mock_product_db):
+        """Publish succeeds when all mandatory compliance fields are satisfied."""
+        # Mock the product lookup
+        data_products_manager._repo.get = MagicMock(return_value=mock_product_db)
+
+        # Mock compliance_templates_manager to return passing
+        with patch("src.controller.data_products_manager.compliance_templates_manager") as mock_mgr:
+            mock_mgr.check_completeness.return_value = CompletenessResult(passed=True, missing=[], messages=[])
+
+            # Mock transition_status to succeed
+            with patch.object(data_products_manager, "transition_status") as mock_transition:
+                mock_transition.return_value = MagicMock(status="active")
+
+                # Mock trigger and other post-transition operations
+                with patch("src.common.workflow_triggers.get_trigger_registry"):
+                    result = data_products_manager.publish_product("prod-123", current_user="user@example.com")
+
+                    # Verify transition_status was called (gate did not block)
+                    mock_transition.assert_called_once_with("prod-123", "active", "user@example.com")
+                    assert result.status == "active"
+
+    def test_compliance_gate_called_with_correct_params(self, data_products_manager, mock_db, mock_product_db):
+        """Verify compliance check is called with data_product entity type and product id."""
+        # Mock the product lookup
+        data_products_manager._repo.get = MagicMock(return_value=mock_product_db)
+
+        # Mock compliance_templates_manager
+        with patch("src.controller.data_products_manager.compliance_templates_manager") as mock_mgr:
+            mock_mgr.check_completeness.return_value = CompletenessResult(passed=True)
+
+            # Mock transition_status to succeed
+            with patch.object(data_products_manager, "transition_status") as mock_transition:
+                mock_transition.return_value = MagicMock(status="active")
+
+                # Mock trigger
+                with patch("src.common.workflow_triggers.get_trigger_registry"):
+                    data_products_manager.publish_product("prod-123", current_user="user@example.com")
+
+                    # Verify check_completeness was called with correct parameters
+                    mock_mgr.check_completeness.assert_called_once()
+                    call_args = mock_mgr.check_completeness.call_args
+                    # Check that it was called with entity_type="data_product" and entity_id=product_id
+                    assert call_args.kwargs.get("entity_type") == "data_product"
+                    assert call_args.kwargs.get("entity_id") == "prod-123"
+
+    def test_error_logs_compliance_failure(self, data_products_manager, mock_db, mock_product_db):
+        """Verify that compliance failures are logged before raising."""
+        # Mock the product lookup
+        data_products_manager._repo.get = MagicMock(return_value=mock_product_db)
+
+        # Mock compliance_templates_manager to return failing
+        with patch("src.controller.data_products_manager.compliance_templates_manager") as mock_mgr:
+            mock_mgr.check_completeness.return_value = CompletenessResult(
+                passed=False,
+                missing=["Owner"],
+                messages=["'Owner' is required but has no value."],
+            )
+
+            # Mock the logger to verify it was called
+            with patch("src.controller.data_products_manager.logger") as mock_logger:
+                with pytest.raises(ValueError):
+                    data_products_manager.publish_product("prod-123", current_user="user@example.com")
+
+                # Verify error was logged
+                mock_logger.error.assert_called()
+                call_args = str(mock_logger.error.call_args)
+                assert "Compliance check failed" in call_args or "prod-123" in call_args
+
+    def test_compliance_gate_executed_before_status_transition(self, data_products_manager, mock_db, mock_product_db):
+        """Verify compliance gate executes before transition_status (order matters for atomicity)."""
+        call_order = []
+
+        def track_completeness_call(*args, **kwargs):
+            call_order.append("completeness_check")
+            return CompletenessResult(passed=True)
+
+        def track_transition_call(*args, **kwargs):
+            call_order.append("transition_status")
+            return MagicMock(status="active")
+
+        # Mock the product lookup
+        data_products_manager._repo.get = MagicMock(return_value=mock_product_db)
+
+        # Mock compliance_templates_manager
+        with patch("src.controller.data_products_manager.compliance_templates_manager") as mock_mgr:
+            mock_mgr.check_completeness.side_effect = track_completeness_call
+
+            # Mock transition_status
+            with patch.object(data_products_manager, "transition_status", side_effect=track_transition_call):
+                # Mock trigger
+                with patch("src.common.workflow_triggers.get_trigger_registry"):
+                    data_products_manager.publish_product("prod-123", current_user="user@example.com")
+
+                    # Verify order: completeness check must come before transition
+                    assert call_order == ["completeness_check", "transition_status"]
+
+    def test_publish_does_not_block_on_edits(self):
+        """Test that product edits are NOT blocked by compliance (only publish is blocked).
+
+        This test documents the intended behavior: only the publish_product path
+        enforces the compliance gate; update_product does not.
+        """
+        # This is a behavior documentation test.
+        # The actual update_product method should not call check_completeness.
+        # We don't test it here, but this comment documents the expected behavior.
+        pass

--- a/src/backend/src/tests/unit/test_compliance_reconcile.py
+++ b/src/backend/src/tests/unit/test_compliance_reconcile.py
@@ -1,0 +1,233 @@
+"""Unit tests for the pure compliance reconciler (materialization & freezing)."""
+import pytest
+from uuid import uuid4
+
+from src.common.compliance_reconcile import FieldDesc, ReconcileAction, reconcile
+
+
+class TestReconcileBasics:
+    """Basic reconciler semantics: propose defaults for fields lacking rows."""
+
+    def test_no_fields(self):
+        """Empty template yields no actions."""
+        actions = reconcile([], set())
+        assert actions == []
+
+    def test_no_existing_rows(self):
+        """All fields without stored rows and with defaults get proposed."""
+        f1 = uuid4()
+        f2 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="string", default_value="default1"),
+            FieldDesc(field_id=f2, value_type="string", default_value="default2"),
+        ]
+        actions = reconcile(fields, set())
+        assert len(actions) == 2
+        assert {a.field_id for a in actions} == {f1, f2}
+
+    def test_fields_with_existing_rows_skipped(self):
+        """Fields in existing_field_ids are never touched."""
+        f1 = uuid4()
+        f2 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="string", default_value="default1"),
+            FieldDesc(field_id=f2, value_type="string", default_value="default2"),
+        ]
+        # f1 already has a row
+        actions = reconcile(fields, {f1})
+        assert len(actions) == 1
+        assert actions[0].field_id == f2
+
+    def test_frozen_rows_never_in_action_set(self):
+        """Existing rows are NEVER modified — they're skipped entirely."""
+        f1 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="string", default_value="newdefault"),
+        ]
+        # f1 already has a stored row (maybe with an old value)
+        actions = reconcile(fields, {f1})
+        # Should propose NO actions because the row already exists
+        assert actions == []
+
+
+class TestEmptyDefaults:
+    """Fields with empty/None defaults yield no row proposal."""
+
+    def test_string_empty_string_no_proposal(self):
+        """Empty string default is unset."""
+        f1 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="string", default_value=""),
+        ]
+        actions = reconcile(fields, set())
+        assert actions == []
+
+    def test_string_none_no_proposal(self):
+        """None default is unset."""
+        f1 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="string", default_value=None),
+        ]
+        actions = reconcile(fields, set())
+        assert actions == []
+
+    def test_multi_enum_empty_list_no_proposal(self):
+        """Empty list is unset for multi_enum."""
+        f1 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="multi_enum", default_value=[]),
+        ]
+        actions = reconcile(fields, set())
+        assert actions == []
+
+    def test_range_missing_bounds_no_proposal(self):
+        """Range with missing bound is unset."""
+        f1 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="range", default_value={"low": 1}),
+        ]
+        actions = reconcile(fields, set())
+        assert actions == []
+
+    def test_boolean_explicit_false_is_set(self):
+        """Explicit false is considered SET for booleans."""
+        f1 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="boolean", default_value=False),
+        ]
+        actions = reconcile(fields, set())
+        assert len(actions) == 1
+        assert actions[0].value is False
+
+
+class TestValuePreservation:
+    """Reconciler preserves the exact default value in the action."""
+
+    def test_string_value_preserved(self):
+        """String default is copied as-is."""
+        f1 = uuid4()
+        default = "my-default-text"
+        fields = [
+            FieldDesc(field_id=f1, value_type="string", default_value=default),
+        ]
+        actions = reconcile(fields, set())
+        assert len(actions) == 1
+        assert actions[0].value == default
+
+    def test_numeric_value_preserved(self):
+        """Numeric default is copied as-is."""
+        f1 = uuid4()
+        default = 42
+        fields = [
+            FieldDesc(field_id=f1, value_type="numeric", default_value=default),
+        ]
+        actions = reconcile(fields, set())
+        assert len(actions) == 1
+        assert actions[0].value == default
+
+    def test_enum_value_preserved(self):
+        """Enum default is copied as-is."""
+        f1 = uuid4()
+        default = "choice1"
+        fields = [
+            FieldDesc(field_id=f1, value_type="enum", default_value=default),
+        ]
+        actions = reconcile(fields, set())
+        assert len(actions) == 1
+        assert actions[0].value == default
+
+    def test_multi_enum_value_preserved(self):
+        """MultiEnum default list is copied as-is."""
+        f1 = uuid4()
+        default = ["a", "b"]
+        fields = [
+            FieldDesc(field_id=f1, value_type="multi_enum", default_value=default),
+        ]
+        actions = reconcile(fields, set())
+        assert len(actions) == 1
+        assert actions[0].value == default
+
+    def test_range_value_preserved(self):
+        """Range default dict is copied as-is."""
+        f1 = uuid4()
+        default = {"low": 10, "high": 20}
+        fields = [
+            FieldDesc(field_id=f1, value_type="range", default_value=default),
+        ]
+        actions = reconcile(fields, set())
+        assert len(actions) == 1
+        assert actions[0].value == default
+
+
+class TestIdempotence:
+    """Reconciler is idempotent: running twice yields same result."""
+
+    def test_second_run_no_new_actions(self):
+        """Running reconcile a second time over the same post-reconcile state yields no actions."""
+        f1 = uuid4()
+        f2 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="string", default_value="d1"),
+            FieldDesc(field_id=f2, value_type="string", default_value="d2"),
+        ]
+        # First run
+        actions1 = reconcile(fields, set())
+        assert len(actions1) == 2
+
+        # Simulate that rows have now been written for f1 and f2
+        existing_after_first_run = {f1, f2}
+
+        # Second run: no new actions should be proposed
+        actions2 = reconcile(fields, existing_after_first_run)
+        assert actions2 == []
+
+
+class TestMandatoryWithoutDefault:
+    """Mandatory fields without defaults are left pending."""
+
+    def test_mandatory_no_default_no_action(self):
+        """Mandatory field with no default yields no proposal (left pending)."""
+        f1 = uuid4()
+        fields = [
+            FieldDesc(field_id=f1, value_type="string", default_value=None),
+        ]
+        actions = reconcile(fields, set())
+        assert actions == []
+
+
+class TestMixedScenario:
+    """Table-driven test combining all semantics."""
+
+    @pytest.mark.parametrize(
+        "field_id,value_type,default_value,in_existing,expect_action",
+        [
+            # (id, type, default, in_existing_set, should_propose)
+            (None, "string", "default", False, True),  # Propose: has default, no row
+            (None, "string", "", False, False),  # Skip: empty default
+            (None, "string", None, False, False),  # Skip: None default
+            (None, "string", "default", True, False),  # Skip: row exists (frozen)
+            (None, "numeric", 0, False, True),  # Propose: 0 is a set number
+            (None, "numeric", None, False, False),  # Skip: None
+            (None, "boolean", False, False, True),  # Propose: False is set
+            (None, "boolean", None, False, False),  # Skip: None
+            (None, "multi_enum", ["a"], False, True),  # Propose: non-empty list
+            (None, "multi_enum", [], False, False),  # Skip: empty list
+            (None, "range", {"low": 1, "high": 2}, False, True),  # Propose: both bounds
+            (None, "range", {"low": 1}, False, False),  # Skip: missing high
+        ],
+    )
+    def test_table_driven(self, field_id, value_type, default_value, in_existing, expect_action):
+        """Table-driven test of reconcile semantics."""
+        if field_id is None:
+            field_id = uuid4()
+        existing_set = {field_id} if in_existing else set()
+        fields = [
+            FieldDesc(field_id=field_id, value_type=value_type, default_value=default_value),
+        ]
+        actions = reconcile(fields, existing_set)
+        if expect_action:
+            assert len(actions) == 1
+            assert actions[0].field_id == field_id
+            assert actions[0].value == default_value
+        else:
+            assert actions == []

--- a/src/backend/src/tests/unit/test_compliance_value_types.py
+++ b/src/backend/src/tests/unit/test_compliance_value_types.py
@@ -1,0 +1,193 @@
+"""Unit tests for the Compliance Templates value-type engine.
+
+Pure-function, table-driven coverage of validation/coercion and "is-set"
+semantics for every value type (mirrors the compliance-DSL evaluator tests).
+"""
+import pytest
+
+from src.common.compliance_value_types import (
+    ComplianceValueType,
+    ValueTypeError,
+    coerce_value,
+    is_set,
+)
+
+
+class TestCoerceString:
+    def test_plain_string_passes_through(self):
+        assert coerce_value("string", "hello") == "hello"
+
+    def test_empty_string_allowed_at_write(self):
+        # Empty is allowed on write; "unset" is a completeness concern.
+        assert coerce_value("string", "") == ""
+
+    def test_non_string_rejected(self):
+        with pytest.raises(ValueTypeError):
+            coerce_value("string", 123)
+
+
+class TestCoerceNumeric:
+    @pytest.mark.parametrize("raw,expected", [
+        (5, 5),
+        (5.0, 5),          # integral float normalized to int
+        (5.5, 5.5),
+        ("42", 42),
+        ("3.14", 3.14),
+        ("  7  ", 7),      # surrounding whitespace tolerated
+        (-2, -2),
+    ])
+    def test_valid_numbers(self, raw, expected):
+        assert coerce_value("numeric", raw) == expected
+
+    @pytest.mark.parametrize("raw", ["abc", "", "  ", "1.2.3", [1], {"n": 1}])
+    def test_invalid_numbers_rejected(self, raw):
+        with pytest.raises(ValueTypeError):
+            coerce_value("numeric", raw)
+
+    def test_boolean_rejected_as_numeric(self):
+        # bool is a subclass of int; must not silently become 1/0.
+        with pytest.raises(ValueTypeError):
+            coerce_value("numeric", True)
+
+
+class TestCoerceBoolean:
+    @pytest.mark.parametrize("raw,expected", [
+        (True, True),
+        (False, False),
+        ("true", True),
+        ("False", False),
+        ("YES", True),
+        ("no", False),
+        (1, True),
+        (0, False),
+    ])
+    def test_valid_booleans(self, raw, expected):
+        assert coerce_value("boolean", raw) is expected
+
+    @pytest.mark.parametrize("raw", ["maybe", "2", 2, "", []])
+    def test_invalid_booleans_rejected(self, raw):
+        with pytest.raises(ValueTypeError):
+            coerce_value("boolean", raw)
+
+
+class TestCoerceDate:
+    @pytest.mark.parametrize("raw,expected", [
+        ("2026-08-13", "2026-08-13"),
+        ("2026-08-13T10:30:00", "2026-08-13"),   # datetime -> date component
+    ])
+    def test_valid_dates(self, raw, expected):
+        assert coerce_value("date", raw) == expected
+
+    @pytest.mark.parametrize("raw", ["not-a-date", "2026-13-40", "", "08/13/2026"])
+    def test_invalid_dates_rejected(self, raw):
+        with pytest.raises(ValueTypeError):
+            coerce_value("date", raw)
+
+
+class TestCoerceRange:
+    def test_valid_range(self):
+        assert coerce_value("range", {"low": 1, "high": 10}) == {"low": 1, "high": 10}
+
+    def test_equal_bounds_allowed(self):
+        assert coerce_value("range", {"low": 5, "high": 5}) == {"low": 5, "high": 5}
+
+    def test_string_bounds_coerced(self):
+        assert coerce_value("range", {"low": "1", "high": "2.5"}) == {"low": 1, "high": 2.5}
+
+    def test_low_greater_than_high_rejected(self):
+        with pytest.raises(ValueTypeError):
+            coerce_value("range", {"low": 10, "high": 1})
+
+    @pytest.mark.parametrize("raw", [
+        {"low": 1},                 # missing high
+        {"high": 1},                # missing low
+        [1, 10],                    # not an object
+        {"low": "x", "high": 10},   # non-numeric bound
+    ])
+    def test_malformed_range_rejected(self, raw):
+        with pytest.raises(ValueTypeError):
+            coerce_value("range", raw)
+
+
+class TestCoerceEnum:
+    VOCAB = ["low", "medium", "high"]
+
+    def test_member_accepted(self):
+        assert coerce_value("enum", "medium", self.VOCAB) == "medium"
+
+    def test_non_member_rejected(self):
+        with pytest.raises(ValueTypeError):
+            coerce_value("enum", "urgent", self.VOCAB)
+
+    def test_missing_vocabulary_rejected(self):
+        with pytest.raises(ValueTypeError):
+            coerce_value("enum", "medium", None)
+
+    def test_non_string_rejected(self):
+        with pytest.raises(ValueTypeError):
+            coerce_value("enum", 3, self.VOCAB)
+
+
+class TestCoerceMultiEnum:
+    VOCAB = ["pii", "phi", "financial"]
+
+    def test_subset_accepted(self):
+        assert coerce_value("multi_enum", ["pii", "financial"], self.VOCAB) == ["pii", "financial"]
+
+    def test_empty_list_allowed_at_write(self):
+        assert coerce_value("multi_enum", [], self.VOCAB) == []
+
+    def test_deduplicates_preserving_order(self):
+        assert coerce_value("multi_enum", ["pii", "pii", "phi"], self.VOCAB) == ["pii", "phi"]
+
+    def test_non_member_rejected(self):
+        with pytest.raises(ValueTypeError):
+            coerce_value("multi_enum", ["pii", "unknown"], self.VOCAB)
+
+    def test_non_list_rejected(self):
+        with pytest.raises(ValueTypeError):
+            coerce_value("multi_enum", "pii", self.VOCAB)
+
+
+class TestCoerceMisc:
+    def test_none_passes_through_for_every_type(self):
+        for vt in ComplianceValueType:
+            assert coerce_value(vt, None) is None
+
+    def test_unknown_type_rejected(self):
+        with pytest.raises(ValueError):
+            coerce_value("banana", "x")
+
+
+class TestIsSet:
+    @pytest.mark.parametrize("vt,value,expected", [
+        # Boolean: both true and false count as set.
+        ("boolean", True, True),
+        ("boolean", False, True),
+        ("boolean", None, False),
+        # String / Enum / Date: non-empty, non-whitespace.
+        ("string", "x", True),
+        ("string", "", False),
+        ("string", "   ", False),
+        ("enum", "high", True),
+        ("enum", "", False),
+        ("date", "2026-08-13", True),
+        ("date", "", False),
+        # Numeric: any number (incl. 0), but not bool.
+        ("numeric", 0, True),
+        ("numeric", 3.5, True),
+        ("numeric", None, False),
+        # MultiEnum: at least one selection.
+        ("multi_enum", ["a"], True),
+        ("multi_enum", [], False),
+        # Range: both bounds present.
+        ("range", {"low": 1, "high": 2}, True),
+        ("range", {"low": 1, "high": None}, False),
+        ("range", {"low": None, "high": 2}, False),
+    ])
+    def test_is_set(self, vt, value, expected):
+        assert is_set(vt, value) is expected
+
+    def test_numeric_bool_not_counted_as_set(self):
+        # A stray bool must not read as a numeric "set".
+        assert is_set("numeric", True) is False

--- a/src/backend/src/tests/unit/test_workflow_template_substitution.py
+++ b/src/backend/src/tests/unit/test_workflow_template_substitution.py
@@ -1,0 +1,161 @@
+"""Tests for workflow template substitution with compliance template values."""
+
+import pytest
+from src.common.workflow_executor import substitute_template, StepContext
+from src.models.process_workflows import TriggerContext
+
+
+@pytest.fixture
+def step_context_with_template_values():
+    """Fixture: StepContext with pre-resolved template values."""
+    return StepContext(
+        entity={"name": "test-product", "owner": "alice@example.com"},
+        entity_type="data_product",
+        entity_id="prod-123",
+        entity_name="test-product",
+        user_email="bob@example.com",
+        trigger_context=None,
+        execution_id="exec-456",
+        workflow_id="wf-789",
+        workflow_name="test-workflow",
+        step_results={},
+        on_behalf_of=None,
+        template_values={
+            "purpose": "Analytics",
+            "retention": "90 days",
+            "classification": "Internal",
+        },
+    )
+
+
+@pytest.fixture
+def step_context_without_template_values():
+    """Fixture: StepContext without template values."""
+    return StepContext(
+        entity={"name": "test-product", "owner": "alice@example.com"},
+        entity_type="data_product",
+        entity_id="prod-123",
+        entity_name="test-product",
+        user_email="bob@example.com",
+        trigger_context=None,
+        execution_id="exec-456",
+        workflow_id="wf-789",
+        workflow_name="test-workflow",
+        step_results={},
+        on_behalf_of=None,
+        template_values=None,
+    )
+
+
+class TestTemplateSubstitution:
+    """Test substitute_template function."""
+
+    def test_resolve_template_field_from_values(self, step_context_with_template_values):
+        """Test ${template.<ref>} resolves from template_values."""
+        template = "Purpose: ${template.purpose}"
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == "Purpose: Analytics"
+
+    def test_resolve_multiple_template_fields(self, step_context_with_template_values):
+        """Test multiple ${template.<ref>} placeholders resolve."""
+        template = (
+            "Purpose: ${template.purpose}, "
+            "Retention: ${template.retention}, "
+            "Classification: ${template.classification}"
+        )
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == "Purpose: Analytics, Retention: 90 days, Classification: Internal"
+
+    def test_unknown_template_field_left_intact(self, step_context_with_template_values):
+        """Test ${template.<unknown>} is left intact when not in template_values."""
+        template = "Purpose: ${template.purpose}, Owner: ${template.unknown_field}"
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == "Purpose: Analytics, Owner: ${template.unknown_field}"
+
+    def test_template_field_without_context_values_left_intact(
+        self, step_context_without_template_values
+    ):
+        """Test ${template.<ref>} is left intact when context.template_values is None."""
+        template = "Purpose: ${template.purpose}"
+        result = substitute_template(template, step_context_without_template_values)
+        assert result == "Purpose: ${template.purpose}"
+
+    def test_entity_field_resolution_still_works(self, step_context_with_template_values):
+        """Test ${entity.<field>} resolution still works (regression)."""
+        template = "Product: ${entity.name}, Owner: ${entity.owner}"
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == "Product: test-product, Owner: alice@example.com"
+
+    def test_context_field_resolution_still_works(self, step_context_with_template_values):
+        """Test ${context.<field>} resolution still works (regression)."""
+        template = "User: ${context.user_email}, Entity ID: ${context.entity_id}"
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == "User: bob@example.com, Entity ID: prod-123"
+
+    def test_flat_scalar_resolution_still_works(self, step_context_with_template_values):
+        """Test flat scalars like ${user_email} still resolve (regression)."""
+        template = "Requester: ${user_email}, Type: ${entity_type}"
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == "Requester: bob@example.com, Type: data_product"
+
+    def test_mixed_template_and_entity_fields(self, step_context_with_template_values):
+        """Test mixing ${template.<ref>} and ${entity.<field>} in same template."""
+        template = (
+            "Product: ${entity.name} "
+            "(Purpose: ${template.purpose}, "
+            "Owner: ${entity.owner})"
+        )
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == (
+            "Product: test-product "
+            "(Purpose: Analytics, "
+            "Owner: alice@example.com)"
+        )
+
+    def test_curly_brace_syntax_also_works(self, step_context_with_template_values):
+        """Test {{template.<ref>}} syntax (alternate) also works."""
+        template = "Purpose: {{template.purpose}}, Owner: {{entity.owner}}"
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == "Purpose: Analytics, Owner: alice@example.com"
+
+    def test_step_results_resolution_still_works(self, step_context_with_template_values):
+        """Test ${step_results.<step>.<field>} resolution still works (regression)."""
+        step_context_with_template_values.step_results = {
+            "approval_step": {
+                "passed": True,
+                "reason": "looks good",
+            }
+        }
+        template = "Approval: ${step_results.approval_step.reason}"
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == "Approval: looks good"
+
+    def test_template_values_with_special_chars(self, step_context_with_template_values):
+        """Test template values containing special characters resolve."""
+        step_context_with_template_values.template_values = {
+            "notes": "Data: PII, Special Chars: <tag> & symbols",
+            "owner": "team+data@example.com",
+        }
+        template = "Notes: ${template.notes}"
+        result = substitute_template(template, step_context_with_template_values)
+        assert result == "Notes: Data: PII, Special Chars: <tag> & symbols"
+
+    def test_empty_template_values_dict_leaves_placeholder_intact(self):
+        """Test that empty template_values dict leaves ${template.<ref>} intact."""
+        context = StepContext(
+            entity={},
+            entity_type="data_product",
+            entity_id="prod-123",
+            entity_name=None,
+            user_email=None,
+            trigger_context=None,
+            execution_id="exec-456",
+            workflow_id="wf-789",
+            workflow_name="test-workflow",
+            step_results={},
+            on_behalf_of=None,
+            template_values={},  # Empty but not None
+        )
+        template = "Purpose: ${template.purpose}"
+        result = substitute_template(template, context)
+        assert result == "Purpose: ${template.purpose}"

--- a/src/frontend/src/app.tsx
+++ b/src/frontend/src/app.tsx
@@ -103,6 +103,7 @@ import SettingsDirectoryView from './views/settings-directory';
 import SettingsSemanticModelsView from './views/settings-semantic-models';
 import SettingsCertificationLevelsView from './views/settings-certification-levels';
 import SettingsMaturityLevelsView from './views/settings-maturity-levels';
+import SettingsComplianceTemplatesView from './views/settings-compliance-templates';
 
 export default function App() {
   const fetchUserInfo = useUserStore((state: any) => state.fetchUserInfo);
@@ -258,6 +259,7 @@ export default function App() {
                 <Route path="semantic-models" element={<SettingsSemanticModelsView />} />
                 <Route path="certification-levels" element={<SettingsCertificationLevelsView />} />
                 <Route path="maturity-levels" element={<SettingsMaturityLevelsView />} />
+                <Route path="compliance-templates" element={<SettingsComplianceTemplatesView />} />
                 <Route path="workflows" element={<Workflows />} />
                 <Route path="workflows/new" element={<WorkflowDesignerView />} />
                 <Route path="workflows/:workflowId" element={<WorkflowDesignerView />} />

--- a/src/frontend/src/components/compliance/compliance-modal.tsx
+++ b/src/frontend/src/components/compliance/compliance-modal.tsx
@@ -1,0 +1,385 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useToast } from '@/hooks/use-toast';
+import { useApi } from '@/hooks/use-api';
+
+// Mirrors the backend Pydantic models (models/compliance_templates.py).
+export interface ComplianceField {
+  id: string;
+  template_id: string;
+  group_title: string;
+  group_order: number;
+  key: string;
+  label: string;
+  reference_id: string;
+  value_type: string; // slice 1 handles "string"; others rendered as text for now
+  possible_values: string[] | null;
+  default_value: unknown | null;
+  hint_text: string | null;
+  is_mandatory: boolean;
+  field_order: number;
+}
+
+export interface ComplianceTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  entity_type: string;
+  is_active: boolean;
+  fields: ComplianceField[];
+}
+
+export interface ComplianceValue {
+  field_id: string;
+  reference_id: string;
+  entity_type: string;
+  entity_id: string;
+  value: unknown | null;
+  filled_by: string | null;
+  filled_at: string | null;
+}
+
+export interface EntityCompliance {
+  template: ComplianceTemplate | null;
+  fields: ComplianceField[];
+  values: ComplianceValue[];
+}
+
+interface ComplianceModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entityType: string;
+  entityId: string;
+  /** When false, inputs and save are disabled (read-only users). */
+  canWrite: boolean;
+  /** Called after a successful save so the host can refresh any indicators. */
+  onSaved?: () => void;
+}
+
+/** Group fields by their denormalized group title, preserving order. */
+function groupFields(fields: ComplianceField[]): { title: string; fields: ComplianceField[] }[] {
+  const sorted = [...fields].sort(
+    (a, b) => a.group_order - b.group_order || a.field_order - b.field_order,
+  );
+  const groups: { title: string; fields: ComplianceField[] }[] = [];
+  for (const f of sorted) {
+    const title = f.group_title || '';
+    let g = groups.find((x) => x.title === title);
+    if (!g) {
+      g = { title, fields: [] };
+      groups.push(g);
+    }
+    g.fields.push(f);
+  }
+  return groups;
+}
+
+interface RangeValue {
+  low: number | string | null;
+  high: number | string | null;
+}
+
+/** Type-aware input for a single compliance field. */
+function FieldInput({
+  field,
+  value,
+  disabled,
+  onChange,
+}: {
+  field: ComplianceField;
+  value: unknown;
+  disabled: boolean;
+  onChange: (value: unknown) => void;
+}) {
+  const id = `cf-${field.id}`;
+
+  switch (field.value_type) {
+    case 'numeric':
+      return (
+        <Input
+          id={id}
+          type="number"
+          value={value == null ? '' : String(value)}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value === '' ? null : Number(e.target.value))}
+          placeholder={field.hint_text || ''}
+        />
+      );
+
+    case 'boolean':
+      return (
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id={id}
+            checked={value === true}
+            disabled={disabled}
+            onCheckedChange={(checked) => onChange(checked === true)}
+          />
+          <label htmlFor={id} className="text-sm text-muted-foreground">
+            {value === true ? 'Yes' : 'No'}
+          </label>
+        </div>
+      );
+
+    case 'date':
+      return (
+        <Input
+          id={id}
+          type="date"
+          value={typeof value === 'string' ? value : ''}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value || null)}
+        />
+      );
+
+    case 'enum':
+      return (
+        <Select
+          value={typeof value === 'string' && value ? value : undefined}
+          disabled={disabled}
+          onValueChange={(v) => onChange(v)}
+        >
+          <SelectTrigger id={id}>
+            <SelectValue placeholder={field.hint_text || 'Select…'} />
+          </SelectTrigger>
+          <SelectContent>
+            {(field.possible_values || []).map((opt) => (
+              <SelectItem key={opt} value={opt}>
+                {opt}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+
+    case 'multi_enum': {
+      const selected: string[] = Array.isArray(value) ? (value as string[]) : [];
+      const toggle = (opt: string, checked: boolean) => {
+        const next = checked ? [...selected, opt] : selected.filter((s) => s !== opt);
+        onChange(next);
+      };
+      return (
+        <div className="space-y-1.5 rounded-md border p-2">
+          {(field.possible_values || []).map((opt) => (
+            <div key={opt} className="flex items-center gap-2">
+              <Checkbox
+                id={`${id}-${opt}`}
+                checked={selected.includes(opt)}
+                disabled={disabled}
+                onCheckedChange={(checked) => toggle(opt, checked === true)}
+              />
+              <label htmlFor={`${id}-${opt}`} className="text-sm">
+                {opt}
+              </label>
+            </div>
+          ))}
+          {(field.possible_values || []).length === 0 && (
+            <p className="text-xs text-muted-foreground">No options defined.</p>
+          )}
+        </div>
+      );
+    }
+
+    case 'range': {
+      const range: RangeValue =
+        value && typeof value === 'object' ? (value as RangeValue) : { low: null, high: null };
+      const update = (key: 'low' | 'high', raw: string) => {
+        const next = { ...range, [key]: raw === '' ? null : Number(raw) };
+        onChange(next.low == null && next.high == null ? null : next);
+      };
+      return (
+        <div className="flex items-center gap-2">
+          <Input
+            id={`${id}-low`}
+            type="number"
+            aria-label={`${field.label} low`}
+            value={range.low == null ? '' : String(range.low)}
+            disabled={disabled}
+            onChange={(e) => update('low', e.target.value)}
+            placeholder="Low"
+          />
+          <span className="text-muted-foreground">–</span>
+          <Input
+            id={`${id}-high`}
+            type="number"
+            aria-label={`${field.label} high`}
+            value={range.high == null ? '' : String(range.high)}
+            disabled={disabled}
+            onChange={(e) => update('high', e.target.value)}
+            placeholder="High"
+          />
+        </div>
+      );
+    }
+
+    case 'string':
+    default:
+      return (
+        <Input
+          id={id}
+          value={typeof value === 'string' ? value : ''}
+          disabled={disabled}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.hint_text || ''}
+        />
+      );
+  }
+}
+
+/** Shared fill-out / read-only modal for an entity's compliance template values. */
+export default function ComplianceModal({
+  open,
+  onOpenChange,
+  entityType,
+  entityId,
+  canWrite,
+  onSaved,
+}: ComplianceModalProps) {
+  const { toast } = useToast();
+  const { get, put } = useApi();
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [data, setData] = useState<EntityCompliance | null>(null);
+  // Local edit buffer keyed by field id; holds typed values per field type.
+  const [draft, setDraft] = useState<Record<string, unknown>>({});
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data: resp, error } = await get<EntityCompliance>(
+        `/api/compliance-templates/entities/${entityType}/${entityId}`,
+      );
+      if (error) throw new Error(error);
+      setData(resp);
+      // Seed the draft: stored value if present, else the field default.
+      const valueByField = new Map((resp?.values || []).map((v) => [v.field_id, v.value]));
+      const seeded: Record<string, unknown> = {};
+      for (const f of resp?.fields || []) {
+        const stored = valueByField.has(f.id) ? valueByField.get(f.id) : f.default_value;
+        seeded[f.id] = stored ?? null;
+      }
+      setDraft(seeded);
+    } catch (err: any) {
+      toast({ title: 'Error', description: err?.message || 'Failed to load compliance data', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+    }
+  }, [get, entityType, entityId, toast]);
+
+  useEffect(() => {
+    if (open) fetchData();
+  }, [open, fetchData]);
+
+  const handleSave = async () => {
+    if (!data?.template) return;
+    setSaving(true);
+    try {
+      // Replace-all write: send every shown field (including untouched defaults).
+      // Empty strings and empty multi-selects are normalized to null (unset).
+      const values = data.fields.map((f) => {
+        let value = draft[f.id];
+        if (value === '' || value === undefined) value = null;
+        if (Array.isArray(value) && value.length === 0) value = null;
+        return { field_id: f.id, value };
+      });
+      const { error } = await put(
+        `/api/compliance-templates/entities/${entityType}/${entityId}/values`,
+        { values },
+      );
+      if (error) throw new Error(error);
+      toast({ title: 'Saved', description: 'Compliance information updated.' });
+      onOpenChange(false);
+      onSaved?.();
+    } catch (err: any) {
+      toast({ title: 'Error', description: err?.message || 'Failed to save', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const groups = data ? groupFields(data.fields) : [];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{data?.template?.name || 'Compliance'}</DialogTitle>
+          <DialogDescription>
+            {canWrite
+              ? 'Complete the compliance information for this item.'
+              : 'Compliance information for this item (read-only).'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : !data?.template ? (
+          <p className="py-8 text-center text-sm text-muted-foreground">
+            No active compliance template for this item.
+          </p>
+        ) : (
+          <div className="space-y-6 py-2">
+            {groups.map((group) => (
+              <div key={group.title || '__default__'} className="space-y-4">
+                {group.title && (
+                  <h3 className="text-sm font-semibold text-foreground border-b pb-1">{group.title}</h3>
+                )}
+                {group.fields.map((field) => (
+                  <div key={field.id} className="space-y-1.5">
+                    <Label htmlFor={`cf-${field.id}`} className="flex items-center gap-1">
+                      {field.label}
+                      {field.is_mandatory && <span className="text-destructive">*</span>}
+                    </Label>
+                    <FieldInput
+                      field={field}
+                      value={draft[field.id]}
+                      disabled={!canWrite}
+                      onChange={(v) => setDraft((prev) => ({ ...prev, [field.id]: v }))}
+                    />
+                    {field.hint_text && (
+                      <p className="text-xs text-muted-foreground">{field.hint_text}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {canWrite ? 'Cancel' : 'Close'}
+          </Button>
+          {canWrite && data?.template && (
+            <Button onClick={handleSave} disabled={saving || loading}>
+              {saving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
+              Save
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/frontend/src/components/settings/compliance-templates-settings.tsx
+++ b/src/frontend/src/components/settings/compliance-templates-settings.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Plus, Trash2, Power, PowerOff, Loader2, X } from 'lucide-react';
+import { Plus, Trash2, Power, PowerOff, Loader2, X, Pencil } from 'lucide-react';
 import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -43,6 +43,8 @@ interface ComplianceField {
   label: string;
   reference_id: string;
   value_type: string;
+  possible_values: string[] | null;
+  default_value: unknown | null;
   hint_text: string | null;
   is_mandatory: boolean;
   field_order: number;
@@ -64,6 +66,7 @@ const ENTITY_TYPE_OPTIONS = [
 ];
 
 interface DraftField {
+  id?: string; // present when editing an existing field
   label: string;
   reference_id: string;
   group_title: string;
@@ -111,9 +114,21 @@ function parseDefaultValue(valueType: string, raw: string): unknown {
   }
 }
 
+/** Stringify a stored default value back into the editor's text field. */
+function stringifyDefault(valueType: string, value: unknown): string {
+  if (value == null) return '';
+  if (valueType === 'multi_enum' && Array.isArray(value)) return value.join(', ');
+  if (valueType === 'range' && typeof value === 'object') {
+    const r = value as { low?: unknown; high?: unknown };
+    return `${r.low ?? ''}-${r.high ?? ''}`;
+  }
+  if (valueType === 'boolean') return value ? 'true' : 'false';
+  return String(value);
+}
+
 export default function ComplianceTemplatesSettings() {
   const { toast } = useToast();
-  const { get, post, delete: apiDelete } = useApi();
+  const { get, post, put, delete: apiDelete } = useApi();
 
   const [templates, setTemplates] = useState<ComplianceTemplate[]>([]);
   const [loading, setLoading] = useState(true);
@@ -123,6 +138,10 @@ export default function ComplianceTemplatesSettings() {
   const [saving, setSaving] = useState(false);
   const [formData, setFormData] = useState({ name: '', description: '', entity_type: 'data_product' });
   const [draftFields, setDraftFields] = useState<DraftField[]>([]);
+  // Edit mode: the template being edited (null = create mode) + its original
+  // fields, so save can diff (add / update / delete) against the server state.
+  const [editingTemplate, setEditingTemplate] = useState<ComplianceTemplate | null>(null);
+  const [originalFields, setOriginalFields] = useState<ComplianceField[]>([]);
   const hasFetched = useRef(false);
 
   const fetchTemplates = useCallback(async () => {
@@ -146,8 +165,37 @@ export default function ComplianceTemplatesSettings() {
   }, [fetchTemplates]);
 
   const handleOpenCreate = () => {
+    setEditingTemplate(null);
+    setOriginalFields([]);
     setFormData({ name: '', description: '', entity_type: 'data_product' });
     setDraftFields([]);
+    setDialogOpen(true);
+  };
+
+  const handleOpenEdit = (template: ComplianceTemplate) => {
+    setEditingTemplate(template);
+    const sorted = [...(template.fields || [])].sort(
+      (a, b) => a.group_order - b.group_order || a.field_order - b.field_order,
+    );
+    setOriginalFields(sorted);
+    setFormData({
+      name: template.name,
+      description: template.description || '',
+      entity_type: template.entity_type,
+    });
+    setDraftFields(
+      sorted.map((f) => ({
+        id: f.id,
+        label: f.label,
+        reference_id: f.reference_id,
+        group_title: f.group_title || '',
+        value_type: f.value_type,
+        possible_values: Array.isArray(f.possible_values) ? f.possible_values.join(', ') : '',
+        hint_text: f.hint_text || '',
+        default_value: stringifyDefault(f.value_type, f.default_value),
+        is_mandatory: f.is_mandatory,
+      })),
+    );
     setDialogOpen(true);
   };
 
@@ -161,38 +209,40 @@ export default function ComplianceTemplatesSettings() {
     ]);
   };
 
+  /** Map an editor draft field to the API field payload. */
+  const draftToPayload = (f: DraftField, idx: number) => ({
+    group_title: f.group_title.trim(),
+    group_order: 0,
+    key: toSlug(f.label) || `field-${idx + 1}`,
+    label: f.label.trim(),
+    reference_id: (f.reference_id.trim() && toSlug(f.reference_id)) || toSlug(f.label) || `field-${idx + 1}`,
+    value_type: f.value_type,
+    possible_values: VOCAB_TYPES.has(f.value_type)
+      ? f.possible_values.split(',').map((s) => s.trim()).filter(Boolean)
+      : null,
+    default_value: parseDefaultValue(f.value_type, f.default_value),
+    hint_text: f.hint_text.trim() || null,
+    is_mandatory: f.is_mandatory,
+    field_order: idx,
+  });
+
   const handleSave = async () => {
     if (!formData.name.trim()) return;
     setSaving(true);
     try {
-      const fields = draftFields
-        .filter((f) => f.label.trim())
-        .map((f, idx) => {
-          const possibleValues = VOCAB_TYPES.has(f.value_type)
-            ? f.possible_values.split(',').map((s) => s.trim()).filter(Boolean)
-            : null;
-          return {
-            group_title: f.group_title.trim(),
-            group_order: 0,
-            key: toSlug(f.label) || `field-${idx + 1}`,
-            label: f.label.trim(),
-            reference_id: (f.reference_id.trim() && toSlug(f.reference_id)) || toSlug(f.label) || `field-${idx + 1}`,
-            value_type: f.value_type,
-            possible_values: possibleValues,
-            default_value: parseDefaultValue(f.value_type, f.default_value),
-            hint_text: f.hint_text.trim() || null,
-            is_mandatory: f.is_mandatory,
-            field_order: idx,
-          };
+      if (editingTemplate) {
+        await saveEdits(editingTemplate);
+      } else {
+        const fields = draftFields.filter((f) => f.label.trim()).map(draftToPayload);
+        const { error } = await post('/api/compliance-templates', {
+          name: formData.name,
+          description: formData.description || null,
+          entity_type: formData.entity_type,
+          fields,
         });
-      const { error } = await post('/api/compliance-templates', {
-        name: formData.name,
-        description: formData.description || null,
-        entity_type: formData.entity_type,
-        fields,
-      });
-      if (error) throw new Error(error);
-      toast({ title: 'Created', description: `Template "${formData.name}" created.` });
+        if (error) throw new Error(error);
+        toast({ title: 'Created', description: `Template "${formData.name}" created.` });
+      }
       setDialogOpen(false);
       fetchTemplates();
     } catch (err: any) {
@@ -200,6 +250,56 @@ export default function ComplianceTemplatesSettings() {
     } finally {
       setSaving(false);
     }
+  };
+
+  /** Persist edits by diffing the editor against the template's original fields:
+   *  update template attrs, add new fields, update changed ones, delete removed. */
+  const saveEdits = async (template: ComplianceTemplate) => {
+    const base = `/api/compliance-templates/${template.id}`;
+
+    // 1. Template name/description (entity_type is immutable server-side).
+    if (formData.name !== template.name || (formData.description || '') !== (template.description || '')) {
+      const { error } = await put(base, {
+        name: formData.name,
+        description: formData.description || null,
+      });
+      if (error) throw new Error(error);
+    }
+
+    const kept = draftFields.filter((f) => f.label.trim());
+    const keptIds = new Set(kept.filter((f) => f.id).map((f) => f.id));
+
+    // 2. Deletes: original fields no longer present. Surfaces a 409 if the
+    //    field has stored values (guarded server-side) — reported to the user.
+    for (const orig of originalFields) {
+      if (orig.id && !keptIds.has(orig.id)) {
+        const { error } = await apiDelete(`${base}/fields/${orig.id}`);
+        if (error) throw new Error(`Cannot remove "${orig.label}": ${error}`);
+      }
+    }
+
+    // 3. Adds + updates.
+    for (let idx = 0; idx < kept.length; idx++) {
+      const f = kept[idx];
+      const payload = draftToPayload(f, idx);
+      if (!f.id) {
+        const { error } = await post(`${base}/fields`, payload);
+        if (error) throw new Error(`Cannot add "${f.label}": ${error}`);
+      } else {
+        const { error } = await put(`${base}/fields/${f.id}`, payload);
+        if (error) throw new Error(`Cannot update "${f.label}": ${error}`);
+      }
+    }
+
+    // 4. Persist ordering (group + field order) in one reorder call.
+    const reorder = kept
+      .filter((f) => f.id)
+      .map((f, idx) => ({ id: f.id, group_title: f.group_title.trim(), group_order: 0, field_order: idx }));
+    if (reorder.length > 0) {
+      await put(`${base}/fields/reorder`, { fields: reorder });
+    }
+
+    toast({ title: 'Saved', description: `Template "${formData.name}" updated.` });
   };
 
   const handleToggleActive = async (template: ComplianceTemplate) => {
@@ -288,6 +388,15 @@ export default function ComplianceTemplatesSettings() {
                     variant="ghost"
                     size="icon"
                     className="h-7 w-7"
+                    title="Edit"
+                    onClick={() => handleOpenEdit(template)}
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
                     title={template.is_active ? 'Deactivate' : 'Activate'}
                     onClick={() => handleToggleActive(template)}
                   >
@@ -317,15 +426,16 @@ export default function ComplianceTemplatesSettings() {
 
       {/* Create Dialog */}
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent className="max-w-lg">
+        <DialogContent className="max-w-3xl max-h-[85vh] flex flex-col">
           <DialogHeader>
-            <DialogTitle>Add Compliance Template</DialogTitle>
+            <DialogTitle>{editingTemplate ? 'Edit Compliance Template' : 'Add Compliance Template'}</DialogTitle>
             <DialogDescription>
-              Create a template and optionally add text fields. Activate it to make it available on
-              the bound entity type.
+              {editingTemplate
+                ? 'Edit fields, defaults, hints and mandatory flags. Changing a field’s type or removing a field/enum value is blocked when products have already stored values.'
+                : 'Create a template and optionally add fields. Activate it to make it available on the bound entity type.'}
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4 py-2">
+          <div className="flex-1 space-y-4 overflow-y-auto py-2 pr-1">
             <div className="space-y-2">
               <Label htmlFor="ct-name">Name</Label>
               <Input
@@ -349,8 +459,9 @@ export default function ComplianceTemplatesSettings() {
               <Label htmlFor="ct-entity">Entity Type</Label>
               <select
                 id="ct-entity"
-                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm disabled:opacity-60"
                 value={formData.entity_type}
+                disabled={!!editingTemplate}
                 onChange={(e) => setFormData((prev) => ({ ...prev, entity_type: e.target.value }))}
               >
                 {ENTITY_TYPE_OPTIONS.map((o) => (
@@ -361,14 +472,14 @@ export default function ComplianceTemplatesSettings() {
 
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <Label>Text Fields</Label>
+                <Label>Fields</Label>
                 <Button variant="outline" size="sm" onClick={handleAddDraftField}>
                   <Plus className="mr-1 h-3.5 w-3.5" /> Add Field
                 </Button>
               </div>
               {draftFields.length === 0 && (
                 <p className="text-xs text-muted-foreground">
-                  No fields yet. Additional value types are added in later releases.
+                  No fields yet. Click "Add Field" to define one.
                 </p>
               )}
               {draftFields.map((field, idx) => (
@@ -466,7 +577,7 @@ export default function ComplianceTemplatesSettings() {
             <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
             <Button onClick={handleSave} disabled={saving || !formData.name.trim()}>
               {saving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
-              Create
+              {editingTemplate ? 'Save changes' : 'Create'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/frontend/src/components/settings/compliance-templates-settings.tsx
+++ b/src/frontend/src/components/settings/compliance-templates-settings.tsx
@@ -1,0 +1,495 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Plus, Trash2, Power, PowerOff, Loader2, X } from 'lucide-react';
+import { ListItemSkeleton } from '@/components/common/list-view-skeleton';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/hooks/use-toast';
+import { useApi } from '@/hooks/use-api';
+
+interface ComplianceField {
+  id?: string;
+  group_title: string;
+  key: string;
+  label: string;
+  reference_id: string;
+  value_type: string;
+  hint_text: string | null;
+  is_mandatory: boolean;
+  field_order: number;
+  group_order: number;
+}
+
+interface ComplianceTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  entity_type: string;
+  is_active: boolean;
+  fields: ComplianceField[];
+}
+
+// Slice 1: Data Products is the only bound entity type exercised end-to-end.
+const ENTITY_TYPE_OPTIONS = [
+  { value: 'data_product', label: 'Data Products' },
+];
+
+interface DraftField {
+  label: string;
+  reference_id: string;
+  group_title: string;
+  value_type: string;
+  possible_values: string; // comma-separated in the editor; split on save
+  hint_text: string;
+  default_value: string; // raw text; backend coerces to the field type
+  is_mandatory: boolean;
+}
+
+const VALUE_TYPE_OPTIONS = [
+  { value: 'string', label: 'Text' },
+  { value: 'numeric', label: 'Number' },
+  { value: 'boolean', label: 'Yes/No' },
+  { value: 'date', label: 'Date' },
+  { value: 'enum', label: 'Single choice' },
+  { value: 'multi_enum', label: 'Multiple choice' },
+  { value: 'range', label: 'Range (low–high)' },
+];
+
+const VOCAB_TYPES = new Set(['enum', 'multi_enum']);
+
+/** Parse the admin's raw default text into the JSON shape for a field type.
+ *  The backend re-validates/coerces, so this only needs to pick the right shape. */
+function parseDefaultValue(valueType: string, raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  switch (valueType) {
+    case 'numeric': {
+      const n = Number(trimmed);
+      return Number.isNaN(n) ? trimmed : n;
+    }
+    case 'boolean':
+      return /^(true|yes|1)$/i.test(trimmed);
+    case 'multi_enum':
+      return trimmed.split(',').map((s) => s.trim()).filter(Boolean);
+    case 'range': {
+      // Accept "low-high" or "low,high".
+      const parts = trimmed.split(/[,-]/).map((s) => s.trim());
+      if (parts.length === 2) return { low: Number(parts[0]), high: Number(parts[1]) };
+      return trimmed;
+    }
+    default:
+      return trimmed; // string, enum, date
+  }
+}
+
+export default function ComplianceTemplatesSettings() {
+  const { toast } = useToast();
+  const { get, post, delete: apiDelete } = useApi();
+
+  const [templates, setTemplates] = useState<ComplianceTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deletingTemplate, setDeletingTemplate] = useState<ComplianceTemplate | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [formData, setFormData] = useState({ name: '', description: '', entity_type: 'data_product' });
+  const [draftFields, setDraftFields] = useState<DraftField[]>([]);
+  const hasFetched = useRef(false);
+
+  const fetchTemplates = useCallback(async () => {
+    try {
+      setLoading(true);
+      const { data, error } = await get<ComplianceTemplate[]>('/api/compliance-templates');
+      if (error) throw new Error(error);
+      setTemplates(Array.isArray(data) ? data : []);
+    } catch {
+      // Silent on initial load to avoid flash.
+    } finally {
+      setLoading(false);
+    }
+  }, [get]);
+
+  useEffect(() => {
+    if (!hasFetched.current) {
+      hasFetched.current = true;
+      fetchTemplates();
+    }
+  }, [fetchTemplates]);
+
+  const handleOpenCreate = () => {
+    setFormData({ name: '', description: '', entity_type: 'data_product' });
+    setDraftFields([]);
+    setDialogOpen(true);
+  };
+
+  const toSlug = (s: string) =>
+    s.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+
+  const handleAddDraftField = () => {
+    setDraftFields((prev) => [
+      ...prev,
+      { label: '', reference_id: '', group_title: '', value_type: 'string', possible_values: '', hint_text: '', default_value: '', is_mandatory: false },
+    ]);
+  };
+
+  const handleSave = async () => {
+    if (!formData.name.trim()) return;
+    setSaving(true);
+    try {
+      const fields = draftFields
+        .filter((f) => f.label.trim())
+        .map((f, idx) => {
+          const possibleValues = VOCAB_TYPES.has(f.value_type)
+            ? f.possible_values.split(',').map((s) => s.trim()).filter(Boolean)
+            : null;
+          return {
+            group_title: f.group_title.trim(),
+            group_order: 0,
+            key: toSlug(f.label) || `field-${idx + 1}`,
+            label: f.label.trim(),
+            reference_id: (f.reference_id.trim() && toSlug(f.reference_id)) || toSlug(f.label) || `field-${idx + 1}`,
+            value_type: f.value_type,
+            possible_values: possibleValues,
+            default_value: parseDefaultValue(f.value_type, f.default_value),
+            hint_text: f.hint_text.trim() || null,
+            is_mandatory: f.is_mandatory,
+            field_order: idx,
+          };
+        });
+      const { error } = await post('/api/compliance-templates', {
+        name: formData.name,
+        description: formData.description || null,
+        entity_type: formData.entity_type,
+        fields,
+      });
+      if (error) throw new Error(error);
+      toast({ title: 'Created', description: `Template "${formData.name}" created.` });
+      setDialogOpen(false);
+      fetchTemplates();
+    } catch (err: any) {
+      toast({ title: 'Error', description: err?.message || 'Failed to save', variant: 'destructive' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggleActive = async (template: ComplianceTemplate) => {
+    const action = template.is_active ? 'deactivate' : 'activate';
+    const { error } = await post<ComplianceTemplate>(
+      `/api/compliance-templates/${template.id}/${action}`,
+      {},
+    );
+    if (error) {
+      toast({ title: 'Error', description: error, variant: 'destructive' });
+    } else {
+      toast({
+        title: template.is_active ? 'Deactivated' : 'Activated',
+        description: `Template "${template.name}" ${template.is_active ? 'deactivated' : 'is now active'}.`,
+      });
+      fetchTemplates();
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deletingTemplate) return;
+    const { error } = await apiDelete(`/api/compliance-templates/${deletingTemplate.id}`);
+    if (error) {
+      toast({ title: 'Cannot delete', description: error, variant: 'destructive' });
+    } else {
+      toast({ title: 'Deleted', description: `Template "${deletingTemplate.name}" deleted.` });
+      setDeletingTemplate(null);
+      fetchTemplates();
+    }
+    setDeleteDialogOpen(false);
+  };
+
+  const entityLabel = (value: string) =>
+    ENTITY_TYPE_OPTIONS.find((o) => o.value === value)?.label || value;
+
+  if (loading) {
+    return <ListItemSkeleton count={3} height="h-16" className="space-y-2" />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Compliance Templates</h2>
+          <p className="text-sm text-muted-foreground">
+            Define typed, grouped governance fields bound to an entity type. Exactly one template
+            can be active per entity type.
+          </p>
+        </div>
+        <Button onClick={handleOpenCreate} size="sm">
+          <Plus className="mr-1 h-4 w-4" /> Add Template
+        </Button>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Entity Type</TableHead>
+            <TableHead>Fields</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead className="w-32">Actions</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {templates.map((template) => (
+            <TableRow key={template.id}>
+              <TableCell className="font-medium">
+                {template.name}
+                {template.description && (
+                  <div className="text-xs text-muted-foreground">{template.description}</div>
+                )}
+              </TableCell>
+              <TableCell className="text-sm text-muted-foreground">{entityLabel(template.entity_type)}</TableCell>
+              <TableCell className="text-sm text-muted-foreground">{template.fields?.length ?? 0}</TableCell>
+              <TableCell>
+                {template.is_active ? (
+                  <Badge className="bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">Active</Badge>
+                ) : (
+                  <Badge variant="outline">Inactive</Badge>
+                )}
+              </TableCell>
+              <TableCell>
+                <div className="flex gap-1">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    title={template.is_active ? 'Deactivate' : 'Activate'}
+                    onClick={() => handleToggleActive(template)}
+                  >
+                    {template.is_active ? <PowerOff className="h-3.5 w-3.5" /> : <Power className="h-3.5 w-3.5" />}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-destructive"
+                    onClick={() => { setDeletingTemplate(template); setDeleteDialogOpen(true); }}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          ))}
+          {templates.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
+                No compliance templates configured. Click "Add Template" to create one.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+
+      {/* Create Dialog */}
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Add Compliance Template</DialogTitle>
+            <DialogDescription>
+              Create a template and optionally add text fields. Activate it to make it available on
+              the bound entity type.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <Label htmlFor="ct-name">Name</Label>
+              <Input
+                id="ct-name"
+                value={formData.name}
+                onChange={(e) => setFormData((prev) => ({ ...prev, name: e.target.value }))}
+                placeholder="e.g., Terms of Use"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ct-desc">Description</Label>
+              <Textarea
+                id="ct-desc"
+                value={formData.description}
+                onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
+                placeholder="What this template captures..."
+                rows={2}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="ct-entity">Entity Type</Label>
+              <select
+                id="ct-entity"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                value={formData.entity_type}
+                onChange={(e) => setFormData((prev) => ({ ...prev, entity_type: e.target.value }))}
+              >
+                {ENTITY_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Label>Text Fields</Label>
+                <Button variant="outline" size="sm" onClick={handleAddDraftField}>
+                  <Plus className="mr-1 h-3.5 w-3.5" /> Add Field
+                </Button>
+              </div>
+              {draftFields.length === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  No fields yet. Additional value types are added in later releases.
+                </p>
+              )}
+              {draftFields.map((field, idx) => (
+                <div key={idx} className="space-y-2 rounded-md border p-2">
+                  <div className="flex items-center gap-2">
+                    <Input
+                      value={field.label}
+                      onChange={(e) =>
+                        setDraftFields((prev) => prev.map((f, i) => (i === idx ? { ...f, label: e.target.value } : f)))
+                      }
+                      placeholder="Field label"
+                    />
+                    <Input
+                      value={field.group_title}
+                      onChange={(e) =>
+                        setDraftFields((prev) => prev.map((f, i) => (i === idx ? { ...f, group_title: e.target.value } : f)))
+                      }
+                      placeholder="Group (optional)"
+                    />
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 shrink-0"
+                      onClick={() => setDraftFields((prev) => prev.filter((_, i) => i !== idx))}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <select
+                      className="rounded-md border border-input bg-background px-2 py-1.5 text-sm"
+                      value={field.value_type}
+                      onChange={(e) =>
+                        setDraftFields((prev) => prev.map((f, i) => (i === idx ? { ...f, value_type: e.target.value } : f)))
+                      }
+                    >
+                      {VALUE_TYPE_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>{o.label}</option>
+                      ))}
+                    </select>
+                    {VOCAB_TYPES.has(field.value_type) && (
+                      <Input
+                        value={field.possible_values}
+                        onChange={(e) =>
+                          setDraftFields((prev) => prev.map((f, i) => (i === idx ? { ...f, possible_values: e.target.value } : f)))
+                        }
+                        placeholder="Options (comma-separated)"
+                      />
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Input
+                      value={field.hint_text}
+                      onChange={(e) =>
+                        setDraftFields((prev) => prev.map((f, i) => (i === idx ? { ...f, hint_text: e.target.value } : f)))
+                      }
+                      placeholder="Hint text (optional)"
+                    />
+                    <Input
+                      value={field.default_value}
+                      onChange={(e) =>
+                        setDraftFields((prev) => prev.map((f, i) => (i === idx ? { ...f, default_value: e.target.value } : f)))
+                      }
+                      placeholder="Default (optional)"
+                    />
+                    <Input
+                      value={field.reference_id}
+                      onChange={(e) =>
+                        setDraftFields((prev) => prev.map((f, i) => (i === idx ? { ...f, reference_id: e.target.value } : f)))
+                      }
+                      placeholder="Reference id (auto)"
+                    />
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      id={`mandatory-${idx}`}
+                      checked={field.is_mandatory}
+                      onCheckedChange={(checked) =>
+                        setDraftFields((prev) => prev.map((f, i) => (i === idx ? { ...f, is_mandatory: checked === true } : f)))
+                      }
+                    />
+                    <label htmlFor={`mandatory-${idx}`} className="text-sm">Mandatory</label>
+                  </div>
+                  {field.is_mandatory && field.default_value.trim() && (
+                    <p className="text-xs text-amber-600 dark:text-amber-500">
+                      This field is mandatory but has a default — the default will satisfy the
+                      requirement, so owners can publish without changing it.
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogOpen(false)}>Cancel</Button>
+            <Button onClick={handleSave} disabled={saving || !formData.name.trim()}>
+              {saving ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : null}
+              Create
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation */}
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete compliance template?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to delete "{deletingTemplate?.name}"? Its fields and any stored
+              values will be removed. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-destructive text-destructive-foreground">
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/frontend/src/components/settings/settings-layout.tsx
+++ b/src/frontend/src/components/settings/settings-layout.tsx
@@ -25,6 +25,7 @@ import {
   Truck,
   ShieldCheck,
   Activity,
+  ClipboardCheck,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -64,6 +65,7 @@ const settingsNavGroups: SettingsNavGroup[] = [
       { path: '/settings/general', labelKey: 'settings:tabs.general', defaultLabel: 'General', icon: Settings, permissionId: 'settings-general' },
       { path: '/settings/ui', labelKey: 'settings:tabs.ui', defaultLabel: 'UI', icon: Palette, permissionId: 'settings-ui' },
       { path: '/settings/tags', labelKey: 'settings:tabs.tags', defaultLabel: 'Tags', icon: Tags, permissionId: 'tags' },
+      { path: '/settings/compliance-templates', labelKey: 'settings:tabs.complianceTemplates', defaultLabel: 'Compliance Templates', icon: ClipboardCheck, permissionId: 'settings-compliance-templates' },
       { path: '/settings/connectors', labelKey: 'settings:tabs.connectors', defaultLabel: 'Connectors', icon: Plug2, permissionId: 'settings-connectors' },
     ],
   },

--- a/src/frontend/src/i18n/locales/en/settings.json
+++ b/src/frontend/src/i18n/locales/en/settings.json
@@ -110,7 +110,8 @@
     "workflows": "Workflows",
     "uiCustomization": "UI Customization",
     "connectors": "Connectors",
-    "schemaImporter": "Schema Importer"
+    "schemaImporter": "Schema Importer",
+    "complianceTemplates": "Compliance Templates"
   },
   "accessDenied": {
     "title": "Access Denied",

--- a/src/frontend/src/views/data-product-details.tsx
+++ b/src/frontend/src/views/data-product-details.tsx
@@ -13,7 +13,7 @@ import { useApi } from '@/hooks/use-api';
 import { useApprovalWizardTrigger } from '@/hooks/use-approval-wizard-trigger';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Loader2, Pencil, Trash2, AlertCircle, Sparkles, CopyPlus, ArrowLeft, Package, KeyRound, Plus, FileText, Download, Bell, BellOff, Users, ShieldCheck, Globe } from 'lucide-react';
+import { Loader2, Pencil, Trash2, AlertCircle, Sparkles, CopyPlus, ArrowLeft, Package, KeyRound, Plus, FileText, Download, Bell, BellOff, Users, ShieldCheck, Globe, ClipboardCheck } from 'lucide-react';
 import {
   DetailHeaderSkeleton,
   PanelSkeleton,
@@ -64,6 +64,14 @@ import { DirectCertifyDialog, DirectPublishDialog } from '@/components/common/di
 import type { CertificationLevel, PublicationScope } from '@/types/lifecycle';
 import { userHasApprovalPrivilege } from '@/lib/permissions';
 import { ApprovalEntity } from '@/types/settings';
+import ComplianceModal from '@/components/compliance/compliance-modal';
+
+interface ComplianceCompleteness {
+  applicable: boolean;
+  passed: boolean;
+  missing: string[];
+  messages: string[];
+}
 
 /**
  * ODPS v1.0.0 Data Product Details View
@@ -522,11 +530,20 @@ export default function DataProductDetails() {
   const [isCloning, setIsCloning] = useState(false);
   const [isDiscarding, setIsDiscarding] = useState(false);
 
+  // Compliance template (button shown only when a template is active for products)
+  const [complianceModalOpen, setComplianceModalOpen] = useState(false);
+  const [hasActiveComplianceTemplate, setHasActiveComplianceTemplate] = useState(false);
+  const [complianceMissingCount, setComplianceMissingCount] = useState(0);
+
   // Permissions
   const featureId = 'data-products';
   const canRead = !permissionsLoading && hasPermission(featureId, Settings.FeatureAccessLevel.READ_ONLY);
   const canWrite = !permissionsLoading && hasPermission(featureId, Settings.FeatureAccessLevel.READ_WRITE);
   const canAdmin = !permissionsLoading && hasPermission(featureId, Settings.FeatureAccessLevel.ADMIN);
+  // Per-entity compliance value write is gated by its own feature; read-only
+  // users can open the modal but cannot edit.
+  const canWriteCompliance =
+    !permissionsLoading && hasPermission('compliance-template-values', Settings.FeatureAccessLevel.READ_WRITE);
 
   const canApproveProductLifecycle = userHasApprovalPrivilege(
     ApprovalEntity.PRODUCTS,
@@ -642,6 +659,22 @@ export default function DataProductDetails() {
         } catch (subErr) {
           console.warn('Failed to fetch subscribers:', subErr);
         }
+      }
+
+      // Detect whether a compliance template is active for data products so
+      // the fill button is only shown when there's a form to open, and load
+      // the advisory completeness status (missing mandatory fields count).
+      try {
+        const completenessResp = await get<ComplianceCompleteness>(
+          `/api/compliance-templates/entities/data_product/${productId}/completeness`,
+        );
+        const c = completenessResp.data;
+        setHasActiveComplianceTemplate(!!c?.applicable);
+        setComplianceMissingCount(c?.applicable && !c.passed ? (c.missing?.length ?? 0) : 0);
+      } catch (compErr) {
+        console.warn('Failed to fetch compliance status:', compErr);
+        setHasActiveComplianceTemplate(false);
+        setComplianceMissingCount(0);
       }
 
       // ODPS v1.0.0: name is at root level
@@ -1490,6 +1523,17 @@ export default function DataProductDetails() {
           <Button variant="outline" onClick={() => setIsImportExportDialogOpen(true)} size="sm">
             <Download className="mr-2 h-4 w-4" /> Export ODPS
           </Button>
+          {/* Compliance - only when a template is active for data products */}
+          {hasActiveComplianceTemplate && (
+            <Button variant="outline" onClick={() => setComplianceModalOpen(true)} size="sm">
+              <ClipboardCheck className="mr-2 h-4 w-4" /> Compliance
+              {complianceMissingCount > 0 && (
+                <Badge variant="destructive" className="ml-2 px-1.5 py-0 text-[10px]">
+                  {complianceMissingCount}
+                </Badge>
+              )}
+            </Button>
+          )}
           {/* Subscribe/Unsubscribe Button */}
           {isSubscribable && (
             subscriptionStatus?.subscribed ? (
@@ -2454,6 +2498,27 @@ export default function DataProductDetails() {
         isSubmitting={lifecycleActionSubmitting}
         onConfirm={handleDirectPublish}
       />
+
+      {productId && (
+        <ComplianceModal
+          open={complianceModalOpen}
+          onOpenChange={setComplianceModalOpen}
+          entityType="data_product"
+          entityId={productId}
+          canWrite={canWriteCompliance}
+          onSaved={async () => {
+            try {
+              const resp = await get<ComplianceCompleteness>(
+                `/api/compliance-templates/entities/data_product/${productId}/completeness`,
+              );
+              const c = resp.data;
+              setComplianceMissingCount(c?.applicable && !c.passed ? (c.missing?.length ?? 0) : 0);
+            } catch {
+              /* advisory only; ignore */
+            }
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/frontend/src/views/settings-compliance-templates.tsx
+++ b/src/frontend/src/views/settings-compliance-templates.tsx
@@ -1,0 +1,15 @@
+import SettingsPageWrapper from '@/components/settings/settings-page-wrapper';
+import ComplianceTemplatesSettings from '@/components/settings/compliance-templates-settings';
+import { useTranslation } from 'react-i18next';
+
+export default function SettingsComplianceTemplatesView() {
+  const { t } = useTranslation(['settings']);
+  return (
+    <SettingsPageWrapper
+      title={t('settings:tabs.complianceTemplates', 'Compliance Templates')}
+      permissionId="settings-compliance-templates"
+    >
+      <ComplianceTemplatesSettings />
+    </SettingsPageWrapper>
+  );
+}


### PR DESCRIPTION
## Summary

Implements PRD #676 — **Compliance Templates**: admin-defined, typed governance fields with mandatory enforcement, delivered as 9 vertical slices (#706–#714). Governance admins define reusable templates of typed fields (string, enum, boolean, date, number, multi-select) scoped per entity type; producers fill those values on entities; publishing is **blocked** until all mandatory fields are complete.

Built on the existing controller/repository/manager pattern with polymorphic per-entity value storage (mirrors `entity_tag_associations`) and RBAC via `PermissionChecker`.

## What's included

- **Data model** (`compliance_templates.py` + Alembic `p1_add_compliance_templates_tables`): 3 tables — template / field / value. Partial unique index enforces one active template per entity-type scope; values are polymorphic (`entity_type` + `entity_id`).
- **Typed value engine** (`compliance_value_types.py`): pure `coerce_value` / `is_set` over a `ComplianceValueType` enum — string, enum, boolean, date, number, multi-select.
- **Completeness gate** (`compliance_completeness.py`): `check_completeness(fields, values)`; publishing is blocked (409) when mandatory fields are unset. Wired into **both** `publish_product()` and the `set-publication-scope` route (the actual UI publish path).
- **Reconcile-on-edit** (`compliance_reconcile.py`): pure diff of template fields vs. stored values so editing a live template materializes/prunes value slots without data loss.
- **Workflow template substitution**: `${template.<ref>}` references resolve against filled compliance values in workflow definitions.
- **Admin UI** (`compliance-templates-settings.tsx`): create / edit / activate / delete templates, add/edit/reorder/remove fields, defaults + hints, destructive-change guards. Wide, scrollable modal.
- **Entity UI** (`compliance-modal.tsx` + `data-product-details.tsx`): type-aware inputs to fill values; completeness advisory badge; Compliance button surfaces for anyone with read access.
- **RBAC**: two feature keys (`settings-compliance-templates` admin, `compliance-template-values`). Read routes gated at READ_ONLY, value writes at READ_WRITE. Read-only roles (Data Consumer, Security Officer) can **view** filled templates; Governance Officer / Steward / Producer can fill them. Seeded in both `settings.yaml` and in-code `DEFAULT_ROLE_PERMISSIONS`.

## Testing

- **~150 backend unit tests** across value-type engine, completeness, reconcile, field admin, publish gate, and workflow substitution — all passing.
- Frontend `tsc --noEmit` clean.
- Verified end-to-end against the live dev API + Playwright: create → activate → fill → publish-gate (blocked then passing) → edit → read-only permission model.

## Notes for reviewers

- Rebased onto current `origin/development`; single Alembic head (`p1_compliance_templates`), chain intact (`l1 → p1`).
- The pre-push secret scanner flagged a **pre-existing** secret in `docs/SECRETS_MANAGEMENT_SECURITY_ANALYSIS.md` (commit `0b3920d7`, already on `development` and `main`) — unrelated to this PR, which does not touch that file. Flagging separately for the team to scrub from history.

Closes #676.
