### PR TITLE
ci(build): cap hatchling <1.32 so ../README.md readme path still builds

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["hatchling>=1.21.0", "hatch-requirements-txt~=0.4.1"]
+# hatchling capped <1.32: 1.32.0 enforces "readme must be within the project
+# directory" and rejects this package's ``readme = "../README.md"`` (the README
+# lives at the repo root, one level above src/). Uncapped, a fresh CI/dev env
+# pulls 1.32.x and every hatch-built job fails at metadata generation. Cap until
+# the readme is relocated into src/ or the field is made project-local.
+requires = ["hatchling>=1.21.0,<1.32", "hatch-requirements-txt~=0.4.1"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
## Problem

`development` CI is currently red for **every** PR (and would be red for a fresh run of `development` itself). Backend Tests, Coverage, and the Alembic Single-Head check all fail in the **dependency install** step, before any project code runs:

```
AttributeError: module 'hatchling.build' has no attribute 'prepare_metadata_for_build_editable'
ValueError: Readme path must be within the project directory: ../README.md
```

**Root cause:** `src/pyproject.toml` declares `readme = "../README.md"` (the README lives at the repo root, one level above `src/`) and an **unbounded** build requirement `hatchling>=1.21.0`. `hatchling 1.32.0` newly enforces that the readme path must be inside the project directory and rejects `../README.md`. A fresh CI env now resolves 1.32.x, so metadata generation fails.

This is **pre-existing on `development`** — its CI last passed on 2026-08-14 only because an older hatchling was resolved then. It is not caused by any feature change; it was armed by the upstream 1.32.0 release.

## Fix

Cap the build requirement to `hatchling>=1.21.0,<1.32`, restoring the working behaviour. One line + an explanatory comment.

## Follow-up

Proper fix is to relocate the README into `src/` (or make the `readme` field project-local) and then lift the cap.

## Testing

CI on this PR exercises the same hatch-built jobs (Backend Tests, Coverage, Alembic Single-Head) that were failing; they should now pass at the install step.

This pull request and its description were written by Isaac.