### PR TITLE
fix(frontend): use query-form entity_id for metadata fetches

### DIFF
--- a/src/frontend/src/hooks/use-entity-metadata.test.ts
+++ b/src/frontend/src/hooks/use-entity-metadata.test.ts
@@ -164,10 +164,10 @@ describe('useEntityMetadata Hook', () => {
         expect(fetchMock).toHaveBeenCalledTimes(4);
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/contract-456/rich-texts');
-      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/contract-456/links');
-      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/contract-456/documents');
-      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/contract-456/attachments');
+      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/rich-texts?entity_id=contract-456');
+      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/links?entity_id=contract-456');
+      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/documents?entity_id=contract-456');
+      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/attachments?entity_id=contract-456');
     });
 
     it('sets loading state during fetch', async () => {
@@ -528,7 +528,7 @@ describe('useEntityMetadata Hook', () => {
         expect(fetchMock).toHaveBeenCalled();
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_domain/domain-123/rich-texts');
+      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_domain/rich-texts?entity_id=domain-123');
     });
 
     it('works with data_product entity type', async () => {
@@ -541,7 +541,7 @@ describe('useEntityMetadata Hook', () => {
         expect(fetchMock).toHaveBeenCalled();
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_product/product-123/rich-texts');
+      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_product/rich-texts?entity_id=product-123');
     });
 
     it('works with data_contract entity type', async () => {
@@ -554,7 +554,7 @@ describe('useEntityMetadata Hook', () => {
         expect(fetchMock).toHaveBeenCalled();
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/contract-123/rich-texts');
+      expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/rich-texts?entity_id=contract-123');
     });
   });
 
@@ -652,7 +652,7 @@ describe('useEntityMetadata Hook', () => {
       );
 
       await waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_product/entity-1/rich-texts');
+        expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_product/rich-texts?entity_id=entity-1');
       });
 
       fetchMock.mockClear();
@@ -660,7 +660,7 @@ describe('useEntityMetadata Hook', () => {
       rerender({ entityId: 'entity-2' });
 
       await waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_product/entity-2/rich-texts');
+        expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_product/rich-texts?entity_id=entity-2');
       });
     });
 
@@ -674,7 +674,7 @@ describe('useEntityMetadata Hook', () => {
       );
 
       await waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_product/entity-123/rich-texts');
+        expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_product/rich-texts?entity_id=entity-123');
       });
 
       fetchMock.mockClear();
@@ -682,7 +682,7 @@ describe('useEntityMetadata Hook', () => {
       rerender({ entityType: 'data_contract' as EntityKind });
 
       await waitFor(() => {
-        expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/entity-123/rich-texts');
+        expect(fetchMock).toHaveBeenCalledWith('/api/entities/data_contract/rich-texts?entity_id=entity-123');
       });
     });
   });

--- a/src/frontend/src/hooks/use-entity-metadata.ts
+++ b/src/frontend/src/hooks/use-entity-metadata.ts
@@ -117,11 +117,14 @@ export function useEntityMetadata(entityType: EntityKind, entityId: string | nul
     try {
       setLoading(true);
       setError(null);
+      // Metadata endpoints take the entity id as a query param (?entity_id=),
+      // not a path segment; the id may be an IRI so it must be URL-encoded.
+      const eid = encodeURIComponent(entityId);
       const [rt, li, docs, att] = await Promise.all([
-        fetch(`/api/entities/${entityType}/${entityId}/rich-texts`).then(r => r.ok ? r.json() : Promise.reject(new Error(`rich-texts ${r.status}`))),
-        fetch(`/api/entities/${entityType}/${entityId}/links`).then(r => r.ok ? r.json() : Promise.reject(new Error(`links ${r.status}`))),
-        fetch(`/api/entities/${entityType}/${entityId}/documents`).then(r => r.ok ? r.json() : Promise.reject(new Error(`documents ${r.status}`))),
-        fetch(`/api/entities/${entityType}/${entityId}/attachments`).then(r => r.ok ? r.json() : []),
+        fetch(`/api/entities/${entityType}/rich-texts?entity_id=${eid}`).then(r => r.ok ? r.json() : Promise.reject(new Error(`rich-texts ${r.status}`))),
+        fetch(`/api/entities/${entityType}/links?entity_id=${eid}`).then(r => r.ok ? r.json() : Promise.reject(new Error(`links ${r.status}`))),
+        fetch(`/api/entities/${entityType}/documents?entity_id=${eid}`).then(r => r.ok ? r.json() : Promise.reject(new Error(`documents ${r.status}`))),
+        fetch(`/api/entities/${entityType}/attachments?entity_id=${eid}`).then(r => r.ok ? r.json() : []),
       ]);
       setRichTexts(Array.isArray(rt) ? rt : []);
       setLinks(Array.isArray(li) ? li : []);

--- a/src/frontend/src/views/data-domain-details.tsx
+++ b/src/frontend/src/views/data-domain-details.tsx
@@ -458,10 +458,13 @@ export default function DataDomainDetailsView() {
 
   const fetchMetadata = useCallback(async (id: string) => {
     try {
+      // Metadata endpoints take the entity id as a query param (?entity_id=),
+      // not a path segment.
+      const eid = encodeURIComponent(id);
       const [rtResp, liResp, docResp] = await Promise.all([
-        get<RichTextItem[]>(`/api/entities/${entityType}/${id}/rich-texts`),
-        get<LinkItem[]>(`/api/entities/${entityType}/${id}/links`),
-        get<DocumentItem[]>(`/api/entities/${entityType}/${id}/documents`),
+        get<RichTextItem[]>(`/api/entities/${entityType}/rich-texts?entity_id=${eid}`),
+        get<LinkItem[]>(`/api/entities/${entityType}/links?entity_id=${eid}`),
+        get<DocumentItem[]>(`/api/entities/${entityType}/documents?entity_id=${eid}`),
       ]);
       setRichTexts(checkApiResponse(rtResp, 'Rich Texts'));
       setLinks(checkApiResponse(liResp, 'Links'));


### PR DESCRIPTION
## Summary

Fixes a metadata-load failure on entity detail views (reproduced on the Data Domain detail page: a "Metadata load failed — Rich Texts fetch returned null or undefined data" toast).

## Root cause

The entity metadata endpoints take the entity id as a **query parameter** (`?entity_id=`):

```
GET /api/entities/{entity_type}/rich-texts?entity_id={id}   (also links, documents, attachments)
```

but `use-entity-metadata.ts` and `data-domain-details.tsx` called them with the id as a **path segment**:

```
GET /api/entities/{entity_type}/{id}/rich-texts
```

Those URLs match no registered route, so they fall through to the SPA catch-all (`@app.get("/{full_path:path}")`), which returns **`200 null`** for unmatched `api/*` paths. The domain view's `checkApiResponse` then treats `null` as an error and raises the toast.

(The shared `entity-metadata-panel.tsx` already used the correct query-form, which is why the panel works elsewhere.)

## Fix

Switch both callers to the query-form the backend defines, URL-encoding the id (it may be an IRI). Update the hook tests to assert the query-form URLs.

## Testing

- `use-entity-metadata.test.ts`: 31 passed; frontend typecheck clean.
- Verified in-app (Playwright): the Data Domain detail page renders with empty-state metadata sections and **no error toast, 0 console errors**.

## Note

This is a pre-existing bug (lines date to Aug 3 / March), independent of any feature work. A follow-up worth considering separately: the SPA catch-all should return 404 for unmatched `api/*` paths instead of `200 null`, so such mismatches fail loudly.

