### PR TITLE
fix(demo-data): repair packs broken by multi-domain migration; truthful loader + drift-proof teardown

### DIFF
--- a/src/backend/src/data/demo_data_auto.sql
+++ b/src/backend/src/data/demo_data_auto.sql
@@ -45,11 +45,10 @@ ON CONFLICT (id) DO NOTHING;
 -- 2. TEAMS
 -- ============================================================================
 
-INSERT INTO teams (id, name, title, description, domain_id, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
-('00100001-0004-4000-8000-000000000001', 'connected-vehicle-platform', 'Connected Vehicle Platform Team', 'Telematics data platform, OTA update orchestration, and remote diagnostics', '00000002-0004-4000-8000-000000000002', '{"slack_channel": "https://company.slack.com/channels/cv-platform", "lead": "cv.architect@oem.com"}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100002-0004-4000-8000-000000000002', 'adas-engineering', 'ADAS & AD Engineering Team', 'Sensor fusion, perception model training, and autonomous driving validation', '00000003-0004-4000-8000-000000000003', '{"slack_channel": "https://company.slack.com/channels/adas-eng", "tools": ["ROS2", "CARLA", "NVIDIA DRIVE"]}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100003-0004-4000-8000-000000000003', 'supply-chain-quality', 'Supply Chain Quality Team', 'Supplier PPAP/APQP management, incoming quality, and supply risk analytics', '00000004-0004-4000-8000-000000000004', '{"slack_channel": "https://company.slack.com/channels/scq-team", "responsibilities": ["PPAP", "APQP", "8D", "Supplier Audits"]}', 'system@demo', 'system@demo', NOW(), NOW())
-
+INSERT INTO teams (id, name, title, description, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
+('00100001-0004-4000-8000-000000000001', 'connected-vehicle-platform', 'Connected Vehicle Platform Team', 'Telematics data platform, OTA update orchestration, and remote diagnostics', '{"slack_channel": "https://company.slack.com/channels/cv-platform", "lead": "cv.architect@oem.com"}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100002-0004-4000-8000-000000000002', 'adas-engineering', 'ADAS & AD Engineering Team', 'Sensor fusion, perception model training, and autonomous driving validation', '{"slack_channel": "https://company.slack.com/channels/adas-eng", "tools": ["ROS2", "CARLA", "NVIDIA DRIVE"]}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100003-0004-4000-8000-000000000003', 'supply-chain-quality', 'Supply Chain Quality Team', 'Supplier PPAP/APQP management, incoming quality, and supply risk analytics', '{"slack_channel": "https://company.slack.com/channels/scq-team", "responsibilities": ["PPAP", "APQP", "8D", "Supplier Audits"]}', 'system@demo', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -99,12 +98,12 @@ ON CONFLICT (project_id, team_id) DO NOTHING;
 -- 4. DATA CONTRACTS
 -- ============================================================================
 
-INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, domain_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
-('00400001-0004-4000-8000-000000000001', 'Vehicle Telematics Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0004-4000-8000-000000000001', '00000002-0004-4000-8000-000000000002', 'Standardized vehicle telemetry including CAN bus signals, diagnostic trouble codes, and driving behavior events', 'Fleet health monitoring, predictive maintenance, usage-based insurance, and OTA campaign targeting', 'CAN signal sampling rate varies by ECU (10ms-1s); DTC freeze-frame data limited to 3 snapshots; GPS accuracy ±3m in urban canyons', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0004-4000-8000-000000000001'),
-('00400002-0004-4000-8000-000000000002', 'ADAS Sensor Data Contract', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100002-0004-4000-8000-000000000002', '00000003-0004-4000-8000-000000000003', 'Camera, LiDAR, radar, and ultrasonic sensor recordings with synchronized timestamps and ego-vehicle pose', 'Perception model training, corner-case mining, simulation replay, and safety validation per ISO 21448 (SOTIF)', 'LiDAR point clouds at 10Hz; camera frames at 30fps; radar at 20Hz; temporal sync tolerance ±5ms; PII (faces, plates) must be anonymized before model training', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0004-4000-8000-000000000002'),
-('00400003-0004-4000-8000-000000000003', 'Supplier Quality Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100003-0004-4000-8000-000000000003', '00000004-0004-4000-8000-000000000004', 'PPAP submissions, incoming inspection data, supplier SPC, and 8D corrective action reports', 'Supplier quality scorecard, incoming quality trends, PPAP status tracking, and risk-based audit planning', 'Supplier SPC data pushed daily via EDI; 8D reports require manual review before closure; sub-tier data limited to Tier-1 disclosures', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0004-4000-8000-000000000003'),
-('00400004-0004-4000-8000-000000000004', 'Warranty Claims Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0004-4000-8000-000000000001', '00000005-0004-4000-8000-000000000005', 'Dealer warranty claims, field failure reports, recall campaign data, and goodwill repair authorizations', 'Early warning analytics, cost-per-vehicle trending, NTF (no trouble found) reduction, and recall scope optimization', 'Claims data lags 5-10 business days from dealer submission; labor codes vary by market; goodwill claims excluded from CPV calculations', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0004-4000-8000-000000000004'),
-('00400005-0004-4000-8000-000000000005', 'Vehicle Configuration & BOM Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100001-0004-4000-8000-000000000001', '00000001-0004-4000-8000-000000000001', 'As-built vehicle configuration, 150% BOM, option constraint rules, and engineering change orders', 'Build-to-order scheduling, variant cost analysis, and engineering change impact assessment', 'ECO effectivity transitions may create temporary BOM inconsistencies; market-specific options encoded differently across legacy PLM systems', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0004-4000-8000-000000000005')
+INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
+('00400001-0004-4000-8000-000000000001', 'Vehicle Telematics Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0004-4000-8000-000000000001', 'Standardized vehicle telemetry including CAN bus signals, diagnostic trouble codes, and driving behavior events', 'Fleet health monitoring, predictive maintenance, usage-based insurance, and OTA campaign targeting', 'CAN signal sampling rate varies by ECU (10ms-1s); DTC freeze-frame data limited to 3 snapshots; GPS accuracy ±3m in urban canyons', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0004-4000-8000-000000000001'),
+('00400002-0004-4000-8000-000000000002', 'ADAS Sensor Data Contract', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100002-0004-4000-8000-000000000002', 'Camera, LiDAR, radar, and ultrasonic sensor recordings with synchronized timestamps and ego-vehicle pose', 'Perception model training, corner-case mining, simulation replay, and safety validation per ISO 21448 (SOTIF)', 'LiDAR point clouds at 10Hz; camera frames at 30fps; radar at 20Hz; temporal sync tolerance ±5ms; PII (faces, plates) must be anonymized before model training', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0004-4000-8000-000000000002'),
+('00400003-0004-4000-8000-000000000003', 'Supplier Quality Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100003-0004-4000-8000-000000000003', 'PPAP submissions, incoming inspection data, supplier SPC, and 8D corrective action reports', 'Supplier quality scorecard, incoming quality trends, PPAP status tracking, and risk-based audit planning', 'Supplier SPC data pushed daily via EDI; 8D reports require manual review before closure; sub-tier data limited to Tier-1 disclosures', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0004-4000-8000-000000000003'),
+('00400004-0004-4000-8000-000000000004', 'Warranty Claims Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0004-4000-8000-000000000001', 'Dealer warranty claims, field failure reports, recall campaign data, and goodwill repair authorizations', 'Early warning analytics, cost-per-vehicle trending, NTF (no trouble found) reduction, and recall scope optimization', 'Claims data lags 5-10 business days from dealer submission; labor codes vary by market; goodwill claims excluded from CPV calculations', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0004-4000-8000-000000000004'),
+('00400005-0004-4000-8000-000000000005', 'Vehicle Configuration & BOM Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100001-0004-4000-8000-000000000001', 'As-built vehicle configuration, 150% BOM, option constraint rules, and engineering change orders', 'Build-to-order scheduling, variant cost analysis, and engineering change impact assessment', 'ECO effectivity transitions may create temporary BOM inconsistencies; market-specific options encoded differently across legacy PLM systems', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0004-4000-8000-000000000005')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -236,12 +235,12 @@ ON CONFLICT (id) DO NOTHING;
 -- 5. DATA PRODUCTS
 -- ============================================================================
 
-INSERT INTO data_products (id, api_version, kind, status, name, version, domain, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
-('00700001-0004-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'Connected Vehicle Analytics v1', '1.0.0', 'Connected Vehicles', 'auto-demo', '00100001-0004-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0004-4000-8000-000000000001'),
-('00700002-0004-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'ADAS Training Data Pipeline v1', '1.0.0', 'Autonomous Driving', 'auto-demo', '00100002-0004-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700002-0004-4000-8000-000000000002'),
-('00700003-0004-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'Supplier Quality Scorecard v1', '1.0.0', 'Supply Chain & Procurement', 'auto-demo', '00100003-0004-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700003-0004-4000-8000-000000000003'),
-('00700004-0004-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Warranty Analytics Platform v1', '1.0.0', 'After-Sales & Warranty', 'auto-demo', '00100001-0004-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700004-0004-4000-8000-000000000004'),
-('00700005-0004-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'Vehicle Configuration Intelligence v1', '1.0.0', 'Vehicle Engineering', 'auto-demo', '00100001-0004-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700005-0004-4000-8000-000000000005')
+INSERT INTO data_products (id, api_version, kind, status, name, version, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
+('00700001-0004-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'Connected Vehicle Analytics v1', '1.0.0', 'auto-demo', '00100001-0004-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0004-4000-8000-000000000001'),
+('00700002-0004-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'ADAS Training Data Pipeline v1', '1.0.0', 'auto-demo', '00100002-0004-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700002-0004-4000-8000-000000000002'),
+('00700003-0004-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'Supplier Quality Scorecard v1', '1.0.0', 'auto-demo', '00100003-0004-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700003-0004-4000-8000-000000000003'),
+('00700004-0004-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Warranty Analytics Platform v1', '1.0.0', 'auto-demo', '00100001-0004-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700004-0004-4000-8000-000000000004'),
+('00700005-0004-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'Vehicle Configuration Intelligence v1', '1.0.0', 'auto-demo', '00100001-0004-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700005-0004-4000-8000-000000000005')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -512,109 +511,79 @@ ON CONFLICT (id) DO NOTHING;
 -- 15. ASSETS — AUTO catalog objects (type=0f3)
 -- ============================================================================
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
--- Vehicle Fleet (vertical asset type)
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('0f300101-0004-4000-8000-000000000001',
  'fleet.evx-2026.eu',
  'EVX-2026 European fleet (~120,000 vehicles).',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Vehicle Fleet' LIMIT 1), '0f200101-0004-4000-8000-000000000001'), 'Connected Cloud', 'fleet://evx-2026/eu',
- '00000002-0004-4000-8000-000000000002',
  '{"model": "EVX-2026", "region": "EU", "vehicle_count": 120000, "model_year": 2026}',
  '["series-production", "connected-services", "r155-in-scope"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- ECU Software (vertical asset type)
 ('0f300102-0004-4000-8000-000000000002',
  'ecu.adas.cam_perception.v4.2.1',
  'ADAS camera perception ECU firmware v4.2.1 — supports L2+ assist.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'ECU Software' LIMIT 1), '0f200102-0004-4000-8000-000000000002'), 'OTA Backend', 'ecu://adas/cam_perception/4.2.1',
- '00000003-0004-4000-8000-000000000003',
  '{"ecu_id": "cam_perception", "version": "4.2.1", "asil": "ASIL-D", "release_date": "2026-04-12"}',
  '["asil-d", "iso-21434", "r155-in-scope"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Telemetry table
 ('0f300103-0004-4000-8000-000000000003',
  'lakehouse.auto.telemetry.can_signals',
  'CAN bus signal telemetry from connected vehicles (resampled to 1Hz curated grid).',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.auto.telemetry.can_signals',
- '00000002-0004-4000-8000-000000000002',
  '{"catalog": "lakehouse", "schema": "auto_telemetry", "table_name": "can_signals", "row_count": 4500000000, "format": "delta"}',
  '["connected-services"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Stream
 ('0f300104-0004-4000-8000-000000000004',
  'kafka.fleet.events.diagnostic_trouble_codes',
  'Real-time DTC stream from on-vehicle diagnostics.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Stream' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Kafka', 'kafka://broker.fleet:9093/events.dtc',
- '00000005-0004-4000-8000-000000000005',
  '{"topic": "events.dtc", "throughput_msgs_per_sec": 9000}',
  '["connected-services"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Warranty Claim (vertical asset type)
 ('0f300105-0004-4000-8000-000000000005',
  'WC-2026-EU-89432',
  'Warranty claim WC-2026-EU-89432 — replacement of suspect HV battery module pack.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Warranty Claim' LIMIT 1), '0f200103-0004-4000-8000-000000000003'), 'Dealer Portal', 'warranty://claims/WC-2026-EU-89432',
- '00000005-0004-4000-8000-000000000005',
  '{"vin_prefix": "WBA****", "claim_amount_eur": 4500, "labor_hours": 8.5, "status": "approved"}',
  '[]',
  'active', 'system@demo', NOW(), NOW()),
-
--- PPAP Submission (vertical asset type)
 ('0f300106-0004-4000-8000-000000000006',
  'PPAP-2026-04-CRANK-EVX',
  'PPAP Level 3 submission for EVX-2026 crankshaft assembly (Tier-1 supplier ABC).',
  COALESCE((SELECT id FROM asset_types WHERE name = 'PPAP Submission' LIMIT 1), '0f200104-0004-4000-8000-000000000004'), 'Quality Portal', 'ppap://submissions/2026-04-CRANK-EVX',
- '00000004-0004-4000-8000-000000000004',
  '{"ppap_level": 3, "supplier": "ABC", "part_number": "CRANK-EVX-001", "status": "approved"}',
  '[]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Recall dashboard
 ('0f300107-0004-4000-8000-000000000007',
  'Recall Risk Dashboard',
  'Field failure trends, claim clusters, and recall risk indicators by VIN cohort.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200002-0000-4000-8000-000000000002'), 'Databricks', 'https://bi.oem.com/dashboards/recall-risk-v1',
- '00000005-0004-4000-8000-000000000005',
  '{"refresh_schedule": "daily", "audience": "quality-recall-board"}',
  '["connected-services"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Supplier table
 ('0f300108-0004-4000-8000-000000000008',
  'lakehouse.auto.supply.tier_n_inventory',
  'Tier-1 to Tier-N supplier inventory and shipment status.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory',
- '00000004-0004-4000-8000-000000000004',
  '{"catalog": "lakehouse", "schema": "auto_supply", "table_name": "tier_n_inventory", "row_count": 280000, "format": "delta"}',
  '[]',
  'active', 'system@demo', NOW(), NOW()),
-
--- ── Column assets for the Auto Tables / Streams above ──
--- 0f300103 lakehouse.auto.telemetry.can_signals
-('0f520103-0004-4000-8000-000000000003', 'vin',           'Vehicle Identification Number',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.vin',           '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["telematics", "pii"]',     'active', 'system@demo', NOW(), NOW()),
-('0f520104-0004-4000-8000-000000000004', 'trip_id',       'Unique trip session identifier',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.trip_id',       '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false, "is_primary_key": true}',  '["telematics", "key"]',     'active', 'system@demo', NOW(), NOW()),
-('0f520105-0004-4000-8000-000000000005', 'signal_name',   'CAN signal name per DBC definition',              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.signal_name',   '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
-('0f520106-0004-4000-8000-000000000006', 'signal_value',  'Decoded physical signal value',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.signal_value',  '00000002-0004-4000-8000-000000000002', '{"data_type": "DECIMAL(18,6)", "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
-('0f520107-0004-4000-8000-000000000007', 'timestamp_utc', 'Signal timestamp (UTC, millisecond precision)',   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.timestamp_utc', '00000002-0004-4000-8000-000000000002', '{"data_type": "TIMESTAMP",     "nullable": false, "partition_key": true}',   '["telematics", "partition"]','active', 'system@demo', NOW(), NOW()),
-('0f520108-0004-4000-8000-000000000008', 'ecu_id',        'Source ECU identifier',                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.ecu_id',        '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
-
--- 0f300104 kafka.fleet.events.diagnostic_trouble_codes (Stream)
-('0f520111-0004-4000-8000-000000000011', 'event_id',      'Unique DTC event identifier',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.event_id',  '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",     "nullable": false, "is_primary_key": true}', '["telematics", "key"]',      'active', 'system@demo', NOW(), NOW()),
-('0f520112-0004-4000-8000-000000000012', 'vin',           'Vehicle Identification Number',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.vin',       '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",     "nullable": false}',                          '["telematics", "pii"]',     'active', 'system@demo', NOW(), NOW()),
-('0f520113-0004-4000-8000-000000000013', 'dtc_code',      'SAE J2012 diagnostic trouble code',               (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.dtc_code',  '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",     "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
-('0f520114-0004-4000-8000-000000000014', 'severity',      'pending | confirmed | permanent',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.severity',  '00000002-0004-4000-8000-000000000002', '{"data_type": "STRING",     "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
-('0f520115-0004-4000-8000-000000000015', 'first_seen_ts', 'First occurrence timestamp (UTC)',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.first_seen_ts','00000002-0004-4000-8000-000000000002','{"data_type": "TIMESTAMP","nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
-
--- 0f300108 lakehouse.auto.supply.tier_n_inventory
-('0f520121-0004-4000-8000-000000000021', 'part_number',     'OEM part number (PK)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.part_number',     '00000004-0004-4000-8000-000000000004', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}',     '["supply-chain", "key"]',  'active', 'system@demo', NOW(), NOW()),
-('0f520122-0004-4000-8000-000000000022', 'supplier_code',   'Supplier code (PK with part_number)',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.supplier_code',   '00000004-0004-4000-8000-000000000004', '{"data_type": "STRING",  "nullable": false}',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520123-0004-4000-8000-000000000023', 'tier',            'Supplier tier (1=direct, 2/3=upstream)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.tier',            '00000004-0004-4000-8000-000000000004', '{"data_type": "INT",     "nullable": false}',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520124-0004-4000-8000-000000000024', 'on_hand_qty',     'Current on-hand quantity',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.on_hand_qty',     '00000004-0004-4000-8000-000000000004', '{"data_type": "INT",     "nullable": false}',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520125-0004-4000-8000-000000000025', 'last_shipment_ts','Last shipment timestamp (UTC)',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.last_shipment_ts','00000004-0004-4000-8000-000000000004', '{"data_type": "TIMESTAMP","nullable": true }',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW())
+('0f520103-0004-4000-8000-000000000003', 'vin',           'Vehicle Identification Number',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.vin', '{"data_type": "STRING",        "nullable": false}',                          '["telematics", "pii"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520104-0004-4000-8000-000000000004', 'trip_id',       'Unique trip session identifier',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.trip_id', '{"data_type": "STRING",        "nullable": false, "is_primary_key": true}',  '["telematics", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520105-0004-4000-8000-000000000005', 'signal_name',   'CAN signal name per DBC definition',              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.signal_name', '{"data_type": "STRING",        "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520106-0004-4000-8000-000000000006', 'signal_value',  'Decoded physical signal value',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.signal_value', '{"data_type": "DECIMAL(18,6)", "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520107-0004-4000-8000-000000000007', 'timestamp_utc', 'Signal timestamp (UTC, millisecond precision)',   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.timestamp_utc', '{"data_type": "TIMESTAMP",     "nullable": false, "partition_key": true}',   '["telematics", "partition"]','active', 'system@demo', NOW(), NOW()),
+('0f520108-0004-4000-8000-000000000008', 'ecu_id',        'Source ECU identifier',                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.telemetry.can_signals.ecu_id', '{"data_type": "STRING",        "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520111-0004-4000-8000-000000000011', 'event_id',      'Unique DTC event identifier',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.event_id', '{"data_type": "STRING",     "nullable": false, "is_primary_key": true}', '["telematics", "key"]',      'active', 'system@demo', NOW(), NOW()),
+('0f520112-0004-4000-8000-000000000012', 'vin',           'Vehicle Identification Number',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.vin', '{"data_type": "STRING",     "nullable": false}',                          '["telematics", "pii"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520113-0004-4000-8000-000000000013', 'dtc_code',      'SAE J2012 diagnostic trouble code',               (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.dtc_code', '{"data_type": "STRING",     "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520114-0004-4000-8000-000000000014', 'severity',      'pending | confirmed | permanent',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.severity', '{"data_type": "STRING",     "nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520115-0004-4000-8000-000000000015', 'first_seen_ts', 'First occurrence timestamp (UTC)',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.fleet.events.diagnostic_trouble_codes.first_seen_ts','{"data_type": "TIMESTAMP","nullable": false}',                          '["telematics"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520121-0004-4000-8000-000000000021', 'part_number',     'OEM part number (PK)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.part_number', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}',     '["supply-chain", "key"]',  'active', 'system@demo', NOW(), NOW()),
+('0f520122-0004-4000-8000-000000000022', 'supplier_code',   'Supplier code (PK with part_number)',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.supplier_code', '{"data_type": "STRING",  "nullable": false}',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520123-0004-4000-8000-000000000023', 'tier',            'Supplier tier (1=direct, 2/3=upstream)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.tier', '{"data_type": "INT",     "nullable": false}',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520124-0004-4000-8000-000000000024', 'on_hand_qty',     'Current on-hand quantity',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.on_hand_qty', '{"data_type": "INT",     "nullable": false}',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520125-0004-4000-8000-000000000025', 'last_shipment_ts','Last shipment timestamp (UTC)',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.auto.supply.tier_n_inventory.last_shipment_ts', '{"data_type": "TIMESTAMP","nullable": true }',                              '["supply-chain"]',         'active', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -768,3 +737,48 @@ COMMIT;
 -- ============================================================================
 -- End of AUTO Demo Data — preset=auto
 -- ============================================================================
+
+
+-- ============================================================================
+-- Domain associations (multi-domain assignment; replaces removed single-value
+-- domain columns on teams/data_contracts/data_products/assets). Type code 031.
+-- ============================================================================
+INSERT INTO entity_domain_associations (id, domain_id, entity_id, entity_type, is_primary, assigned_by, assigned_at) VALUES
+('03100001-0004-4000-8000-000000000001', '00000002-0004-4000-8000-000000000002', '00100001-0004-4000-8000-000000000001', 'team', true, 'system@demo', NOW()),
+('03100002-0004-4000-8000-000000000002', '00000003-0004-4000-8000-000000000003', '00100002-0004-4000-8000-000000000002', 'team', true, 'system@demo', NOW()),
+('03100003-0004-4000-8000-000000000003', '00000004-0004-4000-8000-000000000004', '00100003-0004-4000-8000-000000000003', 'team', true, 'system@demo', NOW()),
+('03100004-0004-4000-8000-000000000004', '00000002-0004-4000-8000-000000000002', '00400001-0004-4000-8000-000000000001', 'data_contract', true, 'system@demo', NOW()),
+('03100005-0004-4000-8000-000000000005', '00000003-0004-4000-8000-000000000003', '00400002-0004-4000-8000-000000000002', 'data_contract', true, 'system@demo', NOW()),
+('03100006-0004-4000-8000-000000000006', '00000004-0004-4000-8000-000000000004', '00400003-0004-4000-8000-000000000003', 'data_contract', true, 'system@demo', NOW()),
+('03100007-0004-4000-8000-000000000007', '00000005-0004-4000-8000-000000000005', '00400004-0004-4000-8000-000000000004', 'data_contract', true, 'system@demo', NOW()),
+('03100008-0004-4000-8000-000000000008', '00000001-0004-4000-8000-000000000001', '00400005-0004-4000-8000-000000000005', 'data_contract', true, 'system@demo', NOW()),
+('03100009-0004-4000-8000-000000000009', '00000002-0004-4000-8000-000000000002', '00700001-0004-4000-8000-000000000001', 'data_product', true, 'system@demo', NOW()),
+('0310000a-0004-4000-8000-000000000010', '00000003-0004-4000-8000-000000000003', '00700002-0004-4000-8000-000000000002', 'data_product', true, 'system@demo', NOW()),
+('0310000b-0004-4000-8000-000000000011', '00000004-0004-4000-8000-000000000004', '00700003-0004-4000-8000-000000000003', 'data_product', true, 'system@demo', NOW()),
+('0310000c-0004-4000-8000-000000000012', '00000005-0004-4000-8000-000000000005', '00700004-0004-4000-8000-000000000004', 'data_product', true, 'system@demo', NOW()),
+('0310000d-0004-4000-8000-000000000013', '00000001-0004-4000-8000-000000000001', '00700005-0004-4000-8000-000000000005', 'data_product', true, 'system@demo', NOW()),
+('0310000e-0004-4000-8000-000000000014', '00000002-0004-4000-8000-000000000002', '0f300101-0004-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('0310000f-0004-4000-8000-000000000015', '00000003-0004-4000-8000-000000000003', '0f300102-0004-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100010-0004-4000-8000-000000000016', '00000002-0004-4000-8000-000000000002', '0f300103-0004-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100011-0004-4000-8000-000000000017', '00000005-0004-4000-8000-000000000005', '0f300104-0004-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100012-0004-4000-8000-000000000018', '00000005-0004-4000-8000-000000000005', '0f300105-0004-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('03100013-0004-4000-8000-000000000019', '00000004-0004-4000-8000-000000000004', '0f300106-0004-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('03100014-0004-4000-8000-000000000020', '00000005-0004-4000-8000-000000000005', '0f300107-0004-4000-8000-000000000007', 'asset', true, 'system@demo', NOW()),
+('03100015-0004-4000-8000-000000000021', '00000004-0004-4000-8000-000000000004', '0f300108-0004-4000-8000-000000000008', 'asset', true, 'system@demo', NOW()),
+('03100016-0004-4000-8000-000000000022', '00000002-0004-4000-8000-000000000002', '0f520103-0004-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100017-0004-4000-8000-000000000023', '00000002-0004-4000-8000-000000000002', '0f520104-0004-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100018-0004-4000-8000-000000000024', '00000002-0004-4000-8000-000000000002', '0f520105-0004-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('03100019-0004-4000-8000-000000000025', '00000002-0004-4000-8000-000000000002', '0f520106-0004-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('0310001a-0004-4000-8000-000000000026', '00000002-0004-4000-8000-000000000002', '0f520107-0004-4000-8000-000000000007', 'asset', true, 'system@demo', NOW()),
+('0310001b-0004-4000-8000-000000000027', '00000002-0004-4000-8000-000000000002', '0f520108-0004-4000-8000-000000000008', 'asset', true, 'system@demo', NOW()),
+('0310001c-0004-4000-8000-000000000028', '00000002-0004-4000-8000-000000000002', '0f520111-0004-4000-8000-000000000011', 'asset', true, 'system@demo', NOW()),
+('0310001d-0004-4000-8000-000000000029', '00000002-0004-4000-8000-000000000002', '0f520112-0004-4000-8000-000000000012', 'asset', true, 'system@demo', NOW()),
+('0310001e-0004-4000-8000-000000000030', '00000002-0004-4000-8000-000000000002', '0f520113-0004-4000-8000-000000000013', 'asset', true, 'system@demo', NOW()),
+('0310001f-0004-4000-8000-000000000031', '00000002-0004-4000-8000-000000000002', '0f520114-0004-4000-8000-000000000014', 'asset', true, 'system@demo', NOW()),
+('03100020-0004-4000-8000-000000000032', '00000002-0004-4000-8000-000000000002', '0f520115-0004-4000-8000-000000000015', 'asset', true, 'system@demo', NOW()),
+('03100021-0004-4000-8000-000000000033', '00000004-0004-4000-8000-000000000004', '0f520121-0004-4000-8000-000000000021', 'asset', true, 'system@demo', NOW()),
+('03100022-0004-4000-8000-000000000034', '00000004-0004-4000-8000-000000000004', '0f520122-0004-4000-8000-000000000022', 'asset', true, 'system@demo', NOW()),
+('03100023-0004-4000-8000-000000000035', '00000004-0004-4000-8000-000000000004', '0f520123-0004-4000-8000-000000000023', 'asset', true, 'system@demo', NOW()),
+('03100024-0004-4000-8000-000000000036', '00000004-0004-4000-8000-000000000004', '0f520124-0004-4000-8000-000000000024', 'asset', true, 'system@demo', NOW()),
+('03100025-0004-4000-8000-000000000037', '00000004-0004-4000-8000-000000000004', '0f520125-0004-4000-8000-000000000025', 'asset', true, 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;

--- a/src/backend/src/data/demo_data_fsi.sql
+++ b/src/backend/src/data/demo_data_fsi.sql
@@ -45,11 +45,10 @@ ON CONFLICT (id) DO NOTHING;
 -- 2. TEAMS
 -- ============================================================================
 
-INSERT INTO teams (id, name, title, description, domain_id, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
-('00100001-0002-4000-8000-000000000001', 'trading-analytics', 'Trading Analytics Team', 'Quantitative analytics for equities, fixed income, and derivatives trading', '00000002-0002-4000-8000-000000000002', '{"slack_channel": "https://company.slack.com/channels/trading-analytics", "lead": "quant.lead@bank.com"}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100002-0002-4000-8000-000000000002', 'risk-management', 'Risk Management Team', 'Enterprise risk measurement, stress testing, and model validation', '00000003-0002-4000-8000-000000000003', '{"slack_channel": "https://company.slack.com/channels/risk-mgmt", "tools": ["SAS", "Python", "Moody''s Analytics"]}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100003-0002-4000-8000-000000000003', 'compliance-ops', 'Compliance Operations Team', 'AML transaction monitoring, KYC remediation, and regulatory reporting', '00000004-0002-4000-8000-000000000004', '{"slack_channel": "https://company.slack.com/channels/compliance-ops", "responsibilities": ["BSA/AML", "OFAC", "KYC/CDD", "SAR Filing"]}', 'system@demo', 'system@demo', NOW(), NOW())
-
+INSERT INTO teams (id, name, title, description, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
+('00100001-0002-4000-8000-000000000001', 'trading-analytics', 'Trading Analytics Team', 'Quantitative analytics for equities, fixed income, and derivatives trading', '{"slack_channel": "https://company.slack.com/channels/trading-analytics", "lead": "quant.lead@bank.com"}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100002-0002-4000-8000-000000000002', 'risk-management', 'Risk Management Team', 'Enterprise risk measurement, stress testing, and model validation', '{"slack_channel": "https://company.slack.com/channels/risk-mgmt", "tools": ["SAS", "Python", "Moody''s Analytics"]}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100003-0002-4000-8000-000000000003', 'compliance-ops', 'Compliance Operations Team', 'AML transaction monitoring, KYC remediation, and regulatory reporting', '{"slack_channel": "https://company.slack.com/channels/compliance-ops", "responsibilities": ["BSA/AML", "OFAC", "KYC/CDD", "SAR Filing"]}', 'system@demo', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -98,12 +97,12 @@ ON CONFLICT (project_id, team_id) DO NOTHING;
 -- 4. DATA CONTRACTS
 -- ============================================================================
 
-INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, domain_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
-('00400001-0002-4000-8000-000000000001', 'Trading & Market Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0002-4000-8000-000000000001', '00000002-0002-4000-8000-000000000002', 'Standardized trade execution, order book, and market data for analytics and regulatory reporting', 'Real-time P&L, best execution analysis, MiFID II transaction reporting, and alpha research', 'Timestamps must be nanosecond precision; all prices in instrument native currency; T+1 settlement data only', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0002-4000-8000-000000000001'),
-('00400002-0002-4000-8000-000000000002', 'Risk Exposure Contract', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100002-0002-4000-8000-000000000002', '00000003-0002-4000-8000-000000000003', 'Aggregated risk exposures across credit, market, and counterparty risk', 'BCBS 239 risk reports, stress testing scenarios, and limit monitoring', 'Netting requires CSA-level granularity; VaR computed at 99% 10-day horizon; CVA/DVA excluded from market risk', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0002-4000-8000-000000000002'),
-('00400003-0002-4000-8000-000000000003', 'KYC/AML Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100003-0002-4000-8000-000000000003', '00000004-0002-4000-8000-000000000004', 'Customer due diligence, beneficial ownership, and transaction monitoring data', 'Entity resolution, risk scoring, SAR narrative generation, and OFAC screening', 'PEP and sanctions data refreshed daily; beneficial ownership threshold 25%; STR filing requires manual review', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0002-4000-8000-000000000003'),
-('00400004-0002-4000-8000-000000000004', 'Regulatory Reporting Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100003-0002-4000-8000-000000000003', '00000004-0002-4000-8000-000000000004', 'Data feeds for prudential regulatory submissions (FR Y-14, CCAR, DFAST)', 'Automated population of regulatory templates and submission validation', 'Quarter-end data only; manual overrides must have four-eyes approval; reconciliation tolerance ±$1M', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0002-4000-8000-000000000004'),
-('00400005-0002-4000-8000-000000000005', 'Account & Transaction Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0002-4000-8000-000000000001', '00000001-0002-4000-8000-000000000001', 'Core banking account master and transaction data for retail and commercial banking', 'Account analytics, fraud detection, fee optimization, and customer 360 enrichment', 'Real-time balance is T+0 approximation; currency conversion uses daily ECB fix; PII encrypted at rest with AES-256', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0002-4000-8000-000000000005')
+INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
+('00400001-0002-4000-8000-000000000001', 'Trading & Market Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0002-4000-8000-000000000001', 'Standardized trade execution, order book, and market data for analytics and regulatory reporting', 'Real-time P&L, best execution analysis, MiFID II transaction reporting, and alpha research', 'Timestamps must be nanosecond precision; all prices in instrument native currency; T+1 settlement data only', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0002-4000-8000-000000000001'),
+('00400002-0002-4000-8000-000000000002', 'Risk Exposure Contract', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100002-0002-4000-8000-000000000002', 'Aggregated risk exposures across credit, market, and counterparty risk', 'BCBS 239 risk reports, stress testing scenarios, and limit monitoring', 'Netting requires CSA-level granularity; VaR computed at 99% 10-day horizon; CVA/DVA excluded from market risk', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0002-4000-8000-000000000002'),
+('00400003-0002-4000-8000-000000000003', 'KYC/AML Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100003-0002-4000-8000-000000000003', 'Customer due diligence, beneficial ownership, and transaction monitoring data', 'Entity resolution, risk scoring, SAR narrative generation, and OFAC screening', 'PEP and sanctions data refreshed daily; beneficial ownership threshold 25%; STR filing requires manual review', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0002-4000-8000-000000000003'),
+('00400004-0002-4000-8000-000000000004', 'Regulatory Reporting Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100003-0002-4000-8000-000000000003', 'Data feeds for prudential regulatory submissions (FR Y-14, CCAR, DFAST)', 'Automated population of regulatory templates and submission validation', 'Quarter-end data only; manual overrides must have four-eyes approval; reconciliation tolerance ±$1M', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0002-4000-8000-000000000004'),
+('00400005-0002-4000-8000-000000000005', 'Account & Transaction Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0002-4000-8000-000000000001', 'Core banking account master and transaction data for retail and commercial banking', 'Account analytics, fraud detection, fee optimization, and customer 360 enrichment', 'Real-time balance is T+0 approximation; currency conversion uses daily ECB fix; PII encrypted at rest with AES-256', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0002-4000-8000-000000000005')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -237,12 +236,12 @@ ON CONFLICT (id) DO NOTHING;
 -- 5. DATA PRODUCTS
 -- ============================================================================
 
-INSERT INTO data_products (id, api_version, kind, status, name, version, domain, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
-('00700001-0002-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'Trading Analytics Dashboard v1', '1.0.0', 'Capital Markets', 'fsi-demo', '00100001-0002-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0002-4000-8000-000000000001'),
-('00700002-0002-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'Enterprise Risk Aggregation v1', '1.0.0', 'Risk Management', 'fsi-demo', '00100002-0002-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700002-0002-4000-8000-000000000002'),
-('00700003-0002-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'AML Transaction Monitoring v1', '1.0.0', 'Regulatory Compliance', 'fsi-demo', '00100003-0002-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700003-0002-4000-8000-000000000003'),
-('00700004-0002-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Regulatory Reporting Hub v1', '1.0.0', 'Regulatory Compliance', 'fsi-demo', '00100003-0002-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700004-0002-4000-8000-000000000004'),
-('00700005-0002-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'Customer 360 Banking v1', '1.0.0', 'Banking', 'fsi-demo', '00100001-0002-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700005-0002-4000-8000-000000000005')
+INSERT INTO data_products (id, api_version, kind, status, name, version, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
+('00700001-0002-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'Trading Analytics Dashboard v1', '1.0.0', 'fsi-demo', '00100001-0002-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0002-4000-8000-000000000001'),
+('00700002-0002-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'Enterprise Risk Aggregation v1', '1.0.0', 'fsi-demo', '00100002-0002-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700002-0002-4000-8000-000000000002'),
+('00700003-0002-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'AML Transaction Monitoring v1', '1.0.0', 'fsi-demo', '00100003-0002-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700003-0002-4000-8000-000000000003'),
+('00700004-0002-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Regulatory Reporting Hub v1', '1.0.0', 'fsi-demo', '00100003-0002-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700004-0002-4000-8000-000000000004'),
+('00700005-0002-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'Customer 360 Banking v1', '1.0.0', 'fsi-demo', '00100001-0002-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700005-0002-4000-8000-000000000005')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -512,116 +511,84 @@ ON CONFLICT (id) DO NOTHING;
 -- 15. ASSETS — FSI catalog objects (type=0f3)
 -- ============================================================================
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
--- Trading
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('0f300101-0002-4000-8000-000000000001',
  'lakehouse.fsi.trading.executions',
  'FIX-protocol execution reports for equities and FX desks (intraday, sub-second).',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.fsi.trading.executions',
- '00000002-0002-4000-8000-000000000002',
  '{"catalog": "lakehouse", "schema": "fsi_trading", "table_name": "executions", "row_count": 92000000, "format": "delta"}',
  '["transaction-data", "mifid-ii"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Trading Position (vertical asset type)
 ('0f300102-0002-4000-8000-000000000002',
  'positions.equities.eod_2026_05_01',
  'End-of-day equity positions snapshot for May 1 2026.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Trading Position' LIMIT 1), '0f200101-0002-4000-8000-000000000001'), 'Databricks', 'positions.equities.eod_2026_05_01',
- '00000002-0002-4000-8000-000000000002',
  '{"asset_class": "equities", "snapshot_date": "2026-05-01", "instrument_count": 8400}',
  '["risk-tier-1", "market-risk"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Risk Limit (vertical asset type)
 ('0f300103-0002-4000-8000-000000000003',
  'limit.equities.var_99_1d',
  'Equities desk 99% / 1-day VaR limit.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Risk Limit' LIMIT 1), '0f200102-0002-4000-8000-000000000002'), 'Risk System', 'limits/equities/var_99_1d',
- '00000003-0002-4000-8000-000000000003',
  '{"limit_type": "VaR", "confidence": 0.99, "horizon_days": 1, "limit_usd": 25000000}',
  '["risk-tier-1", "market-risk"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Risk aggregation table
 ('0f300104-0002-4000-8000-000000000004',
  'lakehouse.fsi.risk.aggregated_var',
  'Aggregated VaR metrics (firm-wide, by desk, by asset class) feeding CRO dashboard.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.fsi.risk.aggregated_var',
- '00000003-0002-4000-8000-000000000003',
  '{"catalog": "lakehouse", "schema": "fsi_risk", "table_name": "aggregated_var", "format": "delta"}',
  '["bcbs-239", "risk-tier-1"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- AML stream
 ('0f300105-0002-4000-8000-000000000005',
  'kafka.fsi.aml.transaction_alerts',
  'Real-time stream of AML scenario hits and ML anomaly alerts.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Stream' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts',
- '00000004-0002-4000-8000-000000000004',
  '{"topic": "aml.transaction_alerts", "throughput_msgs_per_sec": 600}',
  '["aml-monitored", "transaction-data"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Regulatory Filing (vertical asset type)
 ('0f300106-0002-4000-8000-000000000006',
  'FFIEC-Call-Report-2026-Q1',
  'FFIEC Call Report quarterly submission for 2026 Q1.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Regulatory Filing' LIMIT 1), '0f200103-0002-4000-8000-000000000003'), 'Reg Portal', 'filings/ffiec/2026-Q1',
- '00000004-0002-4000-8000-000000000004',
  '{"filing_type": "FFIEC Call Report", "period": "2026-Q1", "status": "submitted", "submission_date": "2026-04-30"}',
  '["bcbs-239"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Customer table
 ('0f300107-0002-4000-8000-000000000007',
  'lakehouse.fsi.banking.customer_master',
  'Banking customer master with KYC tier and segment classifications.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.fsi.banking.customer_master',
- '00000001-0002-4000-8000-000000000001',
  '{"catalog": "lakehouse", "schema": "fsi_banking", "table_name": "customer_master", "row_count": 4200000, "format": "delta"}',
  '["aml-monitored"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Dashboard
 ('0f300108-0002-4000-8000-000000000008',
  'CRO Risk Dashboard',
  'Daily firm-wide risk metrics, breach summary, and stress test results.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200002-0000-4000-8000-000000000002'), 'Databricks', 'https://bi.bank.com/dashboards/cro-risk-v1',
- '00000003-0002-4000-8000-000000000003',
  '{"refresh_schedule": "hourly", "audience": "cro-team"}',
  '["bcbs-239", "risk-tier-1"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- ── Column assets for the FSI Tables / Streams above ──
--- 0f300101 lakehouse.fsi.trading.executions
-('0f520101-0002-4000-8000-000000000001', 'trade_id',     'Unique trade execution identifier',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.trade_id',     '00000002-0002-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false, "is_primary_key": true}',  '["mifid-ii", "key"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520102-0002-4000-8000-000000000002', 'instrument_id','ISIN or internal security identifier',      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.instrument_id','00000002-0002-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
-('0f520103-0002-4000-8000-000000000003', 'side',         'BUY or SELL',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.side',         '00000002-0002-4000-8000-000000000002', '{"data_type": "STRING",        "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
-('0f520104-0002-4000-8000-000000000004', 'quantity',     'Executed quantity',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.quantity',     '00000002-0002-4000-8000-000000000002', '{"data_type": "DECIMAL(18,4)", "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
-('0f520105-0002-4000-8000-000000000005', 'price',        'Execution price (instrument currency)',      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.price',        '00000002-0002-4000-8000-000000000002', '{"data_type": "DECIMAL(18,6)", "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
-('0f520106-0002-4000-8000-000000000006', 'execution_ts', 'Execution timestamp (nanosecond precision)', (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.execution_ts', '00000002-0002-4000-8000-000000000002', '{"data_type": "TIMESTAMP_NS",  "nullable": false, "partition_key": true}',   '["mifid-ii", "partition"]',          'active', 'system@demo', NOW(), NOW()),
-
--- 0f300104 lakehouse.fsi.risk.aggregated_var
-('0f520111-0002-4000-8000-000000000011', 'exposure_id',    'Unique exposure record identifier',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.exposure_id',   '00000003-0002-4000-8000-000000000003', '{"data_type": "STRING",        "nullable": false, "is_primary_key": true}', '["bcbs-239", "key"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520112-0002-4000-8000-000000000012', 'risk_type',      'credit | market | counterparty | operational',(SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.risk_type',     '00000003-0002-4000-8000-000000000003', '{"data_type": "STRING",        "nullable": false}',                         '["bcbs-239"]',                       'active', 'system@demo', NOW(), NOW()),
-('0f520113-0002-4000-8000-000000000013', 'desk',           'Trading desk identifier',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.desk',          '00000003-0002-4000-8000-000000000003', '{"data_type": "STRING",        "nullable": false}',                         '["bcbs-239"]',                       'active', 'system@demo', NOW(), NOW()),
-('0f520114-0002-4000-8000-000000000014', 'var_99',         'Value-at-Risk at 99% confidence',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.var_99',        '00000003-0002-4000-8000-000000000003', '{"data_type": "DECIMAL(18,2)", "nullable": false}',                         '["bcbs-239", "kpi"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520115-0002-4000-8000-000000000015', 'reporting_date', 'Risk reporting date (partition key)',       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.reporting_date','00000003-0002-4000-8000-000000000003', '{"data_type": "DATE",          "nullable": false, "partition_key": true}',  '["bcbs-239", "partition"]',          'active', 'system@demo', NOW(), NOW()),
-
--- 0f300105 kafka.fsi.aml.transaction_alerts (Stream — schema as advertised on the topic)
-('0f520121-0002-4000-8000-000000000021', 'alert_id',       'Unique AML alert identifier',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.alert_id',     '00000004-0002-4000-8000-000000000004', '{"data_type": "STRING", "nullable": false, "is_primary_key": true}', '["aml", "key"]',     'active', 'system@demo', NOW(), NOW()),
-('0f520122-0002-4000-8000-000000000022', 'customer_id',    'FK to customer_kyc.customer_id',             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.customer_id',  '00000004-0002-4000-8000-000000000004', '{"data_type": "STRING", "nullable": false}',                          '["aml", "fk"]',      'active', 'system@demo', NOW(), NOW()),
-('0f520123-0002-4000-8000-000000000023', 'scenario_code',  'Scenario / model that fired',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.scenario_code','00000004-0002-4000-8000-000000000004', '{"data_type": "STRING", "nullable": false}',                          '["aml"]',            'active', 'system@demo', NOW(), NOW()),
-('0f520124-0002-4000-8000-000000000024', 'severity',       'low | medium | high | critical',             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.severity',     '00000004-0002-4000-8000-000000000004', '{"data_type": "STRING", "nullable": false}',                          '["aml"]',            'active', 'system@demo', NOW(), NOW()),
-('0f520125-0002-4000-8000-000000000025', 'alert_ts',       'Alert generation timestamp (UTC)',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.alert_ts',     '00000004-0002-4000-8000-000000000004', '{"data_type": "TIMESTAMP", "nullable": false}',                       '["aml"]',            'active', 'system@demo', NOW(), NOW()),
-
--- 0f300107 lakehouse.fsi.banking.customer_master
-('0f520131-0002-4000-8000-000000000031', 'customer_id',  'Unique customer identifier',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.customer_id', '00000001-0002-4000-8000-000000000001', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}', '["pii", "key"]',          'active', 'system@demo', NOW(), NOW()),
-('0f520132-0002-4000-8000-000000000032', 'kyc_tier',     'Tier of customer due diligence applied',      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.kyc_tier',    '00000001-0002-4000-8000-000000000001', '{"data_type": "STRING",  "nullable": false}',                          '["aml-monitored"]',       'active', 'system@demo', NOW(), NOW()),
-('0f520133-0002-4000-8000-000000000033', 'segment',      'Retail | Mass-Affluent | Private | SMB | Corp',(SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.segment',     '00000001-0002-4000-8000-000000000001', '{"data_type": "STRING",  "nullable": false}',                          '["banking"]',             'active', 'system@demo', NOW(), NOW()),
-('0f520134-0002-4000-8000-000000000034', 'opened_date',  'Earliest account opening date for customer',   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.opened_date', '00000001-0002-4000-8000-000000000001', '{"data_type": "DATE",    "nullable": false}',                          '["banking"]',             'active', 'system@demo', NOW(), NOW()),
-('0f520135-0002-4000-8000-000000000035', 'country_code', 'ISO 3166-1 alpha-2 of customer residence',     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.country_code','00000001-0002-4000-8000-000000000001', '{"data_type": "STRING",  "nullable": false}',                          '["banking", "pii"]',      'active', 'system@demo', NOW(), NOW())
+('0f520101-0002-4000-8000-000000000001', 'trade_id',     'Unique trade execution identifier',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.trade_id', '{"data_type": "STRING",        "nullable": false, "is_primary_key": true}',  '["mifid-ii", "key"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520102-0002-4000-8000-000000000002', 'instrument_id','ISIN or internal security identifier',      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.instrument_id', '{"data_type": "STRING",        "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520103-0002-4000-8000-000000000003', 'side',         'BUY or SELL',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.side', '{"data_type": "STRING",        "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520104-0002-4000-8000-000000000004', 'quantity',     'Executed quantity',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.quantity', '{"data_type": "DECIMAL(18,4)", "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520105-0002-4000-8000-000000000005', 'price',        'Execution price (instrument currency)',      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.price', '{"data_type": "DECIMAL(18,6)", "nullable": false}',                          '["mifid-ii"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520106-0002-4000-8000-000000000006', 'execution_ts', 'Execution timestamp (nanosecond precision)', (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.trading.executions.execution_ts', '{"data_type": "TIMESTAMP_NS",  "nullable": false, "partition_key": true}',   '["mifid-ii", "partition"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520111-0002-4000-8000-000000000011', 'exposure_id',    'Unique exposure record identifier',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.exposure_id', '{"data_type": "STRING",        "nullable": false, "is_primary_key": true}', '["bcbs-239", "key"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520112-0002-4000-8000-000000000012', 'risk_type',      'credit | market | counterparty | operational',(SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.risk_type', '{"data_type": "STRING",        "nullable": false}',                         '["bcbs-239"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520113-0002-4000-8000-000000000013', 'desk',           'Trading desk identifier',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.desk', '{"data_type": "STRING",        "nullable": false}',                         '["bcbs-239"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520114-0002-4000-8000-000000000014', 'var_99',         'Value-at-Risk at 99% confidence',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.var_99', '{"data_type": "DECIMAL(18,2)", "nullable": false}',                         '["bcbs-239", "kpi"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520115-0002-4000-8000-000000000015', 'reporting_date', 'Risk reporting date (partition key)',       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.risk.aggregated_var.reporting_date', '{"data_type": "DATE",          "nullable": false, "partition_key": true}',  '["bcbs-239", "partition"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520121-0002-4000-8000-000000000021', 'alert_id',       'Unique AML alert identifier',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.alert_id', '{"data_type": "STRING", "nullable": false, "is_primary_key": true}', '["aml", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520122-0002-4000-8000-000000000022', 'customer_id',    'FK to customer_kyc.customer_id',             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.customer_id', '{"data_type": "STRING", "nullable": false}',                          '["aml", "fk"]',      'active', 'system@demo', NOW(), NOW()),
+('0f520123-0002-4000-8000-000000000023', 'scenario_code',  'Scenario / model that fired',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.scenario_code', '{"data_type": "STRING", "nullable": false}',                          '["aml"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520124-0002-4000-8000-000000000024', 'severity',       'low | medium | high | critical',             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.severity', '{"data_type": "STRING", "nullable": false}',                          '["aml"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520125-0002-4000-8000-000000000025', 'alert_ts',       'Alert generation timestamp (UTC)',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka', 'kafka://broker.bank:9093/aml.transaction_alerts.alert_ts', '{"data_type": "TIMESTAMP", "nullable": false}',                       '["aml"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520131-0002-4000-8000-000000000031', 'customer_id',  'Unique customer identifier',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.customer_id', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}', '["pii", "key"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520132-0002-4000-8000-000000000032', 'kyc_tier',     'Tier of customer due diligence applied',      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.kyc_tier', '{"data_type": "STRING",  "nullable": false}',                          '["aml-monitored"]',       'active', 'system@demo', NOW(), NOW()),
+('0f520133-0002-4000-8000-000000000033', 'segment',      'Retail | Mass-Affluent | Private | SMB | Corp',(SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.segment', '{"data_type": "STRING",  "nullable": false}',                          '["banking"]',             'active', 'system@demo', NOW(), NOW()),
+('0f520134-0002-4000-8000-000000000034', 'opened_date',  'Earliest account opening date for customer',   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.opened_date', '{"data_type": "DATE",    "nullable": false}',                          '["banking"]',             'active', 'system@demo', NOW(), NOW()),
+('0f520135-0002-4000-8000-000000000035', 'country_code', 'ISO 3166-1 alpha-2 of customer residence',     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.fsi.banking.customer_master.country_code', '{"data_type": "STRING",  "nullable": false}',                          '["banking", "pii"]',      'active', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -793,3 +760,53 @@ COMMIT;
 -- ============================================================================
 -- End of FSI Demo Data — preset=fsi
 -- ============================================================================
+
+
+-- ============================================================================
+-- Domain associations (multi-domain assignment; replaces removed single-value
+-- domain columns on teams/data_contracts/data_products/assets). Type code 031.
+-- ============================================================================
+INSERT INTO entity_domain_associations (id, domain_id, entity_id, entity_type, is_primary, assigned_by, assigned_at) VALUES
+('03100001-0002-4000-8000-000000000001', '00000002-0002-4000-8000-000000000002', '00100001-0002-4000-8000-000000000001', 'team', true, 'system@demo', NOW()),
+('03100002-0002-4000-8000-000000000002', '00000003-0002-4000-8000-000000000003', '00100002-0002-4000-8000-000000000002', 'team', true, 'system@demo', NOW()),
+('03100003-0002-4000-8000-000000000003', '00000004-0002-4000-8000-000000000004', '00100003-0002-4000-8000-000000000003', 'team', true, 'system@demo', NOW()),
+('03100004-0002-4000-8000-000000000004', '00000002-0002-4000-8000-000000000002', '00400001-0002-4000-8000-000000000001', 'data_contract', true, 'system@demo', NOW()),
+('03100005-0002-4000-8000-000000000005', '00000003-0002-4000-8000-000000000003', '00400002-0002-4000-8000-000000000002', 'data_contract', true, 'system@demo', NOW()),
+('03100006-0002-4000-8000-000000000006', '00000004-0002-4000-8000-000000000004', '00400003-0002-4000-8000-000000000003', 'data_contract', true, 'system@demo', NOW()),
+('03100007-0002-4000-8000-000000000007', '00000004-0002-4000-8000-000000000004', '00400004-0002-4000-8000-000000000004', 'data_contract', true, 'system@demo', NOW()),
+('03100008-0002-4000-8000-000000000008', '00000001-0002-4000-8000-000000000001', '00400005-0002-4000-8000-000000000005', 'data_contract', true, 'system@demo', NOW()),
+('03100009-0002-4000-8000-000000000009', '00000002-0002-4000-8000-000000000002', '00700001-0002-4000-8000-000000000001', 'data_product', true, 'system@demo', NOW()),
+('0310000a-0002-4000-8000-000000000010', '00000003-0002-4000-8000-000000000003', '00700002-0002-4000-8000-000000000002', 'data_product', true, 'system@demo', NOW()),
+('0310000b-0002-4000-8000-000000000011', '00000004-0002-4000-8000-000000000004', '00700003-0002-4000-8000-000000000003', 'data_product', true, 'system@demo', NOW()),
+('0310000c-0002-4000-8000-000000000012', '00000004-0002-4000-8000-000000000004', '00700004-0002-4000-8000-000000000004', 'data_product', true, 'system@demo', NOW()),
+('0310000d-0002-4000-8000-000000000013', '00000001-0002-4000-8000-000000000001', '00700005-0002-4000-8000-000000000005', 'data_product', true, 'system@demo', NOW()),
+('0310000e-0002-4000-8000-000000000014', '00000002-0002-4000-8000-000000000002', '0f300101-0002-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('0310000f-0002-4000-8000-000000000015', '00000002-0002-4000-8000-000000000002', '0f300102-0002-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100010-0002-4000-8000-000000000016', '00000003-0002-4000-8000-000000000003', '0f300103-0002-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100011-0002-4000-8000-000000000017', '00000003-0002-4000-8000-000000000003', '0f300104-0002-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100012-0002-4000-8000-000000000018', '00000004-0002-4000-8000-000000000004', '0f300105-0002-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('03100013-0002-4000-8000-000000000019', '00000004-0002-4000-8000-000000000004', '0f300106-0002-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('03100014-0002-4000-8000-000000000020', '00000001-0002-4000-8000-000000000001', '0f300107-0002-4000-8000-000000000007', 'asset', true, 'system@demo', NOW()),
+('03100015-0002-4000-8000-000000000021', '00000003-0002-4000-8000-000000000003', '0f300108-0002-4000-8000-000000000008', 'asset', true, 'system@demo', NOW()),
+('03100016-0002-4000-8000-000000000022', '00000002-0002-4000-8000-000000000002', '0f520101-0002-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('03100017-0002-4000-8000-000000000023', '00000002-0002-4000-8000-000000000002', '0f520102-0002-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100018-0002-4000-8000-000000000024', '00000002-0002-4000-8000-000000000002', '0f520103-0002-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100019-0002-4000-8000-000000000025', '00000002-0002-4000-8000-000000000002', '0f520104-0002-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('0310001a-0002-4000-8000-000000000026', '00000002-0002-4000-8000-000000000002', '0f520105-0002-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('0310001b-0002-4000-8000-000000000027', '00000002-0002-4000-8000-000000000002', '0f520106-0002-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('0310001c-0002-4000-8000-000000000028', '00000003-0002-4000-8000-000000000003', '0f520111-0002-4000-8000-000000000011', 'asset', true, 'system@demo', NOW()),
+('0310001d-0002-4000-8000-000000000029', '00000003-0002-4000-8000-000000000003', '0f520112-0002-4000-8000-000000000012', 'asset', true, 'system@demo', NOW()),
+('0310001e-0002-4000-8000-000000000030', '00000003-0002-4000-8000-000000000003', '0f520113-0002-4000-8000-000000000013', 'asset', true, 'system@demo', NOW()),
+('0310001f-0002-4000-8000-000000000031', '00000003-0002-4000-8000-000000000003', '0f520114-0002-4000-8000-000000000014', 'asset', true, 'system@demo', NOW()),
+('03100020-0002-4000-8000-000000000032', '00000003-0002-4000-8000-000000000003', '0f520115-0002-4000-8000-000000000015', 'asset', true, 'system@demo', NOW()),
+('03100021-0002-4000-8000-000000000033', '00000004-0002-4000-8000-000000000004', '0f520121-0002-4000-8000-000000000021', 'asset', true, 'system@demo', NOW()),
+('03100022-0002-4000-8000-000000000034', '00000004-0002-4000-8000-000000000004', '0f520122-0002-4000-8000-000000000022', 'asset', true, 'system@demo', NOW()),
+('03100023-0002-4000-8000-000000000035', '00000004-0002-4000-8000-000000000004', '0f520123-0002-4000-8000-000000000023', 'asset', true, 'system@demo', NOW()),
+('03100024-0002-4000-8000-000000000036', '00000004-0002-4000-8000-000000000004', '0f520124-0002-4000-8000-000000000024', 'asset', true, 'system@demo', NOW()),
+('03100025-0002-4000-8000-000000000037', '00000004-0002-4000-8000-000000000004', '0f520125-0002-4000-8000-000000000025', 'asset', true, 'system@demo', NOW()),
+('03100026-0002-4000-8000-000000000038', '00000001-0002-4000-8000-000000000001', '0f520131-0002-4000-8000-000000000031', 'asset', true, 'system@demo', NOW()),
+('03100027-0002-4000-8000-000000000039', '00000001-0002-4000-8000-000000000001', '0f520132-0002-4000-8000-000000000032', 'asset', true, 'system@demo', NOW()),
+('03100028-0002-4000-8000-000000000040', '00000001-0002-4000-8000-000000000001', '0f520133-0002-4000-8000-000000000033', 'asset', true, 'system@demo', NOW()),
+('03100029-0002-4000-8000-000000000041', '00000001-0002-4000-8000-000000000001', '0f520134-0002-4000-8000-000000000034', 'asset', true, 'system@demo', NOW()),
+('0310002a-0002-4000-8000-000000000042', '00000001-0002-4000-8000-000000000001', '0f520135-0002-4000-8000-000000000035', 'asset', true, 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;

--- a/src/backend/src/data/demo_data_hls.sql
+++ b/src/backend/src/data/demo_data_hls.sql
@@ -46,11 +46,10 @@ ON CONFLICT (id) DO NOTHING;
 -- 2. TEAMS
 -- ============================================================================
 
-INSERT INTO teams (id, name, title, description, domain_id, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
-('00100001-0001-4000-8000-000000000001', 'clinical-data', 'Clinical Data Team', 'Manages EHR integration, patient data pipelines, and clinical analytics', '00000001-0001-4000-8000-000000000001', '{"slack_channel": "https://company.slack.com/channels/clinical-data", "lead": "dr.chen@hospital.org"}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100002-0001-4000-8000-000000000002', 'research-and-dev', 'Research & Development Team', 'Clinical trial data management, study design analytics, and biostatistics', '00000002-0001-4000-8000-000000000002', '{"slack_channel": "https://company.slack.com/channels/rd-data", "tools": ["SAS", "R", "Python", "REDCap"]}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100003-0001-4000-8000-000000000003', 'regulatory-affairs', 'Regulatory Affairs Team', 'FDA/EMA submission preparation, pharmacovigilance, and compliance monitoring', '00000003-0001-4000-8000-000000000003', '{"slack_channel": "https://company.slack.com/channels/reg-affairs", "responsibilities": ["FDA 21 CFR Part 11", "HIPAA", "GxP"]}', 'system@demo', 'system@demo', NOW(), NOW())
-
+INSERT INTO teams (id, name, title, description, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
+('00100001-0001-4000-8000-000000000001', 'clinical-data', 'Clinical Data Team', 'Manages EHR integration, patient data pipelines, and clinical analytics', '{"slack_channel": "https://company.slack.com/channels/clinical-data", "lead": "dr.chen@hospital.org"}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100002-0001-4000-8000-000000000002', 'research-and-dev', 'Research & Development Team', 'Clinical trial data management, study design analytics, and biostatistics', '{"slack_channel": "https://company.slack.com/channels/rd-data", "tools": ["SAS", "R", "Python", "REDCap"]}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100003-0001-4000-8000-000000000003', 'regulatory-affairs', 'Regulatory Affairs Team', 'FDA/EMA submission preparation, pharmacovigilance, and compliance monitoring', '{"slack_channel": "https://company.slack.com/channels/reg-affairs", "responsibilities": ["FDA 21 CFR Part 11", "HIPAA", "GxP"]}', 'system@demo', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -100,12 +99,12 @@ ON CONFLICT (project_id, team_id) DO NOTHING;
 -- 4. DATA CONTRACTS
 -- ============================================================================
 
-INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, domain_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
-('00400001-0001-4000-8000-000000000001', 'Patient EHR Data Contract', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100001-0001-4000-8000-000000000001', '00000001-0001-4000-8000-000000000001', 'Standardized patient electronic health record data for clinical analytics and care coordination', 'Integrate into clinical dashboards, care pathway analysis, and population health management', 'All PHI must be de-identified for analytics; HIPAA Safe Harbor rules apply; data retention 7 years per state regulations', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0001-4000-8000-000000000001'),
-('00400002-0001-4000-8000-000000000002', 'Clinical Trial Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100002-0001-4000-8000-000000000002', '00000002-0001-4000-8000-000000000002', 'Clinical trial enrollment, randomization, endpoint, and adverse event data', 'Support study monitoring, interim analyses, DSMB reporting, and regulatory submissions', 'Subject-level data requires IRB approval; blinded data restricted until study unblinding; 21 CFR Part 11 compliant', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0001-4000-8000-000000000002'),
-('00400003-0001-4000-8000-000000000003', 'Adverse Event Reporting Contract', 'DataContract', 'v3.1.0', '1.1.0', 'active', true, '00100003-0001-4000-8000-000000000003', '00000003-0001-4000-8000-000000000003', 'Spontaneous and solicited adverse event reports for pharmacovigilance signal detection', 'Feed into safety signal detection algorithms, periodic safety reports (PSURs), and FDA FAERS submissions', 'MedDRA coding required; reporter identities must be anonymized; 15-day expedited reporting for serious AEs', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0001-4000-8000-000000000003'),
-('00400004-0001-4000-8000-000000000004', 'Genomic Sequencing Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100002-0001-4000-8000-000000000002', '00000004-0001-4000-8000-000000000004', 'Whole genome and exome sequencing data for precision medicine research', 'Variant calling pipelines, biomarker discovery, and companion diagnostic development', 'Consent-gated access; re-identification risk assessment required; GINA compliance mandatory', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0001-4000-8000-000000000004'),
-('00400005-0001-4000-8000-000000000005', 'Claims & Reimbursement Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0001-4000-8000-000000000001', '00000006-0001-4000-8000-000000000006', 'Healthcare insurance claims, adjudication outcomes, and reimbursement data', 'Revenue cycle analytics, denial management, and payer contract optimization', 'CMS HCPCS/CPT coding standards; member SSN must be masked; data shared under BAA only', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0001-4000-8000-000000000005')
+INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
+('00400001-0001-4000-8000-000000000001', 'Patient EHR Data Contract', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100001-0001-4000-8000-000000000001', 'Standardized patient electronic health record data for clinical analytics and care coordination', 'Integrate into clinical dashboards, care pathway analysis, and population health management', 'All PHI must be de-identified for analytics; HIPAA Safe Harbor rules apply; data retention 7 years per state regulations', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0001-4000-8000-000000000001'),
+('00400002-0001-4000-8000-000000000002', 'Clinical Trial Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100002-0001-4000-8000-000000000002', 'Clinical trial enrollment, randomization, endpoint, and adverse event data', 'Support study monitoring, interim analyses, DSMB reporting, and regulatory submissions', 'Subject-level data requires IRB approval; blinded data restricted until study unblinding; 21 CFR Part 11 compliant', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0001-4000-8000-000000000002'),
+('00400003-0001-4000-8000-000000000003', 'Adverse Event Reporting Contract', 'DataContract', 'v3.1.0', '1.1.0', 'active', true, '00100003-0001-4000-8000-000000000003', 'Spontaneous and solicited adverse event reports for pharmacovigilance signal detection', 'Feed into safety signal detection algorithms, periodic safety reports (PSURs), and FDA FAERS submissions', 'MedDRA coding required; reporter identities must be anonymized; 15-day expedited reporting for serious AEs', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0001-4000-8000-000000000003'),
+('00400004-0001-4000-8000-000000000004', 'Genomic Sequencing Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100002-0001-4000-8000-000000000002', 'Whole genome and exome sequencing data for precision medicine research', 'Variant calling pipelines, biomarker discovery, and companion diagnostic development', 'Consent-gated access; re-identification risk assessment required; GINA compliance mandatory', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0001-4000-8000-000000000004'),
+('00400005-0001-4000-8000-000000000005', 'Claims & Reimbursement Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0001-4000-8000-000000000001', 'Healthcare insurance claims, adjudication outcomes, and reimbursement data', 'Revenue cycle analytics, denial management, and payer contract optimization', 'CMS HCPCS/CPT coding standards; member SSN must be masked; data shared under BAA only', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0001-4000-8000-000000000005')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -241,12 +240,12 @@ ON CONFLICT (id) DO NOTHING;
 -- 5. DATA PRODUCTS
 -- ============================================================================
 
-INSERT INTO data_products (id, api_version, kind, status, name, version, domain, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
-('00700001-0001-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'Patient 360 View v1', '1.0.0', 'Clinical', 'hls-demo', '00100001-0001-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0001-4000-8000-000000000001'),
-('00700002-0001-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'Clinical Trial Analytics v1', '1.0.0', 'Research', 'hls-demo', '00100002-0001-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700002-0001-4000-8000-000000000002'),
-('00700003-0001-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'Drug Safety Signal Detection v1', '1.0.0', 'Regulatory', 'hls-demo', '00100003-0001-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700003-0001-4000-8000-000000000003'),
-('00700004-0001-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Real-World Evidence Platform v1', '1.0.0', 'Research', 'hls-demo', '00100002-0001-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700004-0001-4000-8000-000000000004'),
-('00700005-0001-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'Claims Analytics Dashboard v1', '1.0.0', 'Claims', 'hls-demo', '00100001-0001-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700005-0001-4000-8000-000000000005')
+INSERT INTO data_products (id, api_version, kind, status, name, version, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
+('00700001-0001-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'Patient 360 View v1', '1.0.0', 'hls-demo', '00100001-0001-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0001-4000-8000-000000000001'),
+('00700002-0001-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'Clinical Trial Analytics v1', '1.0.0', 'hls-demo', '00100002-0001-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700002-0001-4000-8000-000000000002'),
+('00700003-0001-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'Drug Safety Signal Detection v1', '1.0.0', 'hls-demo', '00100003-0001-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700003-0001-4000-8000-000000000003'),
+('00700004-0001-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Real-World Evidence Platform v1', '1.0.0', 'hls-demo', '00100002-0001-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700004-0001-4000-8000-000000000004'),
+('00700005-0001-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'Claims Analytics Dashboard v1', '1.0.0', 'hls-demo', '00100001-0001-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700005-0001-4000-8000-000000000005')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -531,114 +530,83 @@ ON CONFLICT (id) DO NOTHING;
 -- the HLS data products. asset_type_id is resolved by name; falls back to a
 -- known ontology UUID if the type name is missing.
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
--- Tables (Clinical)
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('0f300101-0001-4000-8000-000000000001',
  'lakehouse.hls.curated.patients',
  'De-identified patient master record (HIPAA Safe Harbor).',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.hls.curated.patients',
- '00000001-0001-4000-8000-000000000001',
  '{"catalog": "lakehouse", "schema": "hls_curated", "table_name": "patients", "row_count": 2400000, "format": "delta"}',
  '["curated", "phi-deidentified"]',
  'active', 'system@demo', NOW(), NOW()),
-
 ('0f300102-0001-4000-8000-000000000002',
  'lakehouse.hls.curated.encounters',
  'Inpatient and outpatient encounters with billing codes.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.hls.curated.encounters',
- '00000001-0001-4000-8000-000000000001',
  '{"catalog": "lakehouse", "schema": "hls_curated", "table_name": "encounters", "row_count": 18500000, "format": "delta"}',
  '["curated", "phi-limited"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Patient Cohort (vertical asset type)
 ('0f300103-0001-4000-8000-000000000003',
  'cohort.oncology.her2_positive_2024',
  'HER2-positive breast cancer cohort for 2024 RWE study (~12,400 patients).',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Patient Cohort' LIMIT 1), '0f200101-0001-4000-8000-000000000001'), 'Databricks', 'cohort.oncology.her2_positive_2024',
- '00000002-0001-4000-8000-000000000002',
  '{"cohort_size": 12400, "inclusion_criteria": ["HER2+", "stage_II_or_III"], "study_id": "ONCO-RWE-2024-08"}',
  '["cohort-eligible", "rwe-source"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Clinical Trial Dataset (vertical asset type)
 ('0f300104-0001-4000-8000-000000000004',
  'sdtm.onco-2025-001.dm',
  'CDISC SDTM DM (Demographics) dataset for protocol ONCO-2025-001.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Clinical Trial Dataset' LIMIT 1), '0f200102-0001-4000-8000-000000000002'), 'Databricks', 'sdtm.onco-2025-001.dm',
- '00000002-0001-4000-8000-000000000002',
  '{"protocol": "ONCO-2025-001", "cdisc_standard": "SDTM", "version": "3.3", "dataset": "DM"}',
  '["submission-ready", "21cfr-part-11"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Dashboard
 ('0f300105-0001-4000-8000-000000000005',
  'Trial Monitoring Dashboard',
  'Site enrollment, screen failure rate, and SAE summary across active oncology trials.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200002-0000-4000-8000-000000000002'), 'Databricks', 'https://bi.pharma.com/dashboards/trial-monitoring',
- '00000002-0001-4000-8000-000000000002',
  '{"refresh_schedule": "daily", "audience": "study-team"}',
  '["analytics"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Streaming source (FAERS feed)
 ('0f300106-0001-4000-8000-000000000006',
  'kafka.pharma.faers.case_events',
  'Real-time stream of incoming FAERS adverse-event case submissions.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Stream' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Kafka', 'kafka://broker.pharma:9093/faers.case_events',
- '00000003-0001-4000-8000-000000000003',
  '{"topic": "faers.case_events", "throughput_msgs_per_sec": 1200}',
  '["real-time"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Adverse Event Case (vertical asset type)
 ('0f300107-0001-4000-8000-000000000007',
  'ICSR-2025-4521',
  'Individual Case Safety Report — serious adverse event, drug XYZ.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Adverse Event Case' LIMIT 1), '0f200103-0001-4000-8000-000000000003'), 'Pharma Safety DB', 'safety://cases/ICSR-2025-4521',
- '00000003-0001-4000-8000-000000000003',
  '{"seriousness": "serious", "expectedness": "unexpected", "days_to_report": 12, "regulatory_status": "submitted"}',
  '["hipaa", "21cfr-part-11"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Claims table
 ('0f300108-0001-4000-8000-000000000008',
  'lakehouse.hls.claims.adjudicated',
  'Adjudicated medical and pharmacy claims (commercial + Medicare Advantage).',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.hls.claims.adjudicated',
- '00000006-0001-4000-8000-000000000006',
  '{"catalog": "lakehouse", "schema": "hls_claims", "table_name": "adjudicated", "row_count": 45000000, "format": "delta"}',
  '["curated"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- ── Column assets for the HLS Tables / Streams above ──
--- 0f300101 lakehouse.hls.curated.patients
-('0f520101-0001-4000-8000-000000000001', 'patient_id',     'De-identified patient identifier (hash of MRN)',  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.patient_id',     '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["phi", "key", "deidentified"]', 'active', 'system@demo', NOW(), NOW()),
-('0f520102-0001-4000-8000-000000000002', 'date_of_birth',  'Patient date of birth (Safe Harbor shifted)',     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.date_of_birth',  '00000001-0001-4000-8000-000000000001', '{"data_type": "DATE",     "nullable": false}',                          '["phi", "deidentified"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520103-0001-4000-8000-000000000003', 'gender',         'Administrative gender (M/F/O/U)',                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.gender',         '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false}',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
-('0f520104-0001-4000-8000-000000000004', 'race_ethnicity', 'OMB race/ethnicity category',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.race_ethnicity', '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": true }',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
-('0f520105-0001-4000-8000-000000000005', 'zip_3',          'First 3 digits of ZIP (Safe Harbor)',             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.zip_3',          '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": true }',                          '["phi", "deidentified"]',         'active', 'system@demo', NOW(), NOW()),
-
--- 0f300102 lakehouse.hls.curated.encounters
-('0f520111-0001-4000-8000-000000000011', 'encounter_id',   'Unique encounter identifier',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.encounter_id',  '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["phi", "key"]',                  'active', 'system@demo', NOW(), NOW()),
-('0f520112-0001-4000-8000-000000000012', 'patient_id',     'FK to patients.patient_id',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.patient_id',    '00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false}',                          '["phi", "fk"]',                   'active', 'system@demo', NOW(), NOW()),
-('0f520113-0001-4000-8000-000000000013', 'encounter_type', 'inpatient | outpatient | emergency | observation',(SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.encounter_type','00000001-0001-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false}',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
-('0f520114-0001-4000-8000-000000000014', 'admit_date',     'Admit/visit date (UTC)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.admit_date',    '00000001-0001-4000-8000-000000000001', '{"data_type": "TIMESTAMP","nullable": false, "partition_key": true}',  '["phi", "partition"]',            'active', 'system@demo', NOW(), NOW()),
-('0f520115-0001-4000-8000-000000000015', 'discharge_date', 'Discharge date (NULL if still admitted)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.discharge_date','00000001-0001-4000-8000-000000000001', '{"data_type": "TIMESTAMP","nullable": true }',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
-
--- 0f300106 kafka.pharma.faers.case_events (Stream)
-('0f520121-0001-4000-8000-000000000021', 'case_id',        'ICSR case number',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.case_id',         '00000003-0001-4000-8000-000000000003', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}', '["pharmacovigilance", "key"]',   'active', 'system@demo', NOW(), NOW()),
-('0f520122-0001-4000-8000-000000000022', 'product_id',     'Product (substance) identifier',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.product_id',      '00000003-0001-4000-8000-000000000003', '{"data_type": "STRING",  "nullable": false}',                          '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520123-0001-4000-8000-000000000023', 'meddra_pt',      'MedDRA preferred term',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.meddra_pt',       '00000003-0001-4000-8000-000000000003', '{"data_type": "STRING",  "nullable": false}',                          '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520124-0001-4000-8000-000000000024', 'seriousness',    'serious | non_serious',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.seriousness',     '00000003-0001-4000-8000-000000000003', '{"data_type": "STRING",  "nullable": false}',                          '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520125-0001-4000-8000-000000000025', 'received_ts',    'Submission receive timestamp (UTC)',              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.received_ts',     '00000003-0001-4000-8000-000000000003', '{"data_type": "TIMESTAMP","nullable": false}',                         '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
-
--- 0f300108 lakehouse.hls.claims.adjudicated
-('0f520131-0001-4000-8000-000000000031', 'claim_id',       'Unique medical claim identifier',                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.claim_id',      '00000006-0001-4000-8000-000000000006', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}', '["claims", "key"]',               'active', 'system@demo', NOW(), NOW()),
-('0f520132-0001-4000-8000-000000000032', 'member_id',      'Insurance plan member identifier',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.member_id',     '00000006-0001-4000-8000-000000000006', '{"data_type": "STRING",  "nullable": false}',                          '["claims", "phi"]',               'active', 'system@demo', NOW(), NOW()),
-('0f520133-0001-4000-8000-000000000033', 'service_date',   'Date of service (partition)',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.service_date',  '00000006-0001-4000-8000-000000000006', '{"data_type": "DATE",    "nullable": false, "partition_key": true}',  '["claims", "partition"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520134-0001-4000-8000-000000000034', 'cpt_code',       'CMS HCPCS / CPT procedure code',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.cpt_code',      '00000006-0001-4000-8000-000000000006', '{"data_type": "STRING",  "nullable": false}',                          '["claims"]',                       'active', 'system@demo', NOW(), NOW()),
-('0f520135-0001-4000-8000-000000000035', 'allowed_amount', 'Amount allowed by payer (USD)',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.allowed_amount','00000006-0001-4000-8000-000000000006', '{"data_type": "DECIMAL(18,2)","nullable": false}',                     '["claims", "kpi"]',               'active', 'system@demo', NOW(), NOW())
+('0f520101-0001-4000-8000-000000000001', 'patient_id',     'De-identified patient identifier (hash of MRN)',  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.patient_id', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["phi", "key", "deidentified"]', 'active', 'system@demo', NOW(), NOW()),
+('0f520102-0001-4000-8000-000000000002', 'date_of_birth',  'Patient date of birth (Safe Harbor shifted)',     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.date_of_birth', '{"data_type": "DATE",     "nullable": false}',                          '["phi", "deidentified"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520103-0001-4000-8000-000000000003', 'gender',         'Administrative gender (M/F/O/U)',                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.gender', '{"data_type": "STRING",   "nullable": false}',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
+('0f520104-0001-4000-8000-000000000004', 'race_ethnicity', 'OMB race/ethnicity category',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.race_ethnicity', '{"data_type": "STRING",   "nullable": true }',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
+('0f520105-0001-4000-8000-000000000005', 'zip_3',          'First 3 digits of ZIP (Safe Harbor)',             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.patients.zip_3', '{"data_type": "STRING",   "nullable": true }',                          '["phi", "deidentified"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520111-0001-4000-8000-000000000011', 'encounter_id',   'Unique encounter identifier',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.encounter_id', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["phi", "key"]',                  'active', 'system@demo', NOW(), NOW()),
+('0f520112-0001-4000-8000-000000000012', 'patient_id',     'FK to patients.patient_id',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.patient_id', '{"data_type": "STRING",   "nullable": false}',                          '["phi", "fk"]',                   'active', 'system@demo', NOW(), NOW()),
+('0f520113-0001-4000-8000-000000000013', 'encounter_type', 'inpatient | outpatient | emergency | observation',(SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.encounter_type', '{"data_type": "STRING",   "nullable": false}',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
+('0f520114-0001-4000-8000-000000000014', 'admit_date',     'Admit/visit date (UTC)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.admit_date', '{"data_type": "TIMESTAMP","nullable": false, "partition_key": true}',  '["phi", "partition"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520115-0001-4000-8000-000000000015', 'discharge_date', 'Discharge date (NULL if still admitted)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.curated.encounters.discharge_date', '{"data_type": "TIMESTAMP","nullable": true }',                          '["phi"]',                          'active', 'system@demo', NOW(), NOW()),
+('0f520121-0001-4000-8000-000000000021', 'case_id',        'ICSR case number',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.case_id', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}', '["pharmacovigilance", "key"]',   'active', 'system@demo', NOW(), NOW()),
+('0f520122-0001-4000-8000-000000000022', 'product_id',     'Product (substance) identifier',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.product_id', '{"data_type": "STRING",  "nullable": false}',                          '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520123-0001-4000-8000-000000000023', 'meddra_pt',      'MedDRA preferred term',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.meddra_pt', '{"data_type": "STRING",  "nullable": false}',                          '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520124-0001-4000-8000-000000000024', 'seriousness',    'serious | non_serious',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.seriousness', '{"data_type": "STRING",  "nullable": false}',                          '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520125-0001-4000-8000-000000000025', 'received_ts',    'Submission receive timestamp (UTC)',              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.pharma.faers.case_events.received_ts', '{"data_type": "TIMESTAMP","nullable": false}',                         '["pharmacovigilance"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520131-0001-4000-8000-000000000031', 'claim_id',       'Unique medical claim identifier',                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.claim_id', '{"data_type": "STRING",  "nullable": false, "is_primary_key": true}', '["claims", "key"]',               'active', 'system@demo', NOW(), NOW()),
+('0f520132-0001-4000-8000-000000000032', 'member_id',      'Insurance plan member identifier',                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.member_id', '{"data_type": "STRING",  "nullable": false}',                          '["claims", "phi"]',               'active', 'system@demo', NOW(), NOW()),
+('0f520133-0001-4000-8000-000000000033', 'service_date',   'Date of service (partition)',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.service_date', '{"data_type": "DATE",    "nullable": false, "partition_key": true}',  '["claims", "partition"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520134-0001-4000-8000-000000000034', 'cpt_code',       'CMS HCPCS / CPT procedure code',                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.cpt_code', '{"data_type": "STRING",  "nullable": false}',                          '["claims"]',                       'active', 'system@demo', NOW(), NOW()),
+('0f520135-0001-4000-8000-000000000035', 'allowed_amount', 'Amount allowed by payer (USD)',                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.hls.claims.adjudicated.allowed_amount', '{"data_type": "DECIMAL(18,2)","nullable": false}',                     '["claims", "kpi"]',               'active', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -823,3 +791,52 @@ COMMIT;
 -- ============================================================================
 -- End of HLS Demo Data — preset=hls
 -- ============================================================================
+
+
+-- ============================================================================
+-- Domain associations (multi-domain assignment; replaces removed single-value
+-- domain columns on teams/data_contracts/data_products/assets). Type code 031.
+-- ============================================================================
+INSERT INTO entity_domain_associations (id, domain_id, entity_id, entity_type, is_primary, assigned_by, assigned_at) VALUES
+('03100001-0001-4000-8000-000000000001', '00000001-0001-4000-8000-000000000001', '00100001-0001-4000-8000-000000000001', 'team', true, 'system@demo', NOW()),
+('03100002-0001-4000-8000-000000000002', '00000002-0001-4000-8000-000000000002', '00100002-0001-4000-8000-000000000002', 'team', true, 'system@demo', NOW()),
+('03100003-0001-4000-8000-000000000003', '00000003-0001-4000-8000-000000000003', '00100003-0001-4000-8000-000000000003', 'team', true, 'system@demo', NOW()),
+('03100004-0001-4000-8000-000000000004', '00000001-0001-4000-8000-000000000001', '00400001-0001-4000-8000-000000000001', 'data_contract', true, 'system@demo', NOW()),
+('03100005-0001-4000-8000-000000000005', '00000002-0001-4000-8000-000000000002', '00400002-0001-4000-8000-000000000002', 'data_contract', true, 'system@demo', NOW()),
+('03100006-0001-4000-8000-000000000006', '00000003-0001-4000-8000-000000000003', '00400003-0001-4000-8000-000000000003', 'data_contract', true, 'system@demo', NOW()),
+('03100007-0001-4000-8000-000000000007', '00000004-0001-4000-8000-000000000004', '00400004-0001-4000-8000-000000000004', 'data_contract', true, 'system@demo', NOW()),
+('03100008-0001-4000-8000-000000000008', '00000006-0001-4000-8000-000000000006', '00400005-0001-4000-8000-000000000005', 'data_contract', true, 'system@demo', NOW()),
+('03100009-0001-4000-8000-000000000009', '00000001-0001-4000-8000-000000000001', '00700001-0001-4000-8000-000000000001', 'data_product', true, 'system@demo', NOW()),
+('0310000a-0001-4000-8000-000000000010', '00000002-0001-4000-8000-000000000002', '00700002-0001-4000-8000-000000000002', 'data_product', true, 'system@demo', NOW()),
+('0310000b-0001-4000-8000-000000000011', '00000003-0001-4000-8000-000000000003', '00700003-0001-4000-8000-000000000003', 'data_product', true, 'system@demo', NOW()),
+('0310000c-0001-4000-8000-000000000012', '00000002-0001-4000-8000-000000000002', '00700004-0001-4000-8000-000000000004', 'data_product', true, 'system@demo', NOW()),
+('0310000d-0001-4000-8000-000000000013', '00000006-0001-4000-8000-000000000006', '00700005-0001-4000-8000-000000000005', 'data_product', true, 'system@demo', NOW()),
+('0310000e-0001-4000-8000-000000000014', '00000001-0001-4000-8000-000000000001', '0f300101-0001-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('0310000f-0001-4000-8000-000000000015', '00000001-0001-4000-8000-000000000001', '0f300102-0001-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100010-0001-4000-8000-000000000016', '00000002-0001-4000-8000-000000000002', '0f300103-0001-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100011-0001-4000-8000-000000000017', '00000002-0001-4000-8000-000000000002', '0f300104-0001-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100012-0001-4000-8000-000000000018', '00000002-0001-4000-8000-000000000002', '0f300105-0001-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('03100013-0001-4000-8000-000000000019', '00000003-0001-4000-8000-000000000003', '0f300106-0001-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('03100014-0001-4000-8000-000000000020', '00000003-0001-4000-8000-000000000003', '0f300107-0001-4000-8000-000000000007', 'asset', true, 'system@demo', NOW()),
+('03100015-0001-4000-8000-000000000021', '00000006-0001-4000-8000-000000000006', '0f300108-0001-4000-8000-000000000008', 'asset', true, 'system@demo', NOW()),
+('03100016-0001-4000-8000-000000000022', '00000001-0001-4000-8000-000000000001', '0f520101-0001-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('03100017-0001-4000-8000-000000000023', '00000001-0001-4000-8000-000000000001', '0f520102-0001-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100018-0001-4000-8000-000000000024', '00000001-0001-4000-8000-000000000001', '0f520103-0001-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100019-0001-4000-8000-000000000025', '00000001-0001-4000-8000-000000000001', '0f520104-0001-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('0310001a-0001-4000-8000-000000000026', '00000001-0001-4000-8000-000000000001', '0f520105-0001-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('0310001b-0001-4000-8000-000000000027', '00000001-0001-4000-8000-000000000001', '0f520111-0001-4000-8000-000000000011', 'asset', true, 'system@demo', NOW()),
+('0310001c-0001-4000-8000-000000000028', '00000001-0001-4000-8000-000000000001', '0f520112-0001-4000-8000-000000000012', 'asset', true, 'system@demo', NOW()),
+('0310001d-0001-4000-8000-000000000029', '00000001-0001-4000-8000-000000000001', '0f520113-0001-4000-8000-000000000013', 'asset', true, 'system@demo', NOW()),
+('0310001e-0001-4000-8000-000000000030', '00000001-0001-4000-8000-000000000001', '0f520114-0001-4000-8000-000000000014', 'asset', true, 'system@demo', NOW()),
+('0310001f-0001-4000-8000-000000000031', '00000001-0001-4000-8000-000000000001', '0f520115-0001-4000-8000-000000000015', 'asset', true, 'system@demo', NOW()),
+('03100020-0001-4000-8000-000000000032', '00000003-0001-4000-8000-000000000003', '0f520121-0001-4000-8000-000000000021', 'asset', true, 'system@demo', NOW()),
+('03100021-0001-4000-8000-000000000033', '00000003-0001-4000-8000-000000000003', '0f520122-0001-4000-8000-000000000022', 'asset', true, 'system@demo', NOW()),
+('03100022-0001-4000-8000-000000000034', '00000003-0001-4000-8000-000000000003', '0f520123-0001-4000-8000-000000000023', 'asset', true, 'system@demo', NOW()),
+('03100023-0001-4000-8000-000000000035', '00000003-0001-4000-8000-000000000003', '0f520124-0001-4000-8000-000000000024', 'asset', true, 'system@demo', NOW()),
+('03100024-0001-4000-8000-000000000036', '00000003-0001-4000-8000-000000000003', '0f520125-0001-4000-8000-000000000025', 'asset', true, 'system@demo', NOW()),
+('03100025-0001-4000-8000-000000000037', '00000006-0001-4000-8000-000000000006', '0f520131-0001-4000-8000-000000000031', 'asset', true, 'system@demo', NOW()),
+('03100026-0001-4000-8000-000000000038', '00000006-0001-4000-8000-000000000006', '0f520132-0001-4000-8000-000000000032', 'asset', true, 'system@demo', NOW()),
+('03100027-0001-4000-8000-000000000039', '00000006-0001-4000-8000-000000000006', '0f520133-0001-4000-8000-000000000033', 'asset', true, 'system@demo', NOW()),
+('03100028-0001-4000-8000-000000000040', '00000006-0001-4000-8000-000000000006', '0f520134-0001-4000-8000-000000000034', 'asset', true, 'system@demo', NOW()),
+('03100029-0001-4000-8000-000000000041', '00000006-0001-4000-8000-000000000006', '0f520135-0001-4000-8000-000000000035', 'asset', true, 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;

--- a/src/backend/src/data/demo_data_mfg.sql
+++ b/src/backend/src/data/demo_data_mfg.sql
@@ -46,11 +46,10 @@ ON CONFLICT (id) DO NOTHING;
 -- 2. TEAMS
 -- ============================================================================
 
-INSERT INTO teams (id, name, title, description, domain_id, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
-('00100001-0003-4000-8000-000000000001', 'production-engineering', 'Production Engineering Team', 'MES integration, production optimization, and OEE improvement', '00000001-0003-4000-8000-000000000001', '{"slack_channel": "https://company.slack.com/channels/prod-eng", "lead": "plant.manager@factory.com"}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100002-0003-4000-8000-000000000002', 'quality-assurance', 'Quality Assurance Team', 'Incoming/in-process/final inspection, SPC analysis, and CAPA management', '00000002-0003-4000-8000-000000000002', '{"slack_channel": "https://company.slack.com/channels/qa-team", "tools": ["Minitab", "JMP", "InfinityQS"]}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100003-0003-4000-8000-000000000003', 'predictive-maintenance', 'Predictive Maintenance Team', 'Vibration analysis, thermal imaging, and ML-based failure prediction', '00000003-0003-4000-8000-000000000003', '{"slack_channel": "https://company.slack.com/channels/pred-maint", "responsibilities": ["Condition Monitoring", "CMMS", "Spare Parts Optimization"]}', 'system@demo', 'system@demo', NOW(), NOW())
-
+INSERT INTO teams (id, name, title, description, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
+('00100001-0003-4000-8000-000000000001', 'production-engineering', 'Production Engineering Team', 'MES integration, production optimization, and OEE improvement', '{"slack_channel": "https://company.slack.com/channels/prod-eng", "lead": "plant.manager@factory.com"}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100002-0003-4000-8000-000000000002', 'quality-assurance', 'Quality Assurance Team', 'Incoming/in-process/final inspection, SPC analysis, and CAPA management', '{"slack_channel": "https://company.slack.com/channels/qa-team", "tools": ["Minitab", "JMP", "InfinityQS"]}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100003-0003-4000-8000-000000000003', 'predictive-maintenance', 'Predictive Maintenance Team', 'Vibration analysis, thermal imaging, and ML-based failure prediction', '{"slack_channel": "https://company.slack.com/channels/pred-maint", "responsibilities": ["Condition Monitoring", "CMMS", "Spare Parts Optimization"]}', 'system@demo', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -100,12 +99,12 @@ ON CONFLICT (project_id, team_id) DO NOTHING;
 -- 4. DATA CONTRACTS
 -- ============================================================================
 
-INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, domain_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
-('00400001-0003-4000-8000-000000000001', 'Production Line Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0003-4000-8000-000000000001', '00000001-0003-4000-8000-000000000001', 'Real-time production line data from MES including work orders, cycle times, and machine states', 'OEE calculation, production scheduling optimization, and bottleneck analysis', 'PLC data sampled at 1s intervals; MES timestamps may drift ±500ms; downtime codes require operator confirmation', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0003-4000-8000-000000000001'),
-('00400002-0003-4000-8000-000000000002', 'Quality Inspection Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100002-0003-4000-8000-000000000002', '00000002-0003-4000-8000-000000000002', 'In-process and final inspection measurements, defect classifications, and SPC control chart data', 'Real-time quality dashboards, Cpk/Ppk tracking, and automated non-conformance routing', 'CMM measurement uncertainty ±0.005mm; visual inspection results are categorical; SPC rules per AIAG manual', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0003-4000-8000-000000000002'),
-('00400003-0003-4000-8000-000000000003', 'Equipment Health Contract', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100003-0003-4000-8000-000000000003', '00000003-0003-4000-8000-000000000003', 'Vibration, temperature, pressure, and current sensor data from critical production equipment', 'Predictive maintenance models, remaining useful life estimation, and maintenance work order prioritization', 'Sensor data sampled at 10Hz for vibration, 1Hz for temperature; edge gateway buffers up to 1h during connectivity loss', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0003-4000-8000-000000000003'),
-('00400004-0003-4000-8000-000000000004', 'EHS Incident Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100002-0003-4000-8000-000000000002', '00000004-0003-4000-8000-000000000004', 'Safety incidents, near-misses, environmental monitoring, and OSHA recordable events', 'Safety trend analysis, leading indicator dashboards, and regulatory reporting (OSHA 300 log)', 'Incident severity classification per ANSI Z16.1; near-miss reporting is voluntary and likely under-reported', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0003-4000-8000-000000000004'),
-('00400005-0003-4000-8000-000000000005', 'Bill of Materials Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100001-0003-4000-8000-000000000001', '00000001-0003-4000-8000-000000000001', 'Engineering and manufacturing BOMs with revision history and where-used relationships', 'Cost roll-up, material requirements planning, and engineering change impact analysis', 'BOM effectivity dates may overlap during ECN transitions; phantom assemblies excluded from cost roll-up', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0003-4000-8000-000000000005')
+INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
+('00400001-0003-4000-8000-000000000001', 'Production Line Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0003-4000-8000-000000000001', 'Real-time production line data from MES including work orders, cycle times, and machine states', 'OEE calculation, production scheduling optimization, and bottleneck analysis', 'PLC data sampled at 1s intervals; MES timestamps may drift ±500ms; downtime codes require operator confirmation', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0003-4000-8000-000000000001'),
+('00400002-0003-4000-8000-000000000002', 'Quality Inspection Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100002-0003-4000-8000-000000000002', 'In-process and final inspection measurements, defect classifications, and SPC control chart data', 'Real-time quality dashboards, Cpk/Ppk tracking, and automated non-conformance routing', 'CMM measurement uncertainty ±0.005mm; visual inspection results are categorical; SPC rules per AIAG manual', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0003-4000-8000-000000000002'),
+('00400003-0003-4000-8000-000000000003', 'Equipment Health Contract', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100003-0003-4000-8000-000000000003', 'Vibration, temperature, pressure, and current sensor data from critical production equipment', 'Predictive maintenance models, remaining useful life estimation, and maintenance work order prioritization', 'Sensor data sampled at 10Hz for vibration, 1Hz for temperature; edge gateway buffers up to 1h during connectivity loss', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0003-4000-8000-000000000003'),
+('00400004-0003-4000-8000-000000000004', 'EHS Incident Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100002-0003-4000-8000-000000000002', 'Safety incidents, near-misses, environmental monitoring, and OSHA recordable events', 'Safety trend analysis, leading indicator dashboards, and regulatory reporting (OSHA 300 log)', 'Incident severity classification per ANSI Z16.1; near-miss reporting is voluntary and likely under-reported', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0003-4000-8000-000000000004'),
+('00400005-0003-4000-8000-000000000005', 'Bill of Materials Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100001-0003-4000-8000-000000000001', 'Engineering and manufacturing BOMs with revision history and where-used relationships', 'Cost roll-up, material requirements planning, and engineering change impact analysis', 'BOM effectivity dates may overlap during ECN transitions; phantom assemblies excluded from cost roll-up', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0003-4000-8000-000000000005')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -241,12 +240,12 @@ ON CONFLICT (id) DO NOTHING;
 -- 5. DATA PRODUCTS
 -- ============================================================================
 
-INSERT INTO data_products (id, api_version, kind, status, name, version, domain, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
-('00700001-0003-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'Production KPI Dashboard v1', '1.0.0', 'Production', 'mfg-demo', '00100001-0003-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0003-4000-8000-000000000001'),
-('00700002-0003-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'Quality Analytics Platform v1', '1.0.0', 'Quality', 'mfg-demo', '00100002-0003-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700002-0003-4000-8000-000000000002'),
-('00700003-0003-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'Predictive Maintenance v1', '1.0.0', 'Maintenance', 'mfg-demo', '00100003-0003-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700003-0003-4000-8000-000000000003'),
-('00700004-0003-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Supply Chain Visibility v1', '1.0.0', 'Supply Chain', 'mfg-demo', '00100001-0003-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700004-0003-4000-8000-000000000004'),
-('00700005-0003-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'EHS Safety Analytics v1', '1.0.0', 'Safety & EHS', 'mfg-demo', '00100002-0003-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700005-0003-4000-8000-000000000005')
+INSERT INTO data_products (id, api_version, kind, status, name, version, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
+('00700001-0003-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'Production KPI Dashboard v1', '1.0.0', 'mfg-demo', '00100001-0003-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0003-4000-8000-000000000001'),
+('00700002-0003-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'Quality Analytics Platform v1', '1.0.0', 'mfg-demo', '00100002-0003-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700002-0003-4000-8000-000000000002'),
+('00700003-0003-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'Predictive Maintenance v1', '1.0.0', 'mfg-demo', '00100003-0003-4000-8000-000000000003', 99, true, 'org', NOW(), NOW(), '00700003-0003-4000-8000-000000000003'),
+('00700004-0003-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Supply Chain Visibility v1', '1.0.0', 'mfg-demo', '00100001-0003-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700004-0003-4000-8000-000000000004'),
+('00700005-0003-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'EHS Safety Analytics v1', '1.0.0', 'mfg-demo', '00100002-0003-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700005-0003-4000-8000-000000000005')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -514,116 +513,84 @@ ON CONFLICT (id) DO NOTHING;
 -- 15. ASSETS — MFG catalog objects (type=0f3)
 -- ============================================================================
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
--- Production Line (vertical asset type)
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('0f300101-0003-4000-8000-000000000001',
  'plant.detroit.line.assembly_3',
  'Assembly line 3 at Detroit plant — engine sub-assembly.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Production Line' LIMIT 1), '0f200101-0003-4000-8000-000000000001'), 'MES', 'plant://detroit/line/assembly_3',
- '00000001-0003-4000-8000-000000000001',
  '{"plant": "detroit", "line_id": "assembly_3", "shift_pattern": "3x8", "design_capacity_per_hr": 320}',
  '["spc-controlled", "iso-9001"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Equipment Asset (vertical asset type)
 ('0f300102-0003-4000-8000-000000000002',
  'eq.detroit.cnc_42',
  'CNC mill #42 — high-precision crankshaft machining.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Equipment Asset' LIMIT 1), '0f200102-0003-4000-8000-000000000002'), 'CMMS', 'cmms://eq/cnc_42',
- '00000003-0003-4000-8000-000000000003',
  '{"equipment_id": "CNC_42", "manufacturer": "DMG Mori", "install_year": 2019, "vibration_sensor": true}',
  '["critical-asset", "pm-eligible", "iiot-instrumented"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Quality Inspection (vertical asset type)
 ('0f300103-0003-4000-8000-000000000003',
  'qi.detroit.cmm.batch-2026-04-30',
  'CMM inspection batch April 30 2026 — crankshaft dimensional checks.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Quality Inspection' LIMIT 1), '0f200103-0003-4000-8000-000000000003'), 'CMM', 'cmm://detroit/batch/2026-04-30',
- '00000002-0003-4000-8000-000000000002',
  '{"batch_id": "2026-04-30-A", "parts_inspected": 320, "defects_found": 2, "Cpk": 1.62}',
  '["spc-controlled", "capa-source"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Telemetry stream
 ('0f300104-0003-4000-8000-000000000004',
  'kafka.factory.telemetry.equipment',
  'Real-time OPC UA equipment telemetry stream (vibration, temperature, current).',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Stream' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Kafka', 'kafka://broker.factory:9092/telemetry.equipment',
- '00000003-0003-4000-8000-000000000003',
  '{"topic": "telemetry.equipment", "throughput_msgs_per_sec": 18000}',
  '["iiot-instrumented"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- WIP table
 ('0f300105-0003-4000-8000-000000000005',
  'lakehouse.mfg.wip.work_orders',
  'Work-in-process work orders with current station and status.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.mfg.wip.work_orders',
- '00000001-0003-4000-8000-000000000001',
  '{"catalog": "lakehouse", "schema": "mfg_wip", "table_name": "work_orders", "row_count": 86000, "format": "delta"}',
  '["iso-9001"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Quality table
 ('0f300106-0003-4000-8000-000000000006',
  'lakehouse.mfg.quality.defect_log',
  'Defect log with classification, root cause, and CAPA linkage.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.mfg.quality.defect_log',
- '00000002-0003-4000-8000-000000000002',
  '{"catalog": "lakehouse", "schema": "mfg_quality", "table_name": "defect_log", "row_count": 9400, "format": "delta"}',
  '["spc-controlled", "capa-source"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Dashboard
 ('0f300107-0003-4000-8000-000000000007',
  'Plant OEE Dashboard',
  'Live OEE by plant, line, and shift with downtime Pareto.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200002-0000-4000-8000-000000000002'), 'Databricks', 'https://bi.factory.com/dashboards/oee-v1',
- '00000001-0003-4000-8000-000000000001',
  '{"refresh_schedule": "1 minute", "audience": "plant-ops"}',
  '[]',
  'active', 'system@demo', NOW(), NOW()),
-
--- EHS table
 ('0f300108-0003-4000-8000-000000000008',
  'lakehouse.mfg.ehs.incidents',
  'EHS incident reports including near-miss observations.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.mfg.ehs.incidents',
- '00000004-0003-4000-8000-000000000004',
  '{"catalog": "lakehouse", "schema": "mfg_ehs", "table_name": "incidents", "row_count": 1280, "format": "delta"}',
  '["osha-recordable", "iso-14001"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- ── Column assets for the MFG Tables / Streams above ──
--- 0f300104 kafka.factory.telemetry.equipment (Stream)
-('0f520104-0003-4000-8000-000000000004', 'asset_id',     'Equipment asset tag',                              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.asset_id',     '00000003-0003-4000-8000-000000000003', '{"data_type": "STRING",   "nullable": false}',                          '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520105-0003-4000-8000-000000000005', 'sensor_type',  'vibration | temperature | pressure | current',     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.sensor_type',  '00000003-0003-4000-8000-000000000003', '{"data_type": "STRING",   "nullable": false}',                          '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520106-0003-4000-8000-000000000006', 'reading_value','Sensor value (SI units)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.reading_value','00000003-0003-4000-8000-000000000003', '{"data_type": "DECIMAL(18,6)", "nullable": false}',                     '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520107-0003-4000-8000-000000000007', 'reading_ts',   'Reading timestamp (UTC)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.reading_ts',   '00000003-0003-4000-8000-000000000003', '{"data_type": "TIMESTAMP","nullable": false}',                          '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520108-0003-4000-8000-000000000008', 'health_score', 'ML-derived equipment health score (0-100)',        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.health_score', '00000003-0003-4000-8000-000000000003', '{"data_type": "DECIMAL(6,2)","nullable": true }',                       '["telemetry", "ml"]',     'active', 'system@demo', NOW(), NOW()),
-
--- 0f300105 lakehouse.mfg.wip.work_orders
-('0f520111-0003-4000-8000-000000000011', 'work_order_id',     'MES work order number',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.work_order_id',     '00000001-0003-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["mes", "key"]',          'active', 'system@demo', NOW(), NOW()),
-('0f520112-0003-4000-8000-000000000012', 'part_number',       'Manufactured part number',                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.part_number',       '00000001-0003-4000-8000-000000000001', '{"data_type": "STRING",   "nullable": false}',                          '["mes"]',                 'active', 'system@demo', NOW(), NOW()),
-('0f520113-0003-4000-8000-000000000013', 'quantity_planned',  'Planned quantity',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.quantity_planned',  '00000001-0003-4000-8000-000000000001', '{"data_type": "INT",      "nullable": false}',                          '["mes"]',                 'active', 'system@demo', NOW(), NOW()),
-('0f520114-0003-4000-8000-000000000014', 'quantity_produced', 'Good quantity produced',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.quantity_produced', '00000001-0003-4000-8000-000000000001', '{"data_type": "INT",      "nullable": false}',                          '["mes", "kpi"]',          'active', 'system@demo', NOW(), NOW()),
-('0f520115-0003-4000-8000-000000000015', 'scrap_count',       'Scrap count',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.scrap_count',       '00000001-0003-4000-8000-000000000001', '{"data_type": "INT",      "nullable": false}',                          '["mes", "kpi"]',          'active', 'system@demo', NOW(), NOW()),
-('0f520116-0003-4000-8000-000000000016', 'start_time',        'Work order start timestamp (partition)',        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.start_time',        '00000001-0003-4000-8000-000000000001', '{"data_type": "TIMESTAMP","nullable": false, "partition_key": true}',  '["mes", "partition"]',    'active', 'system@demo', NOW(), NOW()),
-
--- 0f300106 lakehouse.mfg.quality.defect_log
-('0f520121-0003-4000-8000-000000000021', 'defect_id',     'Unique defect identifier',                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.defect_id',     '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["quality", "key"]',       'active', 'system@demo', NOW(), NOW()),
-('0f520122-0003-4000-8000-000000000022', 'inspection_id', 'FK to inspections.inspection_id',                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.inspection_id', '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": false}',                          '["quality", "fk"]',        'active', 'system@demo', NOW(), NOW()),
-('0f520123-0003-4000-8000-000000000023', 'defect_code',   'Standardized defect classification',              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.defect_code',   '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": false}',                          '["quality"]',              'active', 'system@demo', NOW(), NOW()),
-('0f520124-0003-4000-8000-000000000024', 'severity',      'minor | major | critical',                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.severity',      '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": false}',                          '["quality"]',              'active', 'system@demo', NOW(), NOW()),
-('0f520125-0003-4000-8000-000000000025', 'capa_ref',      'CAPA reference number (NULL if none)',            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.capa_ref',      '00000002-0003-4000-8000-000000000002', '{"data_type": "STRING",   "nullable": true }',                          '["quality"]',              'active', 'system@demo', NOW(), NOW()),
-
--- 0f300108 lakehouse.mfg.ehs.incidents
-('0f520131-0003-4000-8000-000000000031', 'incident_id',     'Unique incident identifier',                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.incident_id',     '00000004-0003-4000-8000-000000000004', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["ehs", "key"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520132-0003-4000-8000-000000000032', 'incident_type',   'injury | near_miss | environmental | property_damage', (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.incident_type',   '00000004-0003-4000-8000-000000000004', '{"data_type": "STRING",   "nullable": false}',                          '["ehs", "osha-recordable"]','active', 'system@demo', NOW(), NOW()),
-('0f520133-0003-4000-8000-000000000033', 'severity',        'Severity per ANSI Z16.1',                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.severity',        '00000004-0003-4000-8000-000000000004', '{"data_type": "STRING",   "nullable": false}',                          '["ehs"]',                  'active', 'system@demo', NOW(), NOW()),
-('0f520134-0003-4000-8000-000000000034', 'reported_at',     'Incident reported timestamp (partition)',        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.reported_at',     '00000004-0003-4000-8000-000000000004', '{"data_type": "TIMESTAMP","nullable": false, "partition_key": true}',  '["ehs", "partition"]',     'active', 'system@demo', NOW(), NOW()),
-('0f520135-0003-4000-8000-000000000035', 'osha_recordable', 'Whether incident is OSHA-recordable',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.osha_recordable', '00000004-0003-4000-8000-000000000004', '{"data_type": "BOOLEAN",  "nullable": false}',                          '["ehs", "osha-recordable"]','active', 'system@demo', NOW(), NOW())
+('0f520104-0003-4000-8000-000000000004', 'asset_id',     'Equipment asset tag',                              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.asset_id', '{"data_type": "STRING",   "nullable": false}',                          '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520105-0003-4000-8000-000000000005', 'sensor_type',  'vibration | temperature | pressure | current',     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.sensor_type', '{"data_type": "STRING",   "nullable": false}',                          '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520106-0003-4000-8000-000000000006', 'reading_value','Sensor value (SI units)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.reading_value', '{"data_type": "DECIMAL(18,6)", "nullable": false}',                     '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520107-0003-4000-8000-000000000007', 'reading_ts',   'Reading timestamp (UTC)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.reading_ts', '{"data_type": "TIMESTAMP","nullable": false}',                          '["telemetry"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520108-0003-4000-8000-000000000008', 'health_score', 'ML-derived equipment health score (0-100)',        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Kafka',      'kafka.factory.telemetry.equipment.health_score', '{"data_type": "DECIMAL(6,2)","nullable": true }',                       '["telemetry", "ml"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520111-0003-4000-8000-000000000011', 'work_order_id',     'MES work order number',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.work_order_id', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["mes", "key"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520112-0003-4000-8000-000000000012', 'part_number',       'Manufactured part number',                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.part_number', '{"data_type": "STRING",   "nullable": false}',                          '["mes"]',                 'active', 'system@demo', NOW(), NOW()),
+('0f520113-0003-4000-8000-000000000013', 'quantity_planned',  'Planned quantity',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.quantity_planned', '{"data_type": "INT",      "nullable": false}',                          '["mes"]',                 'active', 'system@demo', NOW(), NOW()),
+('0f520114-0003-4000-8000-000000000014', 'quantity_produced', 'Good quantity produced',                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.quantity_produced', '{"data_type": "INT",      "nullable": false}',                          '["mes", "kpi"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520115-0003-4000-8000-000000000015', 'scrap_count',       'Scrap count',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.scrap_count', '{"data_type": "INT",      "nullable": false}',                          '["mes", "kpi"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520116-0003-4000-8000-000000000016', 'start_time',        'Work order start timestamp (partition)',        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.wip.work_orders.start_time', '{"data_type": "TIMESTAMP","nullable": false, "partition_key": true}',  '["mes", "partition"]',    'active', 'system@demo', NOW(), NOW()),
+('0f520121-0003-4000-8000-000000000021', 'defect_id',     'Unique defect identifier',                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.defect_id', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["quality", "key"]',       'active', 'system@demo', NOW(), NOW()),
+('0f520122-0003-4000-8000-000000000022', 'inspection_id', 'FK to inspections.inspection_id',                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.inspection_id', '{"data_type": "STRING",   "nullable": false}',                          '["quality", "fk"]',        'active', 'system@demo', NOW(), NOW()),
+('0f520123-0003-4000-8000-000000000023', 'defect_code',   'Standardized defect classification',              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.defect_code', '{"data_type": "STRING",   "nullable": false}',                          '["quality"]',              'active', 'system@demo', NOW(), NOW()),
+('0f520124-0003-4000-8000-000000000024', 'severity',      'minor | major | critical',                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.severity', '{"data_type": "STRING",   "nullable": false}',                          '["quality"]',              'active', 'system@demo', NOW(), NOW()),
+('0f520125-0003-4000-8000-000000000025', 'capa_ref',      'CAPA reference number (NULL if none)',            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.quality.defect_log.capa_ref', '{"data_type": "STRING",   "nullable": true }',                          '["quality"]',              'active', 'system@demo', NOW(), NOW()),
+('0f520131-0003-4000-8000-000000000031', 'incident_id',     'Unique incident identifier',                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.incident_id', '{"data_type": "STRING",   "nullable": false, "is_primary_key": true}', '["ehs", "key"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520132-0003-4000-8000-000000000032', 'incident_type',   'injury | near_miss | environmental | property_damage', (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.incident_type', '{"data_type": "STRING",   "nullable": false}',                          '["ehs", "osha-recordable"]','active', 'system@demo', NOW(), NOW()),
+('0f520133-0003-4000-8000-000000000033', 'severity',        'Severity per ANSI Z16.1',                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.severity', '{"data_type": "STRING",   "nullable": false}',                          '["ehs"]',                  'active', 'system@demo', NOW(), NOW()),
+('0f520134-0003-4000-8000-000000000034', 'reported_at',     'Incident reported timestamp (partition)',        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.reported_at', '{"data_type": "TIMESTAMP","nullable": false, "partition_key": true}',  '["ehs", "partition"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520135-0003-4000-8000-000000000035', 'osha_recordable', 'Whether incident is OSHA-recordable',           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.mfg.ehs.incidents.osha_recordable', '{"data_type": "BOOLEAN",  "nullable": false}',                          '["ehs", "osha-recordable"]','active', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -780,3 +747,53 @@ COMMIT;
 -- ============================================================================
 -- End of MFG Demo Data — preset=mfg
 -- ============================================================================
+
+
+-- ============================================================================
+-- Domain associations (multi-domain assignment; replaces removed single-value
+-- domain columns on teams/data_contracts/data_products/assets). Type code 031.
+-- ============================================================================
+INSERT INTO entity_domain_associations (id, domain_id, entity_id, entity_type, is_primary, assigned_by, assigned_at) VALUES
+('03100001-0003-4000-8000-000000000001', '00000001-0003-4000-8000-000000000001', '00100001-0003-4000-8000-000000000001', 'team', true, 'system@demo', NOW()),
+('03100002-0003-4000-8000-000000000002', '00000002-0003-4000-8000-000000000002', '00100002-0003-4000-8000-000000000002', 'team', true, 'system@demo', NOW()),
+('03100003-0003-4000-8000-000000000003', '00000003-0003-4000-8000-000000000003', '00100003-0003-4000-8000-000000000003', 'team', true, 'system@demo', NOW()),
+('03100004-0003-4000-8000-000000000004', '00000001-0003-4000-8000-000000000001', '00400001-0003-4000-8000-000000000001', 'data_contract', true, 'system@demo', NOW()),
+('03100005-0003-4000-8000-000000000005', '00000002-0003-4000-8000-000000000002', '00400002-0003-4000-8000-000000000002', 'data_contract', true, 'system@demo', NOW()),
+('03100006-0003-4000-8000-000000000006', '00000003-0003-4000-8000-000000000003', '00400003-0003-4000-8000-000000000003', 'data_contract', true, 'system@demo', NOW()),
+('03100007-0003-4000-8000-000000000007', '00000004-0003-4000-8000-000000000004', '00400004-0003-4000-8000-000000000004', 'data_contract', true, 'system@demo', NOW()),
+('03100008-0003-4000-8000-000000000008', '00000001-0003-4000-8000-000000000001', '00400005-0003-4000-8000-000000000005', 'data_contract', true, 'system@demo', NOW()),
+('03100009-0003-4000-8000-000000000009', '00000001-0003-4000-8000-000000000001', '00700001-0003-4000-8000-000000000001', 'data_product', true, 'system@demo', NOW()),
+('0310000a-0003-4000-8000-000000000010', '00000002-0003-4000-8000-000000000002', '00700002-0003-4000-8000-000000000002', 'data_product', true, 'system@demo', NOW()),
+('0310000b-0003-4000-8000-000000000011', '00000003-0003-4000-8000-000000000003', '00700003-0003-4000-8000-000000000003', 'data_product', true, 'system@demo', NOW()),
+('0310000c-0003-4000-8000-000000000012', '00000006-0000-4000-8000-000000000006', '00700004-0003-4000-8000-000000000004', 'data_product', true, 'system@demo', NOW()),
+('0310000d-0003-4000-8000-000000000013', '00000004-0003-4000-8000-000000000004', '00700005-0003-4000-8000-000000000005', 'data_product', true, 'system@demo', NOW()),
+('0310000e-0003-4000-8000-000000000014', '00000001-0003-4000-8000-000000000001', '0f300101-0003-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('0310000f-0003-4000-8000-000000000015', '00000003-0003-4000-8000-000000000003', '0f300102-0003-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100010-0003-4000-8000-000000000016', '00000002-0003-4000-8000-000000000002', '0f300103-0003-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100011-0003-4000-8000-000000000017', '00000003-0003-4000-8000-000000000003', '0f300104-0003-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100012-0003-4000-8000-000000000018', '00000001-0003-4000-8000-000000000001', '0f300105-0003-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('03100013-0003-4000-8000-000000000019', '00000002-0003-4000-8000-000000000002', '0f300106-0003-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('03100014-0003-4000-8000-000000000020', '00000001-0003-4000-8000-000000000001', '0f300107-0003-4000-8000-000000000007', 'asset', true, 'system@demo', NOW()),
+('03100015-0003-4000-8000-000000000021', '00000004-0003-4000-8000-000000000004', '0f300108-0003-4000-8000-000000000008', 'asset', true, 'system@demo', NOW()),
+('03100016-0003-4000-8000-000000000022', '00000003-0003-4000-8000-000000000003', '0f520104-0003-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100017-0003-4000-8000-000000000023', '00000003-0003-4000-8000-000000000003', '0f520105-0003-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('03100018-0003-4000-8000-000000000024', '00000003-0003-4000-8000-000000000003', '0f520106-0003-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('03100019-0003-4000-8000-000000000025', '00000003-0003-4000-8000-000000000003', '0f520107-0003-4000-8000-000000000007', 'asset', true, 'system@demo', NOW()),
+('0310001a-0003-4000-8000-000000000026', '00000003-0003-4000-8000-000000000003', '0f520108-0003-4000-8000-000000000008', 'asset', true, 'system@demo', NOW()),
+('0310001b-0003-4000-8000-000000000027', '00000001-0003-4000-8000-000000000001', '0f520111-0003-4000-8000-000000000011', 'asset', true, 'system@demo', NOW()),
+('0310001c-0003-4000-8000-000000000028', '00000001-0003-4000-8000-000000000001', '0f520112-0003-4000-8000-000000000012', 'asset', true, 'system@demo', NOW()),
+('0310001d-0003-4000-8000-000000000029', '00000001-0003-4000-8000-000000000001', '0f520113-0003-4000-8000-000000000013', 'asset', true, 'system@demo', NOW()),
+('0310001e-0003-4000-8000-000000000030', '00000001-0003-4000-8000-000000000001', '0f520114-0003-4000-8000-000000000014', 'asset', true, 'system@demo', NOW()),
+('0310001f-0003-4000-8000-000000000031', '00000001-0003-4000-8000-000000000001', '0f520115-0003-4000-8000-000000000015', 'asset', true, 'system@demo', NOW()),
+('03100020-0003-4000-8000-000000000032', '00000001-0003-4000-8000-000000000001', '0f520116-0003-4000-8000-000000000016', 'asset', true, 'system@demo', NOW()),
+('03100021-0003-4000-8000-000000000033', '00000002-0003-4000-8000-000000000002', '0f520121-0003-4000-8000-000000000021', 'asset', true, 'system@demo', NOW()),
+('03100022-0003-4000-8000-000000000034', '00000002-0003-4000-8000-000000000002', '0f520122-0003-4000-8000-000000000022', 'asset', true, 'system@demo', NOW()),
+('03100023-0003-4000-8000-000000000035', '00000002-0003-4000-8000-000000000002', '0f520123-0003-4000-8000-000000000023', 'asset', true, 'system@demo', NOW()),
+('03100024-0003-4000-8000-000000000036', '00000002-0003-4000-8000-000000000002', '0f520124-0003-4000-8000-000000000024', 'asset', true, 'system@demo', NOW()),
+('03100025-0003-4000-8000-000000000037', '00000002-0003-4000-8000-000000000002', '0f520125-0003-4000-8000-000000000025', 'asset', true, 'system@demo', NOW()),
+('03100026-0003-4000-8000-000000000038', '00000004-0003-4000-8000-000000000004', '0f520131-0003-4000-8000-000000000031', 'asset', true, 'system@demo', NOW()),
+('03100027-0003-4000-8000-000000000039', '00000004-0003-4000-8000-000000000004', '0f520132-0003-4000-8000-000000000032', 'asset', true, 'system@demo', NOW()),
+('03100028-0003-4000-8000-000000000040', '00000004-0003-4000-8000-000000000004', '0f520133-0003-4000-8000-000000000033', 'asset', true, 'system@demo', NOW()),
+('03100029-0003-4000-8000-000000000041', '00000004-0003-4000-8000-000000000004', '0f520134-0003-4000-8000-000000000034', 'asset', true, 'system@demo', NOW()),
+('0310002a-0003-4000-8000-000000000042', '00000004-0003-4000-8000-000000000004', '0f520135-0003-4000-8000-000000000035', 'asset', true, 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;

--- a/src/backend/src/data/demo_data_retail.sql
+++ b/src/backend/src/data/demo_data_retail.sql
@@ -70,13 +70,15 @@
 --   01e = data_contract_schema_object_authoritative_definitions
 --   01f = data_contract_schema_property_authoritative_definitions
 --   020 = rdf_triples (demo ontology concepts)
---   030 = knowledge_collection_meta (collection metadata in urn:meta:sources)
---   021 = datasets
---   022 = dataset_subscriptions
---   023 = dataset_tags
---   024 = dataset_custom_properties
---   025 = dataset_instances
---   026 = tag_namespaces
+--   030 = rdf_triples + data_contract_quality_checks (collection meta in urn:meta:sources)
+--   021 = assets + entity_relationships (was: datasets — table dropped, data folded into assets)
+--   022 = entity_subscriptions (was: dataset_subscriptions — table dropped)
+--   023 = (retired: was dataset_tags — table dropped)
+--   024 = (retired: was dataset_custom_properties — table dropped)
+--   025 = assets (was: dataset_instances — table dropped, data folded into assets)
+--   026 = tag_namespaces (0260% also carries migrated entity_subscriptions)
+--   031 = entity_domain_associations (multi-domain assignment; replaces removed
+--         single-value domain columns on teams/contracts/products/assets)
 --   027 = tags
 --   028 = tag_namespace_permissions
 --   029 = entity_tag_associations
@@ -128,12 +130,11 @@ ON CONFLICT (id) DO NOTHING;
 -- 2. TEAMS (type=001)
 -- ============================================================================
 
-INSERT INTO teams (id, name, title, description, domain_id, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
-('00100001-0000-4000-8000-000000000001', 'data-engineering', 'Data Engineering Team', 'Responsible for data pipeline development and infrastructure', '00000001-0000-4000-8000-000000000001', '{"slack_channel": "https://company.slack.com/channels/data-eng", "lead": "john.doe@company.com"}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100002-0000-4000-8000-000000000002', 'analytics-team', 'Analytics Team', 'Business analytics and reporting team', '0000000d-0000-4000-8000-000000000013', '{"slack_channel": "https://company.slack.com/channels/analytics", "tools": ["Tableau", "Power BI", "SQL"]}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100003-0000-4000-8000-000000000003', 'data-science', 'Data Science Team', 'Machine learning and advanced analytics', '00000008-0000-4000-8000-000000000008', '{"slack_channel": "https://company.slack.com/channels/data-science", "research_areas": ["NLP", "Computer Vision", "Recommendation Systems"]}', 'system@demo', 'system@demo', NOW(), NOW()),
-('00100004-0000-4000-8000-000000000004', 'governance-team', 'Data Governance Team', 'Data quality, compliance, and governance oversight', '0000000b-0000-4000-8000-000000000011', '{"slack_channel": "https://company.slack.com/channels/data-governance", "responsibilities": ["Data Quality", "Privacy Compliance", "Access Control"]}', 'system@demo', 'system@demo', NOW(), NOW())
-
+INSERT INTO teams (id, name, title, description, extra_metadata, created_by, updated_by, created_at, updated_at) VALUES
+('00100001-0000-4000-8000-000000000001', 'data-engineering', 'Data Engineering Team', 'Responsible for data pipeline development and infrastructure', '{"slack_channel": "https://company.slack.com/channels/data-eng", "lead": "john.doe@company.com"}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100002-0000-4000-8000-000000000002', 'analytics-team', 'Analytics Team', 'Business analytics and reporting team', '{"slack_channel": "https://company.slack.com/channels/analytics", "tools": ["Tableau", "Power BI", "SQL"]}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100003-0000-4000-8000-000000000003', 'data-science', 'Data Science Team', 'Machine learning and advanced analytics', '{"slack_channel": "https://company.slack.com/channels/data-science", "research_areas": ["NLP", "Computer Vision", "Recommendation Systems"]}', 'system@demo', 'system@demo', NOW(), NOW()),
+('00100004-0000-4000-8000-000000000004', 'governance-team', 'Data Governance Team', 'Data quality, compliance, and governance oversight', '{"slack_channel": "https://company.slack.com/channels/data-governance", "responsibilities": ["Data Quality", "Privacy Compliance", "Access Control"]}', 'system@demo', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -211,21 +212,14 @@ ON CONFLICT (project_id, team_id) DO NOTHING;
 -- 4. DATA CONTRACTS (type=004)
 -- ============================================================================
 
-INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, domain_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
--- Customer Data Contract
-('00400001-0000-4000-8000-000000000001', 'Customer Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0000-4000-8000-000000000001', '00000007-0000-4000-8000-000000000007', 'Core customer data contract defining customer profile, preferences, and transaction history', 'Customer master data to power user-facing apps, analytics, and marketing campaigns', 'Emails must be validated; PII must be encrypted at rest; data retention 7 years max', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0000-4000-8000-000000000001'),
--- Product Catalog Contract
-('00400002-0000-4000-8000-000000000002', 'Product Catalog Contract', 'DataContract', 'v3.1.0', '1.0.0', 'deprecated', false, '00100002-0000-4000-8000-000000000002', '00000008-0000-4000-8000-000000000008', 'Complete product catalog with categories, inventory, pricing, and vendor information', 'Power e-commerce platform, merchandising experiences, and inventory management', 'Price values must be non-negative; SKUs must be unique; inventory counts must be integers', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0000-4000-8000-000000000002'),
--- Data Sharing Agreement
-('00400003-0000-4000-8000-000000000003', 'Data Sharing Agreement', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100004-0000-4000-8000-000000000004', '0000000b-0000-4000-8000-000000000011', 'Legal agreement for data sharing between Analytics and Marketing', 'Enables sharing of aggregated analytics for campaign optimization', 'No external sharing; PII must be masked; delete after 90 days', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0000-4000-8000-000000000003'),
--- IoT Device Data Contract
-('00400004-0000-4000-8000-000000000004', 'IoT Device Data Contract', 'DataContract', 'v3.1.0', '1.1.0', 'active', true, '00100003-0000-4000-8000-000000000003', '0000000a-0000-4000-8000-000000000010', 'Comprehensive IoT device management and telemetry data for smart building systems', 'Monitor device health, performance, and environmental data in near real-time for predictive maintenance and energy optimization', 'Timestamps must be UTC; numeric telemetry must be within calibrated device ranges; data retention 2 years max', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0000-4000-8000-000000000004'),
--- IoT Sensor Data Contract (retired)
-('00400005-0000-4000-8000-000000000005', 'IoT Sensor Data Contract', 'DataContract', 'v3.1.0', '2.0.0', 'retired', false, '00100003-0000-4000-8000-000000000003', '0000000a-0000-4000-8000-000000000010', 'Real-time IoT sensor data from manufacturing floor', 'Stream analytics and anomaly detection', 'Primary key is (sensor_id, timestamp)', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0000-4000-8000-000000000005'),
--- Financial Transactions Contract
-('00400006-0000-4000-8000-000000000006', 'Financial Transactions Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100004-0000-4000-8000-000000000004', '00000002-0000-4000-8000-000000000002', 'Daily financial transaction data', 'Reconciliation, accounting, and reporting', 'Amount must be >= 0; currency must be ISO-4217', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400006-0000-4000-8000-000000000006'),
--- Inventory Management Contract
-('00400007-0000-4000-8000-000000000007', 'Inventory Management Contract', 'DataContract', 'v3.1.0', '1.2.0', 'deprecated', false, '00100002-0000-4000-8000-000000000002', '00000006-0000-4000-8000-000000000006', 'Real-time inventory levels and movements', 'Track stock levels across warehouses', 'Quantity must be integer >= 0', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400007-0000-4000-8000-000000000007')
+INSERT INTO data_contracts (id, name, kind, api_version, version, status, published, owner_team_id, description_purpose, description_usage, description_limitations, publication_scope, created_by, updated_by, created_at, updated_at, version_family_id) VALUES
+('00400001-0000-4000-8000-000000000001', 'Customer Data Contract', 'DataContract', 'v3.1.0', '1.0.0', 'active', true, '00100001-0000-4000-8000-000000000001', 'Core customer data contract defining customer profile, preferences, and transaction history', 'Customer master data to power user-facing apps, analytics, and marketing campaigns', 'Emails must be validated; PII must be encrypted at rest; data retention 7 years max', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400001-0000-4000-8000-000000000001'),
+('00400002-0000-4000-8000-000000000002', 'Product Catalog Contract', 'DataContract', 'v3.1.0', '1.0.0', 'deprecated', false, '00100002-0000-4000-8000-000000000002', 'Complete product catalog with categories, inventory, pricing, and vendor information', 'Power e-commerce platform, merchandising experiences, and inventory management', 'Price values must be non-negative; SKUs must be unique; inventory counts must be integers', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400002-0000-4000-8000-000000000002'),
+('00400003-0000-4000-8000-000000000003', 'Data Sharing Agreement', 'DataContract', 'v3.1.0', '2.0.0', 'active', true, '00100004-0000-4000-8000-000000000004', 'Legal agreement for data sharing between Analytics and Marketing', 'Enables sharing of aggregated analytics for campaign optimization', 'No external sharing; PII must be masked; delete after 90 days', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400003-0000-4000-8000-000000000003'),
+('00400004-0000-4000-8000-000000000004', 'IoT Device Data Contract', 'DataContract', 'v3.1.0', '1.1.0', 'active', true, '00100003-0000-4000-8000-000000000003', 'Comprehensive IoT device management and telemetry data for smart building systems', 'Monitor device health, performance, and environmental data in near real-time for predictive maintenance and energy optimization', 'Timestamps must be UTC; numeric telemetry must be within calibrated device ranges; data retention 2 years max', 'org', 'system@demo', 'system@demo', NOW(), NOW(), '00400004-0000-4000-8000-000000000004'),
+('00400005-0000-4000-8000-000000000005', 'IoT Sensor Data Contract', 'DataContract', 'v3.1.0', '2.0.0', 'retired', false, '00100003-0000-4000-8000-000000000003', 'Real-time IoT sensor data from manufacturing floor', 'Stream analytics and anomaly detection', 'Primary key is (sensor_id, timestamp)', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400005-0000-4000-8000-000000000005'),
+('00400006-0000-4000-8000-000000000006', 'Financial Transactions Contract', 'DataContract', 'v3.1.0', '1.0.0', 'draft', false, '00100004-0000-4000-8000-000000000004', 'Daily financial transaction data', 'Reconciliation, accounting, and reporting', 'Amount must be >= 0; currency must be ISO-4217', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400006-0000-4000-8000-000000000006'),
+('00400007-0000-4000-8000-000000000007', 'Inventory Management Contract', 'DataContract', 'v3.1.0', '1.2.0', 'deprecated', false, '00100002-0000-4000-8000-000000000002', 'Real-time inventory levels and movements', 'Track stock levels across warehouses', 'Quantity must be integer >= 0', 'none', 'system@demo', 'system@demo', NOW(), NOW(), '00400007-0000-4000-8000-000000000007')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -396,14 +390,14 @@ ON CONFLICT (id) DO NOTHING;
 -- 5. DATA PRODUCTS (type=007)
 -- ============================================================================
 
-INSERT INTO data_products (id, api_version, kind, status, name, version, domain, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
-('00700001-0000-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'POS Transaction Stream v1', '1.0.0', 'Retail Operations', 'retail-demo', '00100001-0000-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0000-4000-8000-000000000001'),
-('00700002-0000-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'Prepared Sales Transactions v1', '1.0.0', 'Retail Analytics', 'retail-demo', '00100001-0000-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700002-0000-4000-8000-000000000002'),
-('00700003-0000-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'Demand Forecast Model Output v1', '1.0.0', 'Retail Analytics', 'retail-demo', '00100002-0000-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700003-0000-4000-8000-000000000003'),
-('00700004-0000-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Inventory Optimization Recommendations v1', '1.0.0', 'Supply Chain', 'retail-demo', '00100001-0000-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700004-0000-4000-8000-000000000004'),
-('00700005-0000-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'Price Optimization Model Output v1', '1.0.0', 'Retail Analytics', 'retail-demo', '00100002-0000-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700005-0000-4000-8000-000000000005'),
-('00700006-0000-4000-8000-000000000006', 'v1.0.0', 'DataProduct', 'active', 'Customer Marketing Recommendations v1', '1.0.0', 'Marketing', 'retail-demo', '00100004-0000-4000-8000-000000000004', 99, true, 'org', NOW(), NOW(), '00700006-0000-4000-8000-000000000006'),
-('00700007-0000-4000-8000-000000000007', 'v1.0.0', 'DataProduct', 'active', 'Retail Performance Dashboard Data v1', '1.0.0', 'Retail Analytics', 'retail-demo', '00100002-0000-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700007-0000-4000-8000-000000000007')
+INSERT INTO data_products (id, api_version, kind, status, name, version, tenant, owner_team_id, max_level_inheritance, published, publication_scope, created_at, updated_at, version_family_id) VALUES
+('00700001-0000-4000-8000-000000000001', 'v1.0.0', 'DataProduct', 'active', 'POS Transaction Stream v1', '1.0.0', 'retail-demo', '00100001-0000-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700001-0000-4000-8000-000000000001'),
+('00700002-0000-4000-8000-000000000002', 'v1.0.0', 'DataProduct', 'active', 'Prepared Sales Transactions v1', '1.0.0', 'retail-demo', '00100001-0000-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700002-0000-4000-8000-000000000002'),
+('00700003-0000-4000-8000-000000000003', 'v1.0.0', 'DataProduct', 'active', 'Demand Forecast Model Output v1', '1.0.0', 'retail-demo', '00100002-0000-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700003-0000-4000-8000-000000000003'),
+('00700004-0000-4000-8000-000000000004', 'v1.0.0', 'DataProduct', 'active', 'Inventory Optimization Recommendations v1', '1.0.0', 'retail-demo', '00100001-0000-4000-8000-000000000001', 99, true, 'org', NOW(), NOW(), '00700004-0000-4000-8000-000000000004'),
+('00700005-0000-4000-8000-000000000005', 'v1.0.0', 'DataProduct', 'active', 'Price Optimization Model Output v1', '1.0.0', 'retail-demo', '00100002-0000-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700005-0000-4000-8000-000000000005'),
+('00700006-0000-4000-8000-000000000006', 'v1.0.0', 'DataProduct', 'active', 'Customer Marketing Recommendations v1', '1.0.0', 'retail-demo', '00100004-0000-4000-8000-000000000004', 99, true, 'org', NOW(), NOW(), '00700006-0000-4000-8000-000000000006'),
+('00700007-0000-4000-8000-000000000007', 'v1.0.0', 'DataProduct', 'active', 'Retail Performance Dashboard Data v1', '1.0.0', 'retail-demo', '00100002-0000-4000-8000-000000000002', 99, true, 'org', NOW(), NOW(), '00700007-0000-4000-8000-000000000007')
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -1270,59 +1264,47 @@ ON CONFLICT (id) DO NOTHING;
 -- IDs are preserved from the original dataset IDs for backward compatibility
 -- with polymorphic references (semantic_links, metadata, tags).
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
--- Customer datasets
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('02100001-0000-4000-8000-000000000001', 'Customer Master Data',
  'Customer master data including profiles, preferences, and segmentation',
- (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL, NULL,
+ (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL,
  '{"version": "1.0.0", "published": true, "contract_id": "00400001-0000-4000-8000-000000000001", "owner_team_id": "00100001-0000-4000-8000-000000000001", "project_id": "00300001-0000-4000-8000-000000000001", "data_classification": "confidential", "retention_days": "2555", "refresh_schedule": "daily"}',
  '["customer", "master-data", "pii"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('02100002-0000-4000-8000-000000000002', 'Customer Engagement Analytics',
  'Customer engagement metrics and preferences aggregation',
- (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL, NULL,
+ (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL,
  '{"version": "2.0.0", "published": false, "contract_id": "00400001-0000-4000-8000-000000000001", "owner_team_id": "00100001-0000-4000-8000-000000000001", "project_id": "00300001-0000-4000-8000-000000000001"}',
  '["customer", "analytics"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('02100003-0000-4000-8000-000000000003', 'Customer Preferences',
  'Aggregated customer preferences across channels',
- (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL, NULL,
+ (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL,
  '{"version": "1.0.0", "published": true, "contract_id": "00400001-0000-4000-8000-000000000001", "owner_team_id": "00100002-0000-4000-8000-000000000002", "project_id": "00300001-0000-4000-8000-000000000001"}',
  '["customer", "preferences"]', 'active', 'system@demo', NOW(), NOW()),
-
--- IoT datasets
 ('02100004-0000-4000-8000-000000000004', 'IoT Device Management',
  'Registry and management of all IoT devices and configurations',
- (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL, NULL,
+ (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL,
  '{"version": "1.1.0", "published": true, "contract_id": "00400004-0000-4000-8000-000000000004", "owner_team_id": "00100003-0000-4000-8000-000000000003", "project_id": "00300003-0000-4000-8000-000000000003"}',
  '["iot", "devices"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('02100005-0000-4000-8000-000000000005', 'IoT Telemetry',
  'Real-time and historical telemetry data from IoT devices',
- (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL, NULL,
+ (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL,
  '{"version": "1.1.0", "published": true, "contract_id": "00400004-0000-4000-8000-000000000004", "owner_team_id": "00100003-0000-4000-8000-000000000003", "project_id": "00300003-0000-4000-8000-000000000003", "partition_by": "date", "retention_days": "730", "compression": "zstd"}',
  '["iot", "telemetry", "streaming"]', 'active', 'system@demo', NOW(), NOW()),
-
--- Financial datasets
 ('02100006-0000-4000-8000-000000000006', 'Financial Transactions',
  'Daily financial transactions for analytics and reporting',
- (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL, NULL,
+ (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL,
  '{"version": "1.0.0-alpha", "published": false, "contract_id": "00400006-0000-4000-8000-000000000006", "owner_team_id": "00100004-0000-4000-8000-000000000004", "project_id": "00300002-0000-4000-8000-000000000002"}',
  '["finance", "transactions"]', 'draft', 'system@demo', NOW(), NOW()),
-
--- Retail/Analytics datasets
 ('02100007-0000-4000-8000-000000000007', 'Sales Analytics',
  'Aggregated sales analytics for BI dashboards and reporting',
- (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL, NULL,
+ (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL,
  '{"version": "2.0.0", "published": true, "owner_team_id": "00100002-0000-4000-8000-000000000002", "project_id": "00300005-0000-4000-8000-000000000005", "materialized": "true", "refresh_schedule": "hourly"}',
  '["sales", "analytics", "retail"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('02100008-0000-4000-8000-000000000008', 'Inventory Levels',
  'Current inventory levels across warehouses and regions',
- (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL, NULL,
+ (SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), NULL, NULL,
  '{"version": "1.2.0", "published": false, "contract_id": "00400007-0000-4000-8000-000000000007", "owner_team_id": "00100001-0000-4000-8000-000000000001", "project_id": "00300005-0000-4000-8000-000000000005"}',
  '["inventory", "supply-chain"]', 'deprecated', 'system@demo', NOW(), NOW())
-
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -1332,117 +1314,92 @@ ON CONFLICT (id) DO NOTHING;
 -- Physical implementations are now stored as Asset rows with the appropriate
 -- physical type. Relationships to parent Dataset assets are in entity_relationships.
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
--- Customer Master - Production instances (tables)
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('02500001-0000-4000-8000-000000000001', 'Customers Master Table',
  'Primary production instance in Unity Catalog',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master',
  '{"environment": "prod", "tableRole": "main", "physicalPath": "prod_catalog.crm.customers_master", "originalAssetType": "uc_table"}',
  '["production", "crm"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('02500002-0000-4000-8000-000000000002', 'Snowflake Customers Replica',
  'Snowflake replica for analytics workloads',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Snowflake', 'ANALYTICS_DB.CRM.CUSTOMERS_MASTER', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Snowflake', 'ANALYTICS_DB.CRM.CUSTOMERS_MASTER',
  '{"environment": "prod", "tableRole": "main", "physicalPath": "ANALYTICS_DB.CRM.CUSTOMERS_MASTER", "originalAssetType": "snowflake_table"}',
  '["production", "snowflake"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('0250000a-0000-4000-8000-000000000010', 'Customer Addresses',
  'Customer address dimension table',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses',
  '{"environment": "prod", "tableRole": "dimension", "physicalPath": "prod_catalog.crm.customer_addresses", "originalAssetType": "uc_table"}',
  '["dimension", "crm"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('0250000b-0000-4000-8000-000000000011', 'Countries Lookup',
  'Country reference/lookup table',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries',
  '{"environment": "prod", "tableRole": "lookup", "physicalPath": "prod_catalog.reference.countries", "originalAssetType": "uc_table"}',
  '["lookup", "reference"]', 'active', 'system@demo', NOW(), NOW()),
-
--- Customer Master - Development
 ('02500003-0000-4000-8000-000000000003', 'Dev Customers Table',
  'Development instance for testing new features',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master',
  '{"environment": "dev", "tableRole": "main", "physicalPath": "dev_catalog.crm.customers_master", "originalAssetType": "uc_table"}',
  '["development", "crm"]', 'active', 'system@demo', NOW(), NOW()),
-
--- Customer Preferences View
 ('02500004-0000-4000-8000-000000000004', 'Customer Preferences View',
  'Production view aggregating customer preferences',
- (SELECT id FROM asset_types WHERE name = 'View' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences', NULL,
+ (SELECT id FROM asset_types WHERE name = 'View' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences',
  '{"environment": "prod", "tableRole": "main", "physicalPath": "prod_catalog.crm.v_customer_preferences", "originalAssetType": "uc_view"}',
  '["production", "view", "crm"]', 'active', 'system@demo', NOW(), NOW()),
-
--- IoT Device Registry instances
 ('02500005-0000-4000-8000-000000000005', 'Device Registry',
  'Production IoT device registry',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry',
  '{"environment": "prod", "tableRole": "main", "physicalPath": "iot_catalog.devices.device_registry", "originalAssetType": "uc_table"}',
  '["production", "iot"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('02500006-0000-4000-8000-000000000006', 'Dev Device Registry',
  'Development IoT device registry for testing',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry',
  '{"environment": "dev", "tableRole": "main", "physicalPath": "iot_dev.devices.device_registry", "originalAssetType": "uc_table"}',
  '["development", "iot"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('0250000c-0000-4000-8000-000000000012', 'Device Types',
  'Device type dimension table',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types',
  '{"environment": "prod", "tableRole": "dimension", "physicalPath": "iot_catalog.devices.device_types", "originalAssetType": "uc_table"}',
  '["dimension", "iot"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('0250000d-0000-4000-8000-000000000013', 'Raw Device Data',
  'Staging streaming table for incoming device data',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw',
  '{"environment": "prod", "tableRole": "staging", "physicalPath": "iot_staging.devices.device_raw", "originalAssetType": "uc_streaming_table"}',
  '["staging", "iot", "streaming"]', 'active', 'system@demo', NOW(), NOW()),
-
--- IoT Telemetry
 ('02500007-0000-4000-8000-000000000007', 'Device Readings',
  'Production streaming telemetry data',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings',
  '{"environment": "prod", "tableRole": "main", "physicalPath": "iot_catalog.telemetry.device_readings", "originalAssetType": "uc_streaming_table"}',
  '["production", "telemetry", "streaming"]', 'active', 'system@demo', NOW(), NOW()),
-
--- Financial Transactions
 ('02500008-0000-4000-8000-000000000008', 'Daily Transactions',
  'Development instance for financial testing',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions',
  '{"environment": "dev", "tableRole": "main", "physicalPath": "finance_dev.transactions.daily_transactions", "originalAssetType": "uc_table"}',
  '["development", "finance"]', 'active', 'system@demo', NOW(), NOW()),
-
--- Inventory Levels (deprecated)
 ('02500009-0000-4000-8000-000000000009', 'Current Inventory',
  'Legacy inventory table - migrating to new schema',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current',
  '{"environment": "prod", "tableRole": "main", "physicalPath": "analytics_catalog.supply_chain.inventory_current", "originalAssetType": "uc_table"}',
  '["legacy", "supply-chain"]', 'deprecated', 'system@demo', NOW(), NOW()),
-
--- Additional multi-platform examples
 ('0250000e-0000-4000-8000-000000000014', 'Retail Events Stream',
  'Kafka topic for real-time retail events',
- (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Kafka', 'retail-events', NULL,
+ (SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), 'Kafka', 'retail-events',
  '{"environment": "prod", "tableRole": "main", "physicalPath": "retail-events", "originalAssetType": "kafka_topic"}',
  '["streaming", "retail"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('0250000f-0000-4000-8000-000000000015', 'Sales Metrics MV',
  'Materialized view for sales KPIs',
- (SELECT id FROM asset_types WHERE name = 'View' LIMIT 1), 'Databricks', 'prod_catalog.analytics.sales_metrics', NULL,
+ (SELECT id FROM asset_types WHERE name = 'View' LIMIT 1), 'Databricks', 'prod_catalog.analytics.sales_metrics',
  '{"environment": "prod", "tableRole": "reference", "physicalPath": "prod_catalog.analytics.sales_metrics", "originalAssetType": "uc_materialized_view"}',
  '["materialized-view", "analytics"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('02500010-0000-4000-8000-000000000016', 'Customer 360 Dashboard',
  'Lakeview dashboard for customer insights',
- (SELECT id FROM asset_types WHERE name = 'View' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard', NULL,
+ (SELECT id FROM asset_types WHERE name = 'View' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard',
  '{"environment": "prod", "tableRole": "reference", "physicalPath": "prod_catalog.crm.customer_360_dashboard", "originalAssetType": "uc_dashboard"}',
  '["dashboard", "customer"]', 'active', 'system@demo', NOW(), NOW()),
-
 ('02500011-0000-4000-8000-000000000017', 'PowerBI Customer Dataset',
  'Power BI semantic model for customer analytics',
- (SELECT id FROM asset_types WHERE name = 'View' LIMIT 1), 'Power BI', 'workspace://Workspaces/Analytics/Customer_Analysis', NULL,
+ (SELECT id FROM asset_types WHERE name = 'View' LIMIT 1), 'Power BI', 'workspace://Workspaces/Analytics/Customer_Analysis',
  '{"environment": "prod", "tableRole": "reference", "physicalPath": "workspace://Workspaces/Analytics/Customer_Analysis", "originalAssetType": "powerbi_dataset"}',
  '["powerbi", "analytics"]', 'active', 'system@demo', NOW(), NOW())
-
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -1543,112 +1500,78 @@ ON CONFLICT DO NOTHING;
 -- the assets uq_asset_identity (name, asset_type_id, platform, location)
 -- unique constraint.
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
--- 02500001 Customers Master Table — prod_catalog.crm.customers_master
-('0f520001-0000-4000-8000-000000000001', 'customer_id',       'Unique customer identifier (UUID)',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.customer_id',       NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["pii", "key"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520002-0000-4000-8000-000000000002', 'email',             'Customer email address',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.email',             NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520003-0000-4000-8000-000000000003', 'first_name',        'Customer first name',                                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.first_name',        NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520004-0000-4000-8000-000000000004', 'last_name',         'Customer last name',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.last_name',         NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520005-0000-4000-8000-000000000005', 'registration_date', 'Account registration timestamp (UTC)',                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.registration_date', NULL, '{"data_type": "TIMESTAMP", "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
-
--- 02500002 Snowflake Customers Replica — ANALYTICS_DB.CRM.CUSTOMERS_MASTER
-('0f520011-0000-4000-8000-000000000011', 'CUSTOMER_ID',       'Unique customer identifier (UUID, Snowflake replica)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.CUSTOMER_ID',       NULL, '{"data_type": "VARCHAR",   "nullable": false, "is_primary_key": true}',  '["pii", "key", "snowflake"]', 'active', 'system@demo', NOW(), NOW()),
-('0f520012-0000-4000-8000-000000000012', 'EMAIL',             'Customer email (Snowflake replica)',                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.EMAIL',             NULL, '{"data_type": "VARCHAR",   "nullable": false}',                          '["pii", "snowflake"]',   'active', 'system@demo', NOW(), NOW()),
-('0f520013-0000-4000-8000-000000000013', 'FIRST_NAME',        'Customer first name (Snowflake replica)',                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.FIRST_NAME',        NULL, '{"data_type": "VARCHAR",   "nullable": false}',                          '["pii", "snowflake"]',   'active', 'system@demo', NOW(), NOW()),
-('0f520014-0000-4000-8000-000000000014', 'REGISTRATION_DATE', 'Registration date (Snowflake replica)',                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.REGISTRATION_DATE', NULL, '{"data_type": "TIMESTAMP_NTZ", "nullable": false}',                      '["snowflake"]',          'active', 'system@demo', NOW(), NOW()),
-
--- 02500003 Dev Customers Table — dev_catalog.crm.customers_master
-('0f520021-0000-4000-8000-000000000021', 'customer_id',       'Unique customer identifier (dev)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.customer_id',        NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["dev", "key"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520022-0000-4000-8000-000000000022', 'email',             'Customer email (dev)',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.email',              NULL, '{"data_type": "STRING",    "nullable": true }',                          '["dev"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520023-0000-4000-8000-000000000023', 'first_name',        'Customer first name (dev)',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.first_name',         NULL, '{"data_type": "STRING",    "nullable": true }',                          '["dev"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520024-0000-4000-8000-000000000024', 'last_name',         'Customer last name (dev)',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.last_name',          NULL, '{"data_type": "STRING",    "nullable": true }',                          '["dev"]',                'active', 'system@demo', NOW(), NOW()),
-
--- 02500004 Customer Preferences View — prod_catalog.crm.v_customer_preferences
-('0f520031-0000-4000-8000-000000000031', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.customer_id', NULL, '{"data_type": "STRING",    "nullable": false}',                          '["fk"]',                 'active', 'system@demo', NOW(), NOW()),
-('0f520032-0000-4000-8000-000000000032', 'preference_key',    'Preference name (channel, language, marketing_optin)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.preference_key',NULL,'{"data_type": "STRING",    "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
-('0f520033-0000-4000-8000-000000000033', 'preference_value',  'Preference value (string)',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.preference_value',NULL,'{"data_type": "STRING", "nullable": false}',                            '[]',                     'active', 'system@demo', NOW(), NOW()),
-('0f520034-0000-4000-8000-000000000034', 'updated_at',        'Last update timestamp (UTC)',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.updated_at',  NULL, '{"data_type": "TIMESTAMP", "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
-
--- 02500005 Device Registry — iot_catalog.devices.device_registry
-('0f520041-0000-4000-8000-000000000041', 'device_id',         'Unique device identifier',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.device_id',       NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "key"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520042-0000-4000-8000-000000000042', 'device_serial',     'Manufacturer serial number',                                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.device_serial',   NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520043-0000-4000-8000-000000000043', 'device_type',       'sensor | actuator | gateway | controller',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.device_type',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520044-0000-4000-8000-000000000044', 'status',            'Operational state',                                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.status',          NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot"]',                'active', 'system@demo', NOW(), NOW()),
-
--- 02500006 Dev Device Registry — iot_dev.devices.device_registry
-('0f520051-0000-4000-8000-000000000051', 'device_id',         'Unique device identifier (dev)',                               (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry.device_id',           NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "dev"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520052-0000-4000-8000-000000000052', 'device_serial',     'Manufacturer serial number (dev)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry.device_serial',       NULL, '{"data_type": "STRING",    "nullable": true }',                          '["iot", "dev"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520053-0000-4000-8000-000000000053', 'device_type',       'Device type (dev)',                                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry.device_type',         NULL, '{"data_type": "STRING",    "nullable": true }',                          '["iot", "dev"]',         'active', 'system@demo', NOW(), NOW()),
-
--- 02500007 Device Readings — iot_catalog.telemetry.device_readings
-('0f520061-0000-4000-8000-000000000061', 'reading_id',        'Unique reading identifier',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.reading_id',    NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "telemetry", "key"]','active','system@demo', NOW(), NOW()),
-('0f520062-0000-4000-8000-000000000062', 'device_id',         'FK to devices.device_id',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.device_id',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "telemetry", "fk"]','active', 'system@demo', NOW(), NOW()),
-('0f520063-0000-4000-8000-000000000063', 'metric_value',      'Numeric measurement value',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.metric_value',  NULL, '{"data_type": "DECIMAL(10,4)", "nullable": false}',                      '["iot", "telemetry"]',   'active', 'system@demo', NOW(), NOW()),
-('0f520064-0000-4000-8000-000000000064', 'reading_timestamp', 'Reading timestamp (UTC)',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.reading_timestamp', NULL, '{"data_type": "TIMESTAMP", "nullable": false, "partition_key": true}', '["iot", "telemetry", "partition"]', 'active', 'system@demo', NOW(), NOW()),
-
--- 02500008 Daily Transactions — finance_dev.transactions.daily_transactions
-('0f520071-0000-4000-8000-000000000071', 'transaction_id',    'Unique transaction identifier',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.transaction_id', NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["finance", "key"]',     'active', 'system@demo', NOW(), NOW()),
-('0f520072-0000-4000-8000-000000000072', 'account_id',        'Internal account identifier',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.account_id',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["finance", "fk"]',      'active', 'system@demo', NOW(), NOW()),
-('0f520073-0000-4000-8000-000000000073', 'amount',            'Transaction amount (>= 0)',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.amount',         NULL, '{"data_type": "DECIMAL(18,2)", "nullable": false}',                      '["finance", "amount"]',  'active', 'system@demo', NOW(), NOW()),
-('0f520074-0000-4000-8000-000000000074', 'currency',          'ISO-4217 currency code',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.currency',       NULL, '{"data_type": "STRING",    "nullable": false}',                          '["finance"]',            'active', 'system@demo', NOW(), NOW()),
-('0f520075-0000-4000-8000-000000000075', 'transaction_date',  'Transaction date (partition key)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.transaction_date',NULL,'{"data_type": "DATE",      "nullable": false, "partition_key": true}',   '["finance", "partition"]','active','system@demo', NOW(), NOW()),
-
--- 02500009 Current Inventory (deprecated) — analytics_catalog.supply_chain.inventory_current
-('0f520081-0000-4000-8000-000000000081', 'product_id',        'FK to products.sku',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.product_id',   NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["supply-chain", "deprecated", "key"]', 'deprecated', 'system@demo', NOW(), NOW()),
-('0f520082-0000-4000-8000-000000000082', 'warehouse_id',      'Warehouse identifier',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.warehouse_id', NULL, '{"data_type": "STRING",    "nullable": false}',                          '["supply-chain", "deprecated"]',         'deprecated', 'system@demo', NOW(), NOW()),
-('0f520083-0000-4000-8000-000000000083', 'quantity_on_hand',  'Current quantity on hand (>= 0)',                              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.quantity_on_hand', NULL,'{"data_type": "INT",     "nullable": false}',                          '["supply-chain", "deprecated"]',         'deprecated', 'system@demo', NOW(), NOW()),
-('0f520084-0000-4000-8000-000000000084', 'last_updated',      'Last stock update timestamp (UTC)',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.last_updated', NULL, '{"data_type": "TIMESTAMP", "nullable": false}',                          '["supply-chain", "deprecated"]',         'deprecated', 'system@demo', NOW(), NOW()),
-
--- 0250000a Customer Addresses — prod_catalog.crm.customer_addresses
-('0f520091-0000-4000-8000-000000000091', 'address_id',        'Unique address identifier (UUID)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.address_id',      NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["pii", "key"]',         'active', 'system@demo', NOW(), NOW()),
-('0f520092-0000-4000-8000-000000000092', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.customer_id',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii", "fk"]',          'active', 'system@demo', NOW(), NOW()),
-('0f520093-0000-4000-8000-000000000093', 'street',            'Street address line 1',                                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.street',          NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520094-0000-4000-8000-000000000094', 'city',              'City',                                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.city',            NULL, '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
-('0f520095-0000-4000-8000-000000000095', 'country_code',      'ISO 3166-1 alpha-2',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.country_code',    NULL, '{"data_type": "STRING",    "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
-
--- 0250000b Countries Lookup — prod_catalog.reference.countries
-('0f5200a1-0000-4000-8000-0000000000a1', 'country_code',      'ISO 3166-1 alpha-2 (PK)',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries.country_code',       NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["reference", "key"]',   'active', 'system@demo', NOW(), NOW()),
-('0f5200a2-0000-4000-8000-0000000000a2', 'country_name',      'Official country name',                                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries.country_name',       NULL, '{"data_type": "STRING",    "nullable": false}',                          '["reference"]',          'active', 'system@demo', NOW(), NOW()),
-('0f5200a3-0000-4000-8000-0000000000a3', 'continent',         'Continent (Europe, Asia, ...)',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries.continent',          NULL, '{"data_type": "STRING",    "nullable": false}',                          '["reference"]',          'active', 'system@demo', NOW(), NOW()),
-
--- 0250000c Device Types — iot_catalog.devices.device_types
-('0f5200b1-0000-4000-8000-0000000000b1', 'type_id',           'Type identifier (PK)',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.type_id',            NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "reference", "key"]','active','system@demo', NOW(), NOW()),
-('0f5200b2-0000-4000-8000-0000000000b2', 'type_name',         'Display name',                                                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.type_name',          NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "reference"]',   'active', 'system@demo', NOW(), NOW()),
-('0f5200b3-0000-4000-8000-0000000000b3', 'manufacturer',      'Hardware manufacturer',                                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.manufacturer',       NULL, '{"data_type": "STRING",    "nullable": true }',                          '["iot", "reference"]',   'active', 'system@demo', NOW(), NOW()),
-('0f5200b4-0000-4000-8000-0000000000b4', 'capabilities',      'JSON-encoded device capabilities map',                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.capabilities',       NULL, '{"data_type": "STRING",    "nullable": true,  "format": "json"}',        '["iot", "reference"]',   'active', 'system@demo', NOW(), NOW()),
-
--- 0250000d Raw Device Data (staging) — iot_staging.devices.device_raw
-('0f5200c1-0000-4000-8000-0000000000c1', 'event_id',          'Raw event ID (UUID)',                                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.event_id',             NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "staging", "key"]','active', 'system@demo', NOW(), NOW()),
-('0f5200c2-0000-4000-8000-0000000000c2', 'device_id',         'Originating device',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.device_id',            NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "staging", "fk"]','active','system@demo', NOW(), NOW()),
-('0f5200c3-0000-4000-8000-0000000000c3', 'payload',           'Raw event payload (JSON)',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.payload',              NULL, '{"data_type": "STRING",    "nullable": false, "format": "json"}',        '["iot", "staging"]',     'active', 'system@demo', NOW(), NOW()),
-('0f5200c4-0000-4000-8000-0000000000c4', 'ingest_timestamp',  'Bronze ingest timestamp (UTC)',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.ingest_timestamp',     NULL, '{"data_type": "TIMESTAMP", "nullable": false, "partition_key": true}',   '["iot", "staging"]',     'active', 'system@demo', NOW(), NOW()),
-
--- 02500010 Customer 360 Dashboard view — prod_catalog.crm.customer_360_dashboard
-('0f5200d1-0000-4000-8000-0000000000d1', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.customer_id',     NULL, '{"data_type": "STRING",    "nullable": false}',                          '["customer-360"]',       'active', 'system@demo', NOW(), NOW()),
-('0f5200d2-0000-4000-8000-0000000000d2', 'ltv',               'Lifetime value (USD)',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.ltv',             NULL, '{"data_type": "DECIMAL(18,2)", "nullable": true }',                      '["customer-360", "kpi"]','active', 'system@demo', NOW(), NOW()),
-('0f5200d3-0000-4000-8000-0000000000d3', 'total_orders',      'Cumulative order count',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.total_orders',    NULL, '{"data_type": "INT",       "nullable": false}',                          '["customer-360", "kpi"]','active', 'system@demo', NOW(), NOW()),
-('0f5200d4-0000-4000-8000-0000000000d4', 'last_purchase_date','Most recent purchase date',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.last_purchase_date',NULL,'{"data_type": "DATE",     "nullable": true }',                          '["customer-360"]',       'active', 'system@demo', NOW(), NOW()),
-
--- 02500011 PowerBI Customer Dataset — workspace://Workspaces/Analytics/Customer_Analysis
-('0f5200e1-0000-4000-8000-0000000000e1', 'CustomerKey',       'Surrogate key into the customer dimension',                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.CustomerKey',  NULL, '{"data_type": "Int64",    "nullable": false, "is_primary_key": true}',   '["powerbi", "key"]',     'active', 'system@demo', NOW(), NOW()),
-('0f5200e2-0000-4000-8000-0000000000e2', 'Email',             'Email (PowerBI semantic model)',                               (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.Email',        NULL, '{"data_type": "Text",     "nullable": false}',                           '["powerbi", "pii"]',     'active', 'system@demo', NOW(), NOW()),
-('0f5200e3-0000-4000-8000-0000000000e3', 'Segment',           'Marketing segment label',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.Segment',      NULL, '{"data_type": "Text",     "nullable": false}',                           '["powerbi"]',            'active', 'system@demo', NOW(), NOW()),
-('0f5200e4-0000-4000-8000-0000000000e4', 'LifetimeValue',     'Computed CLV measure (USD)',                                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.LifetimeValue',NULL, '{"data_type": "Decimal",  "nullable": true,  "is_measure": true}',       '["powerbi", "kpi"]',     'active', 'system@demo', NOW(), NOW()),
-
--- 0f300006 Invoices — lakehouse.finance.curated.invoices
-('0f5200f1-0000-4000-8000-0000000000f1', 'invoice_id',        'Unique invoice identifier',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.invoice_id',       NULL, '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["finance", "key"]',     'active', 'system@demo', NOW(), NOW()),
-('0f5200f2-0000-4000-8000-0000000000f2', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.customer_id',      NULL, '{"data_type": "STRING",    "nullable": false}',                          '["finance", "fk"]',      'active', 'system@demo', NOW(), NOW()),
-('0f5200f3-0000-4000-8000-0000000000f3', 'total_amount',      'Invoice total in invoice currency (>= 0)',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.total_amount',     NULL, '{"data_type": "DECIMAL(18,2)", "nullable": false}',                      '["finance", "amount"]',  'active', 'system@demo', NOW(), NOW()),
-('0f5200f4-0000-4000-8000-0000000000f4', 'currency',          'ISO-4217 currency code',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.currency',         NULL, '{"data_type": "STRING",    "nullable": false}',                          '["finance"]',            'active', 'system@demo', NOW(), NOW()),
-('0f5200f5-0000-4000-8000-0000000000f5', 'invoice_date',      'Invoice issue date (partition key)',                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.invoice_date',     NULL, '{"data_type": "DATE",      "nullable": false, "partition_key": true}',   '["finance", "partition"]','active','system@demo', NOW(), NOW()),
-
--- 0f30000b iot-device-telemetry — Kafka topic schema (advertised contract)
-('0f520201-0000-4000-8000-000000000201', 'device_id',         'FK to devices.device_id',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.device_id',         NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "streaming", "fk"]',     'active', 'system@demo', NOW(), NOW()),
-('0f520202-0000-4000-8000-000000000202', 'metric_name',       'Metric name (temperature, humidity, ...)',                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.metric_name',       NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520203-0000-4000-8000-000000000203', 'metric_value',      'Numeric measurement value',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.metric_value',      NULL, '{"data_type": "DECIMAL(10,4)", "nullable": false}',                      '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520204-0000-4000-8000-000000000204', 'unit',              'Unit of measurement (C, %, kPa, ...)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.unit',              NULL, '{"data_type": "STRING",    "nullable": false}',                          '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW()),
-('0f520205-0000-4000-8000-000000000205', 'reading_timestamp', 'Reading timestamp (UTC)',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.reading_timestamp', NULL, '{"data_type": "TIMESTAMP", "nullable": false}',                          '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW())
-
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
+('0f520001-0000-4000-8000-000000000001', 'customer_id',       'Unique customer identifier (UUID)',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.customer_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["pii", "key"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520002-0000-4000-8000-000000000002', 'email',             'Customer email address',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.email', '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520003-0000-4000-8000-000000000003', 'first_name',        'Customer first name',                                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.first_name', '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520004-0000-4000-8000-000000000004', 'last_name',         'Customer last name',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.last_name', '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520005-0000-4000-8000-000000000005', 'registration_date', 'Account registration timestamp (UTC)',                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customers_master.registration_date', '{"data_type": "TIMESTAMP", "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
+('0f520011-0000-4000-8000-000000000011', 'CUSTOMER_ID',       'Unique customer identifier (UUID, Snowflake replica)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.CUSTOMER_ID', '{"data_type": "VARCHAR",   "nullable": false, "is_primary_key": true}',  '["pii", "key", "snowflake"]', 'active', 'system@demo', NOW(), NOW()),
+('0f520012-0000-4000-8000-000000000012', 'EMAIL',             'Customer email (Snowflake replica)',                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.EMAIL', '{"data_type": "VARCHAR",   "nullable": false}',                          '["pii", "snowflake"]',   'active', 'system@demo', NOW(), NOW()),
+('0f520013-0000-4000-8000-000000000013', 'FIRST_NAME',        'Customer first name (Snowflake replica)',                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.FIRST_NAME', '{"data_type": "VARCHAR",   "nullable": false}',                          '["pii", "snowflake"]',   'active', 'system@demo', NOW(), NOW()),
+('0f520014-0000-4000-8000-000000000014', 'REGISTRATION_DATE', 'Registration date (Snowflake replica)',                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Snowflake',  'ANALYTICS_DB.CRM.CUSTOMERS_MASTER.REGISTRATION_DATE', '{"data_type": "TIMESTAMP_NTZ", "nullable": false}',                      '["snowflake"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520021-0000-4000-8000-000000000021', 'customer_id',       'Unique customer identifier (dev)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.customer_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["dev", "key"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520022-0000-4000-8000-000000000022', 'email',             'Customer email (dev)',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.email', '{"data_type": "STRING",    "nullable": true }',                          '["dev"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520023-0000-4000-8000-000000000023', 'first_name',        'Customer first name (dev)',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.first_name', '{"data_type": "STRING",    "nullable": true }',                          '["dev"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520024-0000-4000-8000-000000000024', 'last_name',         'Customer last name (dev)',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'dev_catalog.crm.customers_master.last_name', '{"data_type": "STRING",    "nullable": true }',                          '["dev"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520031-0000-4000-8000-000000000031', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.customer_id', '{"data_type": "STRING",    "nullable": false}',                          '["fk"]',                 'active', 'system@demo', NOW(), NOW()),
+('0f520032-0000-4000-8000-000000000032', 'preference_key',    'Preference name (channel, language, marketing_optin)',         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.preference_key','{"data_type": "STRING",    "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
+('0f520033-0000-4000-8000-000000000033', 'preference_value',  'Preference value (string)',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.preference_value','{"data_type": "STRING", "nullable": false}',                            '[]',                     'active', 'system@demo', NOW(), NOW()),
+('0f520034-0000-4000-8000-000000000034', 'updated_at',        'Last update timestamp (UTC)',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.v_customer_preferences.updated_at', '{"data_type": "TIMESTAMP", "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
+('0f520041-0000-4000-8000-000000000041', 'device_id',         'Unique device identifier',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.device_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "key"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520042-0000-4000-8000-000000000042', 'device_serial',     'Manufacturer serial number',                                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.device_serial', '{"data_type": "STRING",    "nullable": false}',                          '["iot"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520043-0000-4000-8000-000000000043', 'device_type',       'sensor | actuator | gateway | controller',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.device_type', '{"data_type": "STRING",    "nullable": false}',                          '["iot"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520044-0000-4000-8000-000000000044', 'status',            'Operational state',                                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_registry.status', '{"data_type": "STRING",    "nullable": false}',                          '["iot"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520051-0000-4000-8000-000000000051', 'device_id',         'Unique device identifier (dev)',                               (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry.device_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "dev"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520052-0000-4000-8000-000000000052', 'device_serial',     'Manufacturer serial number (dev)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry.device_serial', '{"data_type": "STRING",    "nullable": true }',                          '["iot", "dev"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520053-0000-4000-8000-000000000053', 'device_type',       'Device type (dev)',                                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_dev.devices.device_registry.device_type', '{"data_type": "STRING",    "nullable": true }',                          '["iot", "dev"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520061-0000-4000-8000-000000000061', 'reading_id',        'Unique reading identifier',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.reading_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "telemetry", "key"]','active','system@demo', NOW(), NOW()),
+('0f520062-0000-4000-8000-000000000062', 'device_id',         'FK to devices.device_id',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.device_id', '{"data_type": "STRING",    "nullable": false}',                          '["iot", "telemetry", "fk"]','active', 'system@demo', NOW(), NOW()),
+('0f520063-0000-4000-8000-000000000063', 'metric_value',      'Numeric measurement value',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.metric_value', '{"data_type": "DECIMAL(10,4)", "nullable": false}',                      '["iot", "telemetry"]',   'active', 'system@demo', NOW(), NOW()),
+('0f520064-0000-4000-8000-000000000064', 'reading_timestamp', 'Reading timestamp (UTC)',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.telemetry.device_readings.reading_timestamp', '{"data_type": "TIMESTAMP", "nullable": false, "partition_key": true}', '["iot", "telemetry", "partition"]', 'active', 'system@demo', NOW(), NOW()),
+('0f520071-0000-4000-8000-000000000071', 'transaction_id',    'Unique transaction identifier',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.transaction_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["finance", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520072-0000-4000-8000-000000000072', 'account_id',        'Internal account identifier',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.account_id', '{"data_type": "STRING",    "nullable": false}',                          '["finance", "fk"]',      'active', 'system@demo', NOW(), NOW()),
+('0f520073-0000-4000-8000-000000000073', 'amount',            'Transaction amount (>= 0)',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.amount', '{"data_type": "DECIMAL(18,2)", "nullable": false}',                      '["finance", "amount"]',  'active', 'system@demo', NOW(), NOW()),
+('0f520074-0000-4000-8000-000000000074', 'currency',          'ISO-4217 currency code',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.currency', '{"data_type": "STRING",    "nullable": false}',                          '["finance"]',            'active', 'system@demo', NOW(), NOW()),
+('0f520075-0000-4000-8000-000000000075', 'transaction_date',  'Transaction date (partition key)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'finance_dev.transactions.daily_transactions.transaction_date','{"data_type": "DATE",      "nullable": false, "partition_key": true}',   '["finance", "partition"]','active','system@demo', NOW(), NOW()),
+('0f520081-0000-4000-8000-000000000081', 'product_id',        'FK to products.sku',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.product_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["supply-chain", "deprecated", "key"]', 'deprecated', 'system@demo', NOW(), NOW()),
+('0f520082-0000-4000-8000-000000000082', 'warehouse_id',      'Warehouse identifier',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.warehouse_id', '{"data_type": "STRING",    "nullable": false}',                          '["supply-chain", "deprecated"]',         'deprecated', 'system@demo', NOW(), NOW()),
+('0f520083-0000-4000-8000-000000000083', 'quantity_on_hand',  'Current quantity on hand (>= 0)',                              (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.quantity_on_hand','{"data_type": "INT",     "nullable": false}',                          '["supply-chain", "deprecated"]',         'deprecated', 'system@demo', NOW(), NOW()),
+('0f520084-0000-4000-8000-000000000084', 'last_updated',      'Last stock update timestamp (UTC)',                            (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'analytics_catalog.supply_chain.inventory_current.last_updated', '{"data_type": "TIMESTAMP", "nullable": false}',                          '["supply-chain", "deprecated"]',         'deprecated', 'system@demo', NOW(), NOW()),
+('0f520091-0000-4000-8000-000000000091', 'address_id',        'Unique address identifier (UUID)',                             (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.address_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["pii", "key"]',         'active', 'system@demo', NOW(), NOW()),
+('0f520092-0000-4000-8000-000000000092', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.customer_id', '{"data_type": "STRING",    "nullable": false}',                          '["pii", "fk"]',          'active', 'system@demo', NOW(), NOW()),
+('0f520093-0000-4000-8000-000000000093', 'street',            'Street address line 1',                                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.street', '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520094-0000-4000-8000-000000000094', 'city',              'City',                                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.city', '{"data_type": "STRING",    "nullable": false}',                          '["pii"]',                'active', 'system@demo', NOW(), NOW()),
+('0f520095-0000-4000-8000-000000000095', 'country_code',      'ISO 3166-1 alpha-2',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_addresses.country_code', '{"data_type": "STRING",    "nullable": false}',                          '[]',                     'active', 'system@demo', NOW(), NOW()),
+('0f5200a1-0000-4000-8000-0000000000a1', 'country_code',      'ISO 3166-1 alpha-2 (PK)',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries.country_code', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["reference", "key"]',   'active', 'system@demo', NOW(), NOW()),
+('0f5200a2-0000-4000-8000-0000000000a2', 'country_name',      'Official country name',                                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries.country_name', '{"data_type": "STRING",    "nullable": false}',                          '["reference"]',          'active', 'system@demo', NOW(), NOW()),
+('0f5200a3-0000-4000-8000-0000000000a3', 'continent',         'Continent (Europe, Asia, ...)',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.reference.countries.continent', '{"data_type": "STRING",    "nullable": false}',                          '["reference"]',          'active', 'system@demo', NOW(), NOW()),
+('0f5200b1-0000-4000-8000-0000000000b1', 'type_id',           'Type identifier (PK)',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.type_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "reference", "key"]','active','system@demo', NOW(), NOW()),
+('0f5200b2-0000-4000-8000-0000000000b2', 'type_name',         'Display name',                                                 (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.type_name', '{"data_type": "STRING",    "nullable": false}',                          '["iot", "reference"]',   'active', 'system@demo', NOW(), NOW()),
+('0f5200b3-0000-4000-8000-0000000000b3', 'manufacturer',      'Hardware manufacturer',                                        (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.manufacturer', '{"data_type": "STRING",    "nullable": true }',                          '["iot", "reference"]',   'active', 'system@demo', NOW(), NOW()),
+('0f5200b4-0000-4000-8000-0000000000b4', 'capabilities',      'JSON-encoded device capabilities map',                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_catalog.devices.device_types.capabilities', '{"data_type": "STRING",    "nullable": true,  "format": "json"}',        '["iot", "reference"]',   'active', 'system@demo', NOW(), NOW()),
+('0f5200c1-0000-4000-8000-0000000000c1', 'event_id',          'Raw event ID (UUID)',                                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.event_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["iot", "staging", "key"]','active', 'system@demo', NOW(), NOW()),
+('0f5200c2-0000-4000-8000-0000000000c2', 'device_id',         'Originating device',                                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.device_id', '{"data_type": "STRING",    "nullable": false}',                          '["iot", "staging", "fk"]','active','system@demo', NOW(), NOW()),
+('0f5200c3-0000-4000-8000-0000000000c3', 'payload',           'Raw event payload (JSON)',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.payload', '{"data_type": "STRING",    "nullable": false, "format": "json"}',        '["iot", "staging"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200c4-0000-4000-8000-0000000000c4', 'ingest_timestamp',  'Bronze ingest timestamp (UTC)',                                (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'iot_staging.devices.device_raw.ingest_timestamp', '{"data_type": "TIMESTAMP", "nullable": false, "partition_key": true}',   '["iot", "staging"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200d1-0000-4000-8000-0000000000d1', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.customer_id', '{"data_type": "STRING",    "nullable": false}',                          '["customer-360"]',       'active', 'system@demo', NOW(), NOW()),
+('0f5200d2-0000-4000-8000-0000000000d2', 'ltv',               'Lifetime value (USD)',                                         (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.ltv', '{"data_type": "DECIMAL(18,2)", "nullable": true }',                      '["customer-360", "kpi"]','active', 'system@demo', NOW(), NOW()),
+('0f5200d3-0000-4000-8000-0000000000d3', 'total_orders',      'Cumulative order count',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.total_orders', '{"data_type": "INT",       "nullable": false}',                          '["customer-360", "kpi"]','active', 'system@demo', NOW(), NOW()),
+('0f5200d4-0000-4000-8000-0000000000d4', 'last_purchase_date','Most recent purchase date',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'prod_catalog.crm.customer_360_dashboard.last_purchase_date','{"data_type": "DATE",     "nullable": true }',                          '["customer-360"]',       'active', 'system@demo', NOW(), NOW()),
+('0f5200e1-0000-4000-8000-0000000000e1', 'CustomerKey',       'Surrogate key into the customer dimension',                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.CustomerKey', '{"data_type": "Int64",    "nullable": false, "is_primary_key": true}',   '["powerbi", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200e2-0000-4000-8000-0000000000e2', 'Email',             'Email (PowerBI semantic model)',                               (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.Email', '{"data_type": "Text",     "nullable": false}',                           '["powerbi", "pii"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200e3-0000-4000-8000-0000000000e3', 'Segment',           'Marketing segment label',                                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.Segment', '{"data_type": "Text",     "nullable": false}',                           '["powerbi"]',            'active', 'system@demo', NOW(), NOW()),
+('0f5200e4-0000-4000-8000-0000000000e4', 'LifetimeValue',     'Computed CLV measure (USD)',                                   (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Power BI',   'workspace://Workspaces/Analytics/Customer_Analysis.LifetimeValue', '{"data_type": "Decimal",  "nullable": true,  "is_measure": true}',       '["powerbi", "kpi"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200f1-0000-4000-8000-0000000000f1', 'invoice_id',        'Unique invoice identifier',                                    (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.invoice_id', '{"data_type": "STRING",    "nullable": false, "is_primary_key": true}',  '["finance", "key"]',     'active', 'system@demo', NOW(), NOW()),
+('0f5200f2-0000-4000-8000-0000000000f2', 'customer_id',       'FK to customers.customer_id',                                  (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.customer_id', '{"data_type": "STRING",    "nullable": false}',                          '["finance", "fk"]',      'active', 'system@demo', NOW(), NOW()),
+('0f5200f3-0000-4000-8000-0000000000f3', 'total_amount',      'Invoice total in invoice currency (>= 0)',                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.total_amount', '{"data_type": "DECIMAL(18,2)", "nullable": false}',                      '["finance", "amount"]',  'active', 'system@demo', NOW(), NOW()),
+('0f5200f4-0000-4000-8000-0000000000f4', 'currency',          'ISO-4217 currency code',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.currency', '{"data_type": "STRING",    "nullable": false}',                          '["finance"]',            'active', 'system@demo', NOW(), NOW()),
+('0f5200f5-0000-4000-8000-0000000000f5', 'invoice_date',      'Invoice issue date (partition key)',                           (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Databricks', 'lakehouse.finance.curated.invoices.invoice_date', '{"data_type": "DATE",      "nullable": false, "partition_key": true}',   '["finance", "partition"]','active','system@demo', NOW(), NOW()),
+('0f520201-0000-4000-8000-000000000201', 'device_id',         'FK to devices.device_id',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.device_id', '{"data_type": "STRING",    "nullable": false}',                          '["iot", "streaming", "fk"]',     'active', 'system@demo', NOW(), NOW()),
+('0f520202-0000-4000-8000-000000000202', 'metric_name',       'Metric name (temperature, humidity, ...)',                      (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.metric_name', '{"data_type": "STRING",    "nullable": false}',                          '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520203-0000-4000-8000-000000000203', 'metric_value',      'Numeric measurement value',                                     (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.metric_value', '{"data_type": "DECIMAL(10,4)", "nullable": false}',                      '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520204-0000-4000-8000-000000000204', 'unit',              'Unit of measurement (C, %, kPa, ...)',                          (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.unit', '{"data_type": "STRING",    "nullable": false}',                          '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW()),
+('0f520205-0000-4000-8000-000000000205', 'reading_timestamp', 'Reading timestamp (UTC)',                                       (SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry.reading_timestamp', '{"data_type": "TIMESTAMP", "nullable": false}',                          '["iot", "streaming"]',           'active', 'system@demo', NOW(), NOW())
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -2459,230 +2382,164 @@ ON CONFLICT (id) DO NOTHING;
 -- ============================================================================
 -- Concrete cataloged objects linked to asset types, domains, and data products.
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
-
--- Systems
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('0f300001-0000-4000-8000-000000000001',
  'Databricks Lakehouse',
  'Primary Databricks workspace for all lakehouse tables and pipelines.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'System' LIMIT 1), '0f200009-0000-4000-8000-000000000009'), 'Databricks', 'https://adb-1234567890.azuredatabricks.net',
- '00000001-0000-4000-8000-000000000001',
  '{"type": "lakehouse", "environment": "production", "cloud": "Azure"}',
  '["production", "primary"]',
  'active', 'system@demo', NOW(), NOW()),
-
 ('0f300002-0000-4000-8000-000000000002',
  'Power BI Service',
  'Enterprise Power BI tenant for dashboards and reports.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'System' LIMIT 1), '0f200009-0000-4000-8000-000000000009'), 'Power BI', 'https://app.powerbi.com/groups/retail-analytics',
- '00000001-0000-4000-8000-000000000001',
  '{"type": "bi_platform", "environment": "production"}',
  '["analytics", "reporting"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Tables (Retail)
 ('0f300003-0000-4000-8000-000000000003',
  'lakehouse.retail.curated.pos_transactions',
  'Curated POS transaction table with validated, deduplicated retail transactions.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.retail.curated.pos_transactions',
- '0000000c-0000-4000-8000-000000000012',
  '{"catalog": "lakehouse", "schema": "retail_curated", "table_name": "pos_transactions", "row_count": 12500000, "format": "delta"}',
  '["curated", "retail", "pii-free"]',
  'active', 'system@demo', NOW(), NOW()),
-
 ('0f300004-0000-4000-8000-000000000004',
  'lakehouse.retail.curated.inventory_levels',
  'Current and historical inventory levels by store, SKU, and date.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.retail.curated.inventory_levels',
- '0000000c-0000-4000-8000-000000000012',
  '{"catalog": "lakehouse", "schema": "retail_curated", "table_name": "inventory_levels", "row_count": 3200000, "format": "delta"}',
  '["curated", "supply-chain"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Tables (Customer)
--- NOTE: A customer360 / customer master Table previously lived here as 0f300005.
--- It was deduplicated into 02500001 ("Customers Master Table") in section 15b
--- since both represented the same business asset. All relationships and
--- ownership rows that pointed at 0f300005 have been rewired to 02500001.
-
--- Tables (Finance)
 ('0f300006-0000-4000-8000-000000000006',
  'lakehouse.finance.curated.invoices',
  'Validated invoice records for financial reporting and compliance.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Table' LIMIT 1), '0f200001-0000-4000-8000-000000000001'), 'Databricks', 'lakehouse.finance.curated.invoices',
- '00000002-0000-4000-8000-000000000002',
  '{"catalog": "lakehouse", "schema": "finance_curated", "table_name": "invoices", "row_count": 2100000, "format": "delta"}',
  '["curated", "finance", "sox-compliant"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Dashboard
 ('0f300007-0000-4000-8000-000000000007',
  'Retail Performance Overview',
  'Executive dashboard showing daily KPIs: revenue, transactions, basket size, conversion.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200004-0000-4000-8000-000000000004'), 'Power BI', 'https://app.powerbi.com/groups/retail-analytics/reports/rpt-001',
- '0000000d-0000-4000-8000-000000000013',
  '{"tool": "Power BI", "workspace": "retail-analytics", "report_id": "rpt-001"}',
  '["executive", "kpi", "retail"]',
  'active', 'system@demo', NOW(), NOW()),
-
 ('0f300008-0000-4000-8000-000000000008',
  'Customer Lifetime Value Overview',
  'Dashboard showing CLV metrics, segmentation, and churn prediction outputs.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Dashboard' LIMIT 1), '0f200004-0000-4000-8000-000000000004'), 'Power BI', 'https://app.powerbi.com/groups/customer-analytics/reports/rpt-002',
- '00000007-0000-4000-8000-000000000007',
  '{"tool": "Power BI", "workspace": "customer-analytics", "report_id": "rpt-002"}',
  '["analytics", "customer", "ml-driven"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- API Endpoint
 ('0f300009-0000-4000-8000-000000000009',
  'POST /v1/customers/search',
  'Customer search API endpoint for internal applications.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'API Endpoint' LIMIT 1), '0f200005-0000-4000-8000-000000000005'), 'Internal API', 'https://api.internal.example.com/v1/customers/search',
- '00000007-0000-4000-8000-000000000007',
  '{"method": "POST", "path": "/v1/customers/search", "auth_scheme": "OAuth2", "version": "v1"}',
  '["api", "customer", "internal"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- File Dataset (mapped to Dataset type since FileDataset not in ontology)
 ('0f30000a-0000-4000-8000-000000000010',
  'Marketing Raw Clickstream Events',
  'Raw clickstream parquet files from web analytics, partitioned by date.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Dataset' LIMIT 1), '0f200006-0000-4000-8000-000000000006'), 'Azure ADLS', 'abfss://raw@datalake.dfs.core.windows.net/marketing/clickstream/',
- '00000004-0000-4000-8000-000000000004',
  '{"storage_path": "abfss://raw@datalake.dfs.core.windows.net/marketing/clickstream/", "format": "parquet", "partition_keys": ["date"]}',
  '["raw", "marketing", "clickstream"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- Stream
 ('0f30000b-0000-4000-8000-000000000011',
  'iot-device-telemetry',
  'Kafka topic receiving real-time IoT device sensor readings.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Stream' LIMIT 1), '0f200008-0000-4000-8000-000000000008'), 'Confluent Kafka', 'kafka://broker.internal:9092/iot-device-telemetry',
- '0000000a-0000-4000-8000-000000000010',
  '{"stream_name": "iot-device-telemetry", "platform": "Confluent Kafka", "partitions": 12, "retention_hours": 168}',
  '["streaming", "iot", "real-time"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- ML Model
 ('0f30000c-0000-4000-8000-000000000012',
  'demand-forecast-v3',
  'XGBoost demand forecasting model registered in Unity Catalog.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'ML Model' LIMIT 1), '0f200007-0000-4000-8000-000000000007'), 'Databricks', 'models:/demand-forecast-v3/Production',
- '0000000d-0000-4000-8000-000000000013',
  '{"model_name": "demand-forecast-v3", "framework": "xgboost", "version": "3", "stage": "Production", "metrics": {"rmse": 12.4, "mape": 0.08}}',
  '["ml", "forecasting", "production"]',
  'active', 'system@demo', NOW(), NOW()),
-
--- NOTE: A legacy/deprecated stub Table (0f30000d "legacy.sales.raw.transactions_v1")
--- previously lived here, only used to demo a "replacedBy" relationship. Removed
--- during dedup — the deprecated/active state demo is already covered by 02500009
--- ("Current Inventory", status='deprecated') in section 15b.
-
--- Column assets for pos_transactions table (0f300003)
 ('0f500001-0000-4000-8000-000000000001',
  'transaction_id', 'Unique transaction identifier',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.curated.pos_transactions.transaction_id',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "STRING", "nullable": false, "is_primary_key": true}',
  '["retail"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f500002-0000-4000-8000-000000000002',
  'store_id', 'Store where the transaction occurred',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.curated.pos_transactions.store_id',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "STRING", "nullable": false}',
  '["retail"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f500003-0000-4000-8000-000000000003',
  'transaction_amount', 'Total transaction amount in local currency',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.curated.pos_transactions.transaction_amount',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "DECIMAL(10,2)", "nullable": false}',
  '["retail", "financial"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f500004-0000-4000-8000-000000000004',
  'transaction_timestamp', 'When the transaction was recorded',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.curated.pos_transactions.transaction_timestamp',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "TIMESTAMP", "nullable": false}',
  '["retail"]', 'active', 'system@demo', NOW(), NOW()),
-
--- Column assets for inventory_levels table (0f300004)
 ('0f500005-0000-4000-8000-000000000005',
  'product_id', 'SKU identifier for the product',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.curated.inventory_levels.product_id',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "STRING", "nullable": false, "is_primary_key": true}',
  '["supply-chain"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f500006-0000-4000-8000-000000000006',
  'warehouse_id', 'Warehouse or distribution center identifier',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.curated.inventory_levels.warehouse_id',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "STRING", "nullable": false}',
  '["supply-chain"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f500007-0000-4000-8000-000000000007',
  'quantity', 'Current inventory quantity on hand',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.curated.inventory_levels.quantity',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "INT", "nullable": false}',
  '["supply-chain"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f500008-0000-4000-8000-000000000008',
  'last_updated', 'Timestamp of last inventory update',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.curated.inventory_levels.last_updated',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "TIMESTAMP", "nullable": true}',
  '["supply-chain"]', 'active', 'system@demo', NOW(), NOW()),
-
--- Column assets for Retail Events Stream table (0250000e)
 ('0f500009-0000-4000-8000-000000000009',
  'event_id', 'Unique event identifier',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.events.retail_events_stream.event_id',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "STRING", "nullable": false, "is_primary_key": true}',
  '["retail", "streaming"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f50000a-0000-4000-8000-000000000010',
  'store_id', 'Originating store for the retail event',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.events.retail_events_stream.store_id',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "STRING", "nullable": false}',
  '["retail", "streaming"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f50000b-0000-4000-8000-000000000011',
  'transaction_amount', 'Event transaction amount',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.events.retail_events_stream.transaction_amount',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "DECIMAL(10,2)", "nullable": false}',
  '["retail", "streaming", "financial"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f50000c-0000-4000-8000-000000000012',
  'event_timestamp', 'When the retail event occurred',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.events.retail_events_stream.event_timestamp',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "TIMESTAMP", "nullable": false}',
  '["retail", "streaming"]', 'active', 'system@demo', NOW(), NOW()),
-
--- Column assets for Sales Metrics MV view (0250000f)
 ('0f50000d-0000-4000-8000-000000000013',
  'total_revenue', 'Aggregated total revenue',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.analytics.sales_metrics_mv.total_revenue',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "DECIMAL(15,2)", "nullable": false}',
  '["retail", "analytics", "kpi"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f50000e-0000-4000-8000-000000000014',
  'avg_order_value', 'Average order value metric',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.analytics.sales_metrics_mv.avg_order_value',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "DECIMAL(10,2)", "nullable": false}',
  '["retail", "analytics", "kpi"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f50000f-0000-4000-8000-000000000015',
  'transaction_count', 'Total number of transactions',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.analytics.sales_metrics_mv.transaction_count',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "BIGINT", "nullable": false}',
  '["retail", "analytics"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f500010-0000-4000-8000-000000000016',
  'period_start', 'Start of the aggregation period',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Column' LIMIT 1), '0f20000a-0000-4000-8000-000000000010'), 'Databricks', 'lakehouse.retail.analytics.sales_metrics_mv.period_start',
- '0000000c-0000-4000-8000-000000000012',
  '{"data_type": "DATE", "nullable": false}',
  '["retail", "analytics"]', 'active', 'system@demo', NOW(), NOW())
-
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -2691,32 +2548,27 @@ ON CONFLICT (id) DO NOTHING;
 -- ============================================================================
 -- BusinessTerm assets for business lineage CUJ.
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('0f700001-0000-4000-8000-000000000001',
  'Customer', 'A party who has purchased or is eligible to purchase goods or services from the company.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Business Term' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"definition": "A party who has purchased or is eligible to purchase goods or services from the company. Includes both B2C end-consumers and B2B accounts.", "synonyms": "Client, Account, Buyer", "examples": "Retail customer with loyalty card, Enterprise account with MSA"}',
  '["customer", "core-entity", "pii"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f700002-0000-4000-8000-000000000002',
  'Customer Lifetime Value', 'Predicted total net profit attributed to the entire future relationship with a customer.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Business Term' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"definition": "Predicted total net profit attributed to the entire future relationship with a customer. Calculated using RFM model and historical purchase data.", "synonyms": "CLV, CLTV, LTV", "examples": "A customer with CLV of $2,500 is a high-value segment target"}',
  '["customer", "analytics", "kpi"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f700003-0000-4000-8000-000000000003',
  'Active Customer', 'A customer who has completed at least one transaction within the last 12 months.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Business Term' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"definition": "A customer who has completed at least one purchase transaction within the trailing 12-month window.", "synonyms": "Current Customer, Engaged Customer", "examples": "Customers in the active segment for marketing campaigns"}',
  '["customer", "segmentation"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f700004-0000-4000-8000-000000000004',
  'Transaction', 'A financial exchange event recording the purchase of goods or services.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Business Term' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '0000000c-0000-4000-8000-000000000012',
  '{"definition": "A financial exchange event recording the purchase of goods or services at a point of sale or online.", "synonyms": "Purchase, Sale, Order", "examples": "POS receipt #12345, Online order #ORD-67890"}',
  '["retail", "financial", "core-entity"]', 'active', 'system@demo', NOW(), NOW())
-
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -2725,62 +2577,47 @@ ON CONFLICT (id) DO NOTHING;
 -- ============================================================================
 -- Logical model entities bridging business terms to physical implementations.
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
--- LogicalEntity: Customer
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('0f800001-0000-4000-8000-000000000001',
  'Customer', 'Logical entity representing a customer in the conceptual data model.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Logical Entity' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"entityDomain": "Customer", "entitySupertype": "Party"}',
  '["customer", "cdm", "logical-model"]', 'active', 'system@demo', NOW(), NOW()),
--- LogicalEntity: Transaction
 ('0f800002-0000-4000-8000-000000000002',
  'Transaction', 'Logical entity representing a sales/purchase transaction.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Logical Entity' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '0000000c-0000-4000-8000-000000000012',
  '{"entityDomain": "Sales", "entitySupertype": "Event"}',
  '["retail", "cdm", "logical-model"]', 'active', 'system@demo', NOW(), NOW()),
-
--- LogicalAttributes for Customer
 ('0f810001-0000-4000-8000-000000000001',
  'Customer.Id', 'Unique business identifier for a customer.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Logical Attribute' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"attributeDataType": "String", "isIdentifier": true, "sensitivityLevel": "internal"}',
  '["customer", "identifier"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f810002-0000-4000-8000-000000000002',
  'Customer.Name', 'Full legal name of the customer.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Logical Attribute' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"attributeDataType": "String", "isIdentifier": false, "sensitivityLevel": "pii"}',
  '["customer", "pii"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f810003-0000-4000-8000-000000000003',
  'Customer.Email', 'Primary email address of the customer.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Logical Attribute' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"attributeDataType": "String", "isIdentifier": false, "sensitivityLevel": "pii"}',
  '["customer", "pii", "contact"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f810004-0000-4000-8000-000000000004',
  'Customer.Phone', 'Primary phone number of the customer.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Logical Attribute' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"attributeDataType": "String", "isIdentifier": false, "sensitivityLevel": "pii"}',
  '["customer", "pii", "contact"]', 'active', 'system@demo', NOW(), NOW()),
-
--- LogicalAttributes for Transaction
 ('0f810005-0000-4000-8000-000000000005',
  'Transaction.Id', 'Unique business identifier for a transaction.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Logical Attribute' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '0000000c-0000-4000-8000-000000000012',
  '{"attributeDataType": "String", "isIdentifier": true, "sensitivityLevel": "internal"}',
  '["retail", "identifier"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f810006-0000-4000-8000-000000000006',
  'Transaction.Amount', 'Monetary value of the transaction.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Logical Attribute' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '0000000c-0000-4000-8000-000000000012',
  '{"attributeDataType": "Decimal", "isIdentifier": false, "sensitivityLevel": "internal"}',
  '["retail", "financial"]', 'active', 'system@demo', NOW(), NOW())
-
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -2789,32 +2626,27 @@ ON CONFLICT (id) DO NOTHING;
 -- ============================================================================
 -- Delivery channels through which data products expose data.
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('0f900001-0000-4000-8000-000000000001',
  'Customer 360 API', 'REST API serving unified customer profile data to downstream applications.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Delivery Channel' LIMIT 1), '00000000-0000-0000-0000-000000000000'), 'Databricks', 'https://api.example.com/v1/customers',
- '00000007-0000-4000-8000-000000000007',
  '{"channelType": "api", "channelUrl": "https://api.example.com/v1/customers", "channelFormat": "json", "refreshFrequency": "real_time"}',
  '["customer", "api", "real-time"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f900002-0000-4000-8000-000000000002',
  'CLV Dashboard', 'Interactive dashboard showing customer lifetime value trends and segmentation.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Delivery Channel' LIMIT 1), '00000000-0000-0000-0000-000000000000'), 'Databricks', 'https://dashboards.example.com/clv',
- '00000007-0000-4000-8000-000000000007',
  '{"channelType": "dashboard", "channelUrl": "https://dashboards.example.com/clv", "channelFormat": "html", "refreshFrequency": "daily"}',
  '["customer", "analytics", "dashboard"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f900003-0000-4000-8000-000000000003',
  'Daily Revenue Report', 'Automated daily revenue summary report delivered to finance stakeholders.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Delivery Channel' LIMIT 1), '00000000-0000-0000-0000-000000000000'), 'Databricks', NULL,
- '0000000c-0000-4000-8000-000000000012',
  '{"channelType": "report", "channelFormat": "pdf", "refreshFrequency": "daily"}',
  '["retail", "finance", "report"]', 'active', 'system@demo', NOW(), NOW()),
 ('0f900004-0000-4000-8000-000000000004',
  'Partner Data Feed', 'Nightly Parquet export of anonymized sales data for partner analytics.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Delivery Channel' LIMIT 1), '00000000-0000-0000-0000-000000000000'), 'Databricks', 's3://partner-data/exports/',
- '0000000c-0000-4000-8000-000000000012',
  '{"channelType": "file_export", "channelFormat": "parquet", "refreshFrequency": "daily"}',
  '["retail", "partner", "export"]', 'active', 'system@demo', NOW(), NOW())
-
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -2824,84 +2656,63 @@ ON CONFLICT (id) DO NOTHING;
 -- Formal, reusable rules for data access, usage, protection, and management.
 -- Previously stored in a dedicated policies table, now modeled as Policy assets.
 
-INSERT INTO assets (id, name, description, asset_type_id, platform, location, domain_id, properties, tags, status, created_by, created_at, updated_at) VALUES
--- Access / Privacy policies
+INSERT INTO assets (id, name, description, asset_type_id, platform, location, properties, tags, status, created_by, created_at, updated_at) VALUES
 ('0f100001-0000-4000-8000-000000000001',
  'Customer PII Protection Policy',
  'Customer personally identifiable information must not be visible in any external-facing output. Only users with the Customer Analytics role may view unmasked email and phone fields.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Policy' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"policyType": "access_privacy", "enforcementLevel": "mandatory", "policyContent": "## Scope\nApplies to all assets and data products in the Customer domain.\n\n## Rules\n1. Columns classified as PII (email, phone, address, SSN) MUST be masked in external dashboards and APIs.\n2. Only users with the **Customer Analytics** group may access unmasked PII columns.\n3. Row-level security must filter customer data to the originating region.\n\n## Enforcement\n- Column masking policies in Unity Catalog.\n- Row-level filters on customer_region.", "version": "v1.0", "regulation": "GDPR, CCPA"}',
  '["access-privacy", "mandatory", "pii", "gdpr"]',
  'active', 'system@demo', NOW() - INTERVAL '90 days', NOW() - INTERVAL '5 days'),
-
 ('0f100002-0000-4000-8000-000000000002',
  'Employee Data Access Policy',
  'Employee HR data is restricted to HR department members and authorized managers.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Policy' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000009-0000-4000-8000-000000000009',
  '{"policyType": "access_privacy", "enforcementLevel": "mandatory", "policyContent": "## Scope\nHuman Resources domain.\n\n## Rules\n1. Salary, SSN, and performance review data are restricted to HR group members.\n2. Managers may view direct-report summaries only.\n3. No bulk export of employee PII without VP-level approval.", "version": "v1.1", "regulation": "SOX, internal HR policy"}',
  '["access-privacy", "mandatory", "hr"]',
  'active', 'system@demo', NOW() - INTERVAL '120 days', NOW() - INTERVAL '10 days'),
-
--- Data Quality policies
 ('0f100003-0000-4000-8000-000000000003',
  'Finance Zero-Null Key Fields Policy',
  'For all Finance domain products, key fields (Invoice.Id, Booking.Amount) must have 0% nulls in production outputs, and data must be refreshed at least once per day.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Policy' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000002-0000-4000-8000-000000000002',
  '{"policyType": "data_quality", "enforcementLevel": "automated", "policyContent": "## Scope\nFinance domain — all production data products.\n\n## Rules\n1. Primary key fields must have null_rate = 0%.\n2. Amount/currency fields must have null_rate = 0%.\n3. Freshness SLA: data must be updated within 24 hours.\n4. Duplicate rate for key fields must be < 0.01%.\n\n## Enforcement\nEncoded as expectations in ODCS contracts. Validated by nightly compliance runs.", "version": "v2.0", "freshness_hours": 24}',
  '["data-quality", "automated", "finance"]',
  'active', 'system@demo', NOW() - INTERVAL '60 days', NOW() - INTERVAL '2 days'),
-
 ('0f100004-0000-4000-8000-000000000004',
  'Retail Transactions Completeness Policy',
  'POS transaction data must be complete — no missing store_id, transaction_id, or amount fields in curated layers.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Policy' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '0000000c-0000-4000-8000-000000000012',
  '{"policyType": "data_quality", "enforcementLevel": "automated", "policyContent": "## Scope\nRetail Operations and Retail Analytics domains.\n\n## Rules\n1. store_id, transaction_id, timestamp, and amount are mandatory.\n2. Null rate for these fields must be 0% in curated/gold layers.\n3. Raw/bronze layers may have up to 0.1% nulls with alerting.\n\n## Enforcement\nGreat Expectations suites attached to pipeline output.", "version": "v1.0"}',
  '["data-quality", "automated", "retail"]',
  'active', 'system@demo', NOW() - INTERVAL '45 days', NOW() - INTERVAL '7 days'),
-
--- Retention / Lifecycle policies
 ('0f100005-0000-4000-8000-000000000005',
  'Marketing Raw Events 90-Day Retention',
  'Raw event data in the Marketing domain must be retained for 90 days, then aggregated and anonymized.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Policy' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000004-0000-4000-8000-000000000004',
  '{"policyType": "retention_lifecycle", "enforcementLevel": "automated", "policyContent": "## Scope\nMarketing domain — raw/bronze event tables.\n\n## Rules\n1. Raw clickstream and campaign event data retained for 90 days.\n2. After 90 days, data must be aggregated to daily granularity and anonymized (remove user identifiers).\n3. Aggregated data retained for 3 years.\n4. Deletion jobs must run weekly.\n\n## Enforcement\nScheduled Databricks job manages TTL and aggregation.", "version": "v1.0", "retention_days": 90}',
  '["retention", "automated", "marketing"]',
  'active', 'system@demo', NOW() - INTERVAL '30 days', NOW() - INTERVAL '3 days'),
-
 ('0f100006-0000-4000-8000-000000000006',
  'IoT Telemetry Data Lifecycle',
  'IoT sensor readings retained at full resolution for 30 days, downsampled to 1-minute averages for 1 year, then purged.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Policy' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '0000000a-0000-4000-8000-000000000010',
  '{"policyType": "retention_lifecycle", "enforcementLevel": "advisory", "policyContent": "## Scope\nIoT domain.\n\n## Rules\n1. Full-resolution telemetry: 30-day retention.\n2. 1-minute downsampled averages: 1-year retention.\n3. Device metadata retained indefinitely.\n4. Alert/anomaly events retained for 2 years.\n\n## Enforcement\nPending automation — currently manual.", "version": "v0.9"}',
  '["retention", "advisory", "iot", "draft"]',
  'draft', 'system@demo', NOW() - INTERVAL '15 days', NOW() - INTERVAL '1 day'),
-
--- Usage / Purpose limitation
 ('0f100007-0000-4000-8000-000000000007',
  'EU Customer Data ML Training Restriction',
  'EU customer data may not be used to train models for targeted advertising without explicit consent.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Policy' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- '00000007-0000-4000-8000-000000000007',
  '{"policyType": "usage_purpose", "enforcementLevel": "mandatory", "policyContent": "## Scope\nCustomer and Marketing domains — datasets labeled as \"training datasets\" or \"ML outputs\".\n\n## Rules\n1. Datasets containing EU customer records (country in EU member states) MUST NOT be fed into advertising ML pipelines.\n2. Exception: explicit opt-in consent flag (consent_marketing_ml = true) is present and validated.\n3. All ML training jobs must log data lineage for audit.\n\n## Enforcement\nPipeline pre-checks validate consent flags before training.", "version": "v1.0", "regulation": "GDPR Art. 22"}',
  '["usage-purpose", "mandatory", "gdpr", "ml"]',
  'active', 'system@demo', NOW() - INTERVAL '75 days', NOW() - INTERVAL '20 days'),
-
--- Custom policy
 ('0f100008-0000-4000-8000-000000000008',
  'Cross-Domain Data Sharing Approval',
  'Any data product shared across domain boundaries requires written approval from both domain owners.',
  COALESCE((SELECT id FROM asset_types WHERE name = 'Policy' LIMIT 1), '00000000-0000-0000-0000-000000000000'), NULL, NULL,
- NULL,
  '{"policyType": "custom", "enforcementLevel": "mandatory", "policyContent": "## Scope\nAll domains.\n\n## Rules\n1. Cross-domain data product subscriptions require approval from the source domain owner AND the consuming domain owner.\n2. Approval must be recorded in the system with justification.\n3. Re-approval required annually or when the data product version changes significantly.\n\n## Enforcement\nWorkflow-based approval in Ontos.", "version": "v1.0"}',
  '["custom", "mandatory", "cross-domain"]',
  'active', 'system@demo', NOW() - INTERVAL '40 days', NOW() - INTERVAL '8 days')
-
 ON CONFLICT (id) DO NOTHING;
 
 
@@ -3119,3 +2930,79 @@ COMMIT;
 -- ============================================================================
 -- End of Demo Data
 -- ============================================================================
+
+
+-- ============================================================================
+-- Domain associations (multi-domain assignment; replaces removed single-value
+-- domain columns on teams/data_contracts/data_products/assets). Type code 031.
+-- ============================================================================
+INSERT INTO entity_domain_associations (id, domain_id, entity_id, entity_type, is_primary, assigned_by, assigned_at) VALUES
+('03100001-0000-4000-8000-000000000001', '00000001-0000-4000-8000-000000000001', '00100001-0000-4000-8000-000000000001', 'team', true, 'system@demo', NOW()),
+('03100002-0000-4000-8000-000000000002', '0000000d-0000-4000-8000-000000000013', '00100002-0000-4000-8000-000000000002', 'team', true, 'system@demo', NOW()),
+('03100003-0000-4000-8000-000000000003', '00000008-0000-4000-8000-000000000008', '00100003-0000-4000-8000-000000000003', 'team', true, 'system@demo', NOW()),
+('03100004-0000-4000-8000-000000000004', '0000000b-0000-4000-8000-000000000011', '00100004-0000-4000-8000-000000000004', 'team', true, 'system@demo', NOW()),
+('03100005-0000-4000-8000-000000000005', '00000007-0000-4000-8000-000000000007', '00400001-0000-4000-8000-000000000001', 'data_contract', true, 'system@demo', NOW()),
+('03100006-0000-4000-8000-000000000006', '00000008-0000-4000-8000-000000000008', '00400002-0000-4000-8000-000000000002', 'data_contract', true, 'system@demo', NOW()),
+('03100007-0000-4000-8000-000000000007', '0000000b-0000-4000-8000-000000000011', '00400003-0000-4000-8000-000000000003', 'data_contract', true, 'system@demo', NOW()),
+('03100008-0000-4000-8000-000000000008', '0000000a-0000-4000-8000-000000000010', '00400004-0000-4000-8000-000000000004', 'data_contract', true, 'system@demo', NOW()),
+('03100009-0000-4000-8000-000000000009', '0000000a-0000-4000-8000-000000000010', '00400005-0000-4000-8000-000000000005', 'data_contract', true, 'system@demo', NOW()),
+('0310000a-0000-4000-8000-000000000010', '00000002-0000-4000-8000-000000000002', '00400006-0000-4000-8000-000000000006', 'data_contract', true, 'system@demo', NOW()),
+('0310000b-0000-4000-8000-000000000011', '00000006-0000-4000-8000-000000000006', '00400007-0000-4000-8000-000000000007', 'data_contract', true, 'system@demo', NOW()),
+('0310000c-0000-4000-8000-000000000012', '0000000c-0000-4000-8000-000000000012', '00700001-0000-4000-8000-000000000001', 'data_product', true, 'system@demo', NOW()),
+('0310000d-0000-4000-8000-000000000013', '0000000d-0000-4000-8000-000000000013', '00700002-0000-4000-8000-000000000002', 'data_product', true, 'system@demo', NOW()),
+('0310000e-0000-4000-8000-000000000014', '0000000d-0000-4000-8000-000000000013', '00700003-0000-4000-8000-000000000003', 'data_product', true, 'system@demo', NOW()),
+('0310000f-0000-4000-8000-000000000015', '00000006-0000-4000-8000-000000000006', '00700004-0000-4000-8000-000000000004', 'data_product', true, 'system@demo', NOW()),
+('03100010-0000-4000-8000-000000000016', '0000000d-0000-4000-8000-000000000013', '00700005-0000-4000-8000-000000000005', 'data_product', true, 'system@demo', NOW()),
+('03100011-0000-4000-8000-000000000017', '00000004-0000-4000-8000-000000000004', '00700006-0000-4000-8000-000000000006', 'data_product', true, 'system@demo', NOW()),
+('03100012-0000-4000-8000-000000000018', '0000000d-0000-4000-8000-000000000013', '00700007-0000-4000-8000-000000000007', 'data_product', true, 'system@demo', NOW()),
+('03100013-0000-4000-8000-000000000019', '00000001-0000-4000-8000-000000000001', '0f300001-0000-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('03100014-0000-4000-8000-000000000020', '00000001-0000-4000-8000-000000000001', '0f300002-0000-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100015-0000-4000-8000-000000000021', '0000000c-0000-4000-8000-000000000012', '0f300003-0000-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100016-0000-4000-8000-000000000022', '0000000c-0000-4000-8000-000000000012', '0f300004-0000-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100017-0000-4000-8000-000000000023', '00000002-0000-4000-8000-000000000002', '0f300006-0000-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('03100018-0000-4000-8000-000000000024', '0000000d-0000-4000-8000-000000000013', '0f300007-0000-4000-8000-000000000007', 'asset', true, 'system@demo', NOW()),
+('03100019-0000-4000-8000-000000000025', '00000007-0000-4000-8000-000000000007', '0f300008-0000-4000-8000-000000000008', 'asset', true, 'system@demo', NOW()),
+('0310001a-0000-4000-8000-000000000026', '00000007-0000-4000-8000-000000000007', '0f300009-0000-4000-8000-000000000009', 'asset', true, 'system@demo', NOW()),
+('0310001b-0000-4000-8000-000000000027', '00000004-0000-4000-8000-000000000004', '0f30000a-0000-4000-8000-000000000010', 'asset', true, 'system@demo', NOW()),
+('0310001c-0000-4000-8000-000000000028', '0000000a-0000-4000-8000-000000000010', '0f30000b-0000-4000-8000-000000000011', 'asset', true, 'system@demo', NOW()),
+('0310001d-0000-4000-8000-000000000029', '0000000d-0000-4000-8000-000000000013', '0f30000c-0000-4000-8000-000000000012', 'asset', true, 'system@demo', NOW()),
+('0310001e-0000-4000-8000-000000000030', '0000000c-0000-4000-8000-000000000012', '0f500001-0000-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('0310001f-0000-4000-8000-000000000031', '0000000c-0000-4000-8000-000000000012', '0f500002-0000-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100020-0000-4000-8000-000000000032', '0000000c-0000-4000-8000-000000000012', '0f500003-0000-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100021-0000-4000-8000-000000000033', '0000000c-0000-4000-8000-000000000012', '0f500004-0000-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100022-0000-4000-8000-000000000034', '0000000c-0000-4000-8000-000000000012', '0f500005-0000-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('03100023-0000-4000-8000-000000000035', '0000000c-0000-4000-8000-000000000012', '0f500006-0000-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('03100024-0000-4000-8000-000000000036', '0000000c-0000-4000-8000-000000000012', '0f500007-0000-4000-8000-000000000007', 'asset', true, 'system@demo', NOW()),
+('03100025-0000-4000-8000-000000000037', '0000000c-0000-4000-8000-000000000012', '0f500008-0000-4000-8000-000000000008', 'asset', true, 'system@demo', NOW()),
+('03100026-0000-4000-8000-000000000038', '0000000c-0000-4000-8000-000000000012', '0f500009-0000-4000-8000-000000000009', 'asset', true, 'system@demo', NOW()),
+('03100027-0000-4000-8000-000000000039', '0000000c-0000-4000-8000-000000000012', '0f50000a-0000-4000-8000-000000000010', 'asset', true, 'system@demo', NOW()),
+('03100028-0000-4000-8000-000000000040', '0000000c-0000-4000-8000-000000000012', '0f50000b-0000-4000-8000-000000000011', 'asset', true, 'system@demo', NOW()),
+('03100029-0000-4000-8000-000000000041', '0000000c-0000-4000-8000-000000000012', '0f50000c-0000-4000-8000-000000000012', 'asset', true, 'system@demo', NOW()),
+('0310002a-0000-4000-8000-000000000042', '0000000c-0000-4000-8000-000000000012', '0f50000d-0000-4000-8000-000000000013', 'asset', true, 'system@demo', NOW()),
+('0310002b-0000-4000-8000-000000000043', '0000000c-0000-4000-8000-000000000012', '0f50000e-0000-4000-8000-000000000014', 'asset', true, 'system@demo', NOW()),
+('0310002c-0000-4000-8000-000000000044', '0000000c-0000-4000-8000-000000000012', '0f50000f-0000-4000-8000-000000000015', 'asset', true, 'system@demo', NOW()),
+('0310002d-0000-4000-8000-000000000045', '0000000c-0000-4000-8000-000000000012', '0f500010-0000-4000-8000-000000000016', 'asset', true, 'system@demo', NOW()),
+('0310002e-0000-4000-8000-000000000046', '00000007-0000-4000-8000-000000000007', '0f700001-0000-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('0310002f-0000-4000-8000-000000000047', '00000007-0000-4000-8000-000000000007', '0f700002-0000-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100030-0000-4000-8000-000000000048', '00000007-0000-4000-8000-000000000007', '0f700003-0000-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100031-0000-4000-8000-000000000049', '0000000c-0000-4000-8000-000000000012', '0f700004-0000-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100032-0000-4000-8000-000000000050', '00000007-0000-4000-8000-000000000007', '0f800001-0000-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('03100033-0000-4000-8000-000000000051', '0000000c-0000-4000-8000-000000000012', '0f800002-0000-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100034-0000-4000-8000-000000000052', '00000007-0000-4000-8000-000000000007', '0f810001-0000-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('03100035-0000-4000-8000-000000000053', '00000007-0000-4000-8000-000000000007', '0f810002-0000-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100036-0000-4000-8000-000000000054', '00000007-0000-4000-8000-000000000007', '0f810003-0000-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100037-0000-4000-8000-000000000055', '00000007-0000-4000-8000-000000000007', '0f810004-0000-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100038-0000-4000-8000-000000000056', '0000000c-0000-4000-8000-000000000012', '0f810005-0000-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('03100039-0000-4000-8000-000000000057', '0000000c-0000-4000-8000-000000000012', '0f810006-0000-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('0310003a-0000-4000-8000-000000000058', '00000007-0000-4000-8000-000000000007', '0f900001-0000-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('0310003b-0000-4000-8000-000000000059', '00000007-0000-4000-8000-000000000007', '0f900002-0000-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('0310003c-0000-4000-8000-000000000060', '0000000c-0000-4000-8000-000000000012', '0f900003-0000-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('0310003d-0000-4000-8000-000000000061', '0000000c-0000-4000-8000-000000000012', '0f900004-0000-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('0310003e-0000-4000-8000-000000000062', '00000007-0000-4000-8000-000000000007', '0f100001-0000-4000-8000-000000000001', 'asset', true, 'system@demo', NOW()),
+('0310003f-0000-4000-8000-000000000063', '00000009-0000-4000-8000-000000000009', '0f100002-0000-4000-8000-000000000002', 'asset', true, 'system@demo', NOW()),
+('03100040-0000-4000-8000-000000000064', '00000002-0000-4000-8000-000000000002', '0f100003-0000-4000-8000-000000000003', 'asset', true, 'system@demo', NOW()),
+('03100041-0000-4000-8000-000000000065', '0000000c-0000-4000-8000-000000000012', '0f100004-0000-4000-8000-000000000004', 'asset', true, 'system@demo', NOW()),
+('03100042-0000-4000-8000-000000000066', '00000004-0000-4000-8000-000000000004', '0f100005-0000-4000-8000-000000000005', 'asset', true, 'system@demo', NOW()),
+('03100043-0000-4000-8000-000000000067', '0000000a-0000-4000-8000-000000000010', '0f100006-0000-4000-8000-000000000006', 'asset', true, 'system@demo', NOW()),
+('03100044-0000-4000-8000-000000000068', '00000007-0000-4000-8000-000000000007', '0f100007-0000-4000-8000-000000000007', 'asset', true, 'system@demo', NOW())
+ON CONFLICT (id) DO NOTHING;

--- a/src/backend/src/routes/settings_routes.py
+++ b/src/backend/src/routes/settings_routes.py
@@ -550,6 +550,7 @@ async def load_demo_data(
                 current_statement = []
 
         executed_count = 0
+        failures: List[Dict[str, str]] = []
         for stmt in statements:
             if stmt.strip():
                 try:
@@ -559,30 +560,58 @@ async def load_demo_data(
                     executed_count += 1
                 except Exception as stmt_error:
                     nested.rollback()
+                    err_short = str(stmt_error).splitlines()[0][:200]
+                    # First token(s) of the statement identify what failed
+                    # (e.g. "INSERT INTO assets") without dumping the payload.
+                    head = " ".join(stmt.split()[:3])
                     logger.warning(
-                        f"Statement execution warning ({sql_file.name}): {stmt_error}"
+                        f"Statement execution FAILED ({sql_file.name}): {err_short} | at: {head}"
                     )
+                    failures.append({"statement": head, "error": err_short})
 
         db.commit()
 
-        success = True
+        # A "success" that silently dropped half the statements is a lie that
+        # hides schema drift (the packs falling out of sync with migrations).
+        # Report the real outcome so callers see partial loads.
+        failed_count = len(failures)
+        success = failed_count == 0
         details["statements_executed"] = executed_count
+        details["statements_failed"] = failed_count
         details["file"] = sql_file.name
+        if failures:
+            details["failures"] = failures[:20]
 
-        logger.info(
-            f"Demo data loaded successfully. Preset='{preset_slug}', "
-            f"file='{sql_file.name}', statements={executed_count}."
-        )
-
-        return {
-            "status": "success",
-            "message": (
+        if success:
+            logger.info(
+                f"Demo data loaded successfully. Preset='{preset_slug}', "
+                f"file='{sql_file.name}', statements={executed_count}."
+            )
+            message = (
                 f"Demo data loaded successfully (preset='{preset_slug}'). "
                 f"Executed {executed_count} SQL statements from {sql_file.name}."
-            ),
+            )
+        else:
+            logger.error(
+                f"Demo data load INCOMPLETE. Preset='{preset_slug}', "
+                f"file='{sql_file.name}': {executed_count} executed, "
+                f"{failed_count} FAILED (schema drift?)."
+            )
+            message = (
+                f"Demo data load incomplete (preset='{preset_slug}'): "
+                f"{executed_count} statements executed, {failed_count} failed "
+                f"from {sql_file.name}. See 'failures' for details — the pack may "
+                f"be out of sync with the current schema."
+            )
+
+        return {
+            "status": "success" if success else "partial",
+            "message": message,
             "preset": preset_slug,
             "file": sql_file.name,
             "statements_executed": executed_count,
+            "statements_failed": failed_count,
+            "failures": failures[:20],
         }
 
     except HTTPException:
@@ -630,184 +659,66 @@ async def clear_demo_data(
     details = {"action": "clear_demo_data"}
     
     try:
-        from sqlalchemy import text
-        
-        # Delete in reverse dependency order
-        # UUID patterns use type codes in first 3 hex chars (see demo_data_retail.sql for mapping)
-        # Pattern: {type:3}{seq:5}-{dataset:4}-4000-8000-...
-        # Dataset segments: 0000=retail, 0001=hls, 0002=fsi, 0003=mfg, 0004=auto.
-        # The LIKE patterns below match by type-code prefix only, so they remove rows
-        # from every preset (the dataset segment is in chars 9-12, not the prefix).
-        delete_statements = [
-            # Suggested quality checks (02e%) - before data_profiling_runs
-            "DELETE FROM suggested_quality_checks WHERE id::text LIKE '02e%'",
-            
-            # Data profiling runs (02d%)
-            "DELETE FROM data_profiling_runs WHERE id::text LIKE '02d%'",
-            
-            # Comments/ratings (02c%)
-            "DELETE FROM comments WHERE id::text LIKE '02c%'",
-            
-            # Workflow steps (02b%, 02e%) - before process_workflows
-            "DELETE FROM workflow_steps WHERE id::text LIKE '02b%'",
-            "DELETE FROM workflow_steps WHERE id::text LIKE '02e%'",
-            
-            # Process workflows (02a%, 02d%)
-            "DELETE FROM process_workflows WHERE id::text LIKE '02a%'",
-            "DELETE FROM process_workflows WHERE id::text LIKE '02d%'",
-            
-            # Entity tag associations (029%) - all entity types, before tags
-            "DELETE FROM entity_tag_associations WHERE id::text LIKE '029%'",
-            
-            # Tag namespace permissions (028%) - before tag_namespaces
-            "DELETE FROM tag_namespace_permissions WHERE id::text LIKE '028%'",
-            
-            # Tags (027%) - before tag_namespaces
-            "DELETE FROM tags WHERE id::text LIKE '027%'",
-            
-            # Tag namespaces (0260%) - note: uses 02601xx pattern to avoid collision with dataset_subscriptions
-            "DELETE FROM tag_namespaces WHERE id::text LIKE '0260%'",
-            
-            # RDF triples (020%, 030%)
-            "DELETE FROM rdf_triples WHERE id::text LIKE '020%'",
-            "DELETE FROM rdf_triples WHERE id::text LIKE '030%'",
-            
-            # Entity subscriptions (022%, 0260%) — migrated from dataset_subscriptions
-            "DELETE FROM entity_subscriptions WHERE id::text LIKE '022%'",
-            "DELETE FROM entity_subscriptions WHERE id::text LIKE '0260%'",
-            
-            # Entity relationships (0215%) — Dataset→Table/View/Contract
-            "DELETE FROM entity_relationships WHERE id::text LIKE '0215%'",
-            # Entity relationships (0f4%) — asset lineage/containment
-            "DELETE FROM entity_relationships WHERE id::text LIKE '0f4%'",
-            # Entity relationships (0fa%) — business lineage
-            "DELETE FROM entity_relationships WHERE id::text LIKE '0fa%'",
-            # Entity relationships (0f6%) — hasColumn
-            "DELETE FROM entity_relationships WHERE id::text LIKE '0f6%'",
-            
-            # Physical assets (025%) — migrated from dataset_instances
-            "DELETE FROM assets WHERE id::text LIKE '025%'",
-            
-            # Dataset assets (021%) — migrated from datasets table
-            "DELETE FROM assets WHERE id::text LIKE '021%'",
-            
-            # Policy assets (0f1%)
-            "DELETE FROM assets WHERE id::text LIKE '0f1%'",
-            # General catalog assets (0f3%) — Tables, Views, Dashboards, Streams,
-            # Patient Cohorts, ICSR cases, etc. (covers all preset packs).
-            "DELETE FROM assets WHERE id::text LIKE '0f3%'",
-            # Column assets (0f5%)
-            "DELETE FROM assets WHERE id::text LIKE '0f5%'",
-            # Business Term assets (0f7%)
-            "DELETE FROM assets WHERE id::text LIKE '0f7%'",
-            # Logical Entity/Attribute assets (0f8%)
-            "DELETE FROM assets WHERE id::text LIKE '0f8%'",
-            # Delivery Channel assets (0f9%)
-            "DELETE FROM assets WHERE id::text LIKE '0f9%'",
-            # Business Owners — must be removed before business_roles because
-            # of the role_id FK. Retail uses the 0f6% prefix; the vertical
-            # packs (hls/fsi/mfg/auto) use 0fb%.
-            "DELETE FROM business_owners WHERE id::text LIKE '0f6%'",
-            "DELETE FROM business_owners WHERE id::text LIKE '0fb%'",
-            # Vertical-specific demo asset types (0f2%, is_system=false)
-            "DELETE FROM asset_types WHERE id::text LIKE '0f2%' AND is_system = false AND created_by = 'system@demo'",
-            # Demo-inserted business_roles and delivery_methods — scoped by
-            # created_by to avoid touching app-seeded reference rows.
-            "DELETE FROM business_roles WHERE id::text LIKE '0f0%' AND created_by = 'system@demo'",
-            "DELETE FROM delivery_methods WHERE id::text LIKE '0f4%' AND created_by = 'system@demo'",
-            # Note: legacy dataset_subscriptions / dataset_custom_properties /
-            # dataset_instances / datasets tables were dropped by migration
-            # c1_drop_legacy_dataset_tables.py — no DELETEs needed.
-            
-            # Data contract servers (srv pattern for server IDs)
-            "DELETE FROM data_contract_servers WHERE id::text LIKE 'srv%'",
-            
-            # Metadata (018=document, 017=link, 016=rich_text)
-            "DELETE FROM document_metadata WHERE id::text LIKE '018%'",
-            "DELETE FROM link_metadata WHERE id::text LIKE '017%'",
-            "DELETE FROM rich_text_metadata WHERE id::text LIKE '016%'",
-            
-            # MDM (01c=match_candidates, 01b=match_runs, 01a=source_links, 019=configs)
-            "DELETE FROM mdm_match_candidates WHERE id::text LIKE '01c%'",
-            "DELETE FROM mdm_match_runs WHERE id::text LIKE '01b%'",
-            "DELETE FROM mdm_source_links WHERE id::text LIKE '01a%'",
-            "DELETE FROM mdm_configs WHERE id::text LIKE '019%'",
-            
-            # Authoritative Definitions (01f=property, 01e=schema_object, 01d=contract)
-            "DELETE FROM data_contract_schema_property_authoritative_definitions WHERE id::text LIKE '01f%'",
-            "DELETE FROM data_contract_schema_object_authoritative_definitions WHERE id::text LIKE '01e%'",
-            "DELETE FROM data_contract_authoritative_definitions WHERE id::text LIKE '01d%'",
-            
-            # Semantic Links (015)
-            "DELETE FROM entity_semantic_links WHERE id::text LIKE '015%'",
-            
-            # Cost Items (014)
-            "DELETE FROM cost_items WHERE id::text LIKE '014%'",
-            
-            # Compliance (013=results, 012=runs, 011=policies)
-            "DELETE FROM compliance_results WHERE id::text LIKE '013%'",
-            "DELETE FROM compliance_runs WHERE id::text LIKE '012%'",
-            "DELETE FROM compliance_policies WHERE id::text LIKE '011%'",
-            
-            # Notifications (010)
-            "DELETE FROM notifications WHERE id::text LIKE '010%'",
-            
-            # Reviews (00f=reviewed_assets, 00e=requests)
-            "DELETE FROM reviewed_assets WHERE id::text LIKE '00f%'",
-            "DELETE FROM data_asset_review_requests WHERE id::text LIKE '00e%'",
-            
-            # Data Products (00d=team_members, 00c=teams, 00b=support, 00a=input, 009=output, 008=desc, 007=products)
-            "DELETE FROM data_product_team_members WHERE id::text LIKE '00d%'",
-            "DELETE FROM data_product_teams WHERE id::text LIKE '00c%'",
-            "DELETE FROM data_product_support_channels WHERE id::text LIKE '00b%'",
-            "DELETE FROM data_product_input_ports WHERE id::text LIKE '00a%'",
-            "DELETE FROM data_product_output_ports WHERE id::text LIKE '009%'",
-            "DELETE FROM data_product_descriptions WHERE id::text LIKE '008%'",
-            "DELETE FROM data_products WHERE id::text LIKE '007%'",
-            
-            # Data Contracts (006=properties, 005=schema_objects, 004=contracts)
-            "DELETE FROM data_contract_schema_properties WHERE id::text LIKE '006%'",
-            "DELETE FROM data_contract_schema_objects WHERE id::text LIKE '005%'",
-            "DELETE FROM data_contracts WHERE id::text LIKE '004%'",
-            
-            # Projects (003)
-            "DELETE FROM project_teams WHERE project_id::text LIKE '003%'",
-            "DELETE FROM projects WHERE id::text LIKE '003%'",
-            
-            # Teams (002=members, 001=teams)
-            "DELETE FROM team_members WHERE id::text LIKE '002%'",
-            "DELETE FROM teams WHERE id::text LIKE '001%'",
-            
-            # Domains (000)
-            "DELETE FROM data_domains WHERE id::text LIKE '000%'",
-        ]
-        
-        # Wrap each statement in a SAVEPOINT so that a single failing
-        # DELETE (e.g. against a table dropped by a later migration) does
-        # not poison the surrounding transaction and silently abort all
-        # subsequent deletes. Accumulate rowcounts per table since several
-        # patterns target the same table (e.g. entity_relationships).
+        from pathlib import Path
+        from sqlalchemy import bindparam, text
+        from src.utils.demo_data_sql import parse_demo_inserts
+
+        # Derive the teardown directly from the demo packs instead of maintaining a
+        # hand-written prefix list. The prefix list silently drifted from the packs
+        # (columns/tables change under migrations, the list did not), so teardown
+        # left orphaned rows behind. Parsing the packs recovers the exact
+        # (table, pk_column, ids) each preset inserts; deleting those precise keys
+        # in reverse insertion order is drift-proof and FK-safe (a referencing row
+        # is always inserted after — thus deleted before — the row it points at),
+        # and can never touch a built-in row that merely shares an id prefix.
+        data_dir = Path(__file__).parent.parent / "data"
+        all_inserts = []
+        for preset_slug in DEMO_DATA_PRESETS:
+            pack = data_dir / f"demo_data_{preset_slug}.sql"
+            if pack.exists():
+                all_inserts.extend(parse_demo_inserts(pack.read_text(encoding="utf-8")))
+
+        # Coalesce every (table, pk_column) into a single DELETE, anchored at its
+        # first reverse-encounter. Coalescing is required for self-referential
+        # tables (e.g. data_domains.parent_id): splitting the hierarchy across
+        # multiple statements can delete a parent before its child under the FK's
+        # NO ACTION check, whereas one multi-row DELETE is validated at
+        # end-of-statement and succeeds.
+        order: List[tuple] = []
+        agg: Dict[tuple, List[str]] = {}
+        for ins in reversed(all_inserts):
+            key = (ins.table, ins.pk_column)
+            if key not in agg:
+                agg[key] = []
+                order.append(key)
+            agg[key].extend(ins.pk_values)
+
+        # Wrap each statement in a SAVEPOINT so that a single failing DELETE (e.g.
+        # against a table dropped by a later migration) does not poison the
+        # surrounding transaction and silently abort all subsequent deletes.
         deleted_counts: Dict[str, int] = {}
         skipped: List[Dict[str, str]] = []
-        for stmt in delete_statements:
-            table_name = stmt.split("FROM ")[1].split(" ")[0]
+        for table_name, pk_column in order:
+            ids = list(dict.fromkeys(agg[(table_name, pk_column)]))  # dedup, keep order
+            stmt = text(
+                f"DELETE FROM {table_name} WHERE {pk_column}::text IN :ids"
+            ).bindparams(bindparam("ids", expanding=True))
             try:
                 with db.begin_nested():
-                    result = db.execute(text(stmt))
+                    result = db.execute(stmt, {"ids": ids})
                 rowcount = result.rowcount or 0
                 if rowcount > 0:
                     deleted_counts[table_name] = deleted_counts.get(table_name, 0) + rowcount
             except Exception as e:
                 err_short = str(e).splitlines()[0][:200]
                 logger.warning(
-                    f"Delete statement FAILED ({table_name}): {err_short} | stmt={stmt}"
+                    f"Delete statement FAILED ({table_name}): {err_short}"
                 )
                 skipped.append({
                     "table": table_name,
-                    "statement": stmt,
                     "error": err_short,
                 })
-        
+
         db.commit()
 
         success = True

--- a/src/backend/src/tests/unit/test_demo_data_sql.py
+++ b/src/backend/src/tests/unit/test_demo_data_sql.py
@@ -1,0 +1,115 @@
+"""Unit tests for the demo-data SQL parser (``src.utils.demo_data_sql``).
+
+The parser recovers ``(table, pk_column, [ids])`` from a demo pack so teardown can
+delete the exact rows a pack inserts (drift-proof, replacing the old hand-written
+prefix list). These tests pin the tricky bits: quotes-with-semicolons, JSON
+payloads with commas, ``COALESCE((SELECT ...))`` in a value, interleaved comments,
+``ON CONFLICT`` tails, and non-``id`` primary keys.
+"""
+import pytest
+
+from src.utils.demo_data_sql import parse_demo_inserts
+
+
+def test_basic_single_row():
+    sql = "INSERT INTO teams (id, name) VALUES ('t1', 'Alpha') ON CONFLICT (id) DO NOTHING;"
+    out = parse_demo_inserts(sql)
+    assert len(out) == 1
+    assert out[0].table == "teams"
+    assert out[0].pk_column == "id"
+    assert out[0].pk_values == ["t1"]
+
+
+def test_multi_row_and_order():
+    sql = (
+        "INSERT INTO data_domains (id, name) VALUES ('d1','A'),('d2','B');\n"
+        "INSERT INTO teams (id, name) VALUES ('t1','X');\n"
+    )
+    out = parse_demo_inserts(sql)
+    assert [d.table for d in out] == ["data_domains", "teams"]
+    assert out[0].pk_values == ["d1", "d2"]
+
+
+def test_semicolon_inside_quoted_string_does_not_terminate():
+    # A description containing ';' must not split the statement (the old regex bug
+    # that silently dropped the entire data_contracts INSERT).
+    sql = (
+        "INSERT INTO data_contracts (id, name, description) VALUES\n"
+        "('c1', 'Telemetry', 'rate varies (10ms-1s); DTC limited; GPS +/-3m'),\n"
+        "('c2', 'Sensors', 'LiDAR 10Hz; camera 30fps')\n"
+        "ON CONFLICT (id) DO NOTHING;"
+    )
+    out = parse_demo_inserts(sql)
+    assert len(out) == 1
+    assert out[0].pk_values == ["c1", "c2"]
+
+
+def test_json_commas_and_coalesce_subquery():
+    sql = (
+        "INSERT INTO assets (id, name, asset_type_id, properties) VALUES\n"
+        "('a1', 'fleet.eu',\n"
+        " COALESCE((SELECT id FROM asset_types WHERE name = 'Fleet' LIMIT 1), 'fallback'),\n"
+        " '{\"region\": \"EU\", \"count\": 120000, \"nested\": {\"a\": 1}}')\n"
+        "ON CONFLICT (id) DO NOTHING;"
+    )
+    out = parse_demo_inserts(sql)
+    assert len(out) == 1
+    assert out[0].table == "assets"
+    assert out[0].pk_values == ["a1"]
+
+
+def test_interleaved_line_comments_in_values():
+    sql = (
+        "INSERT INTO assets (id, name) VALUES\n"
+        "-- Vehicle Fleet (vertical asset type)\n"
+        "('a1', 'one'),\n"
+        "-- ECU Software (vertical asset type)\n"
+        "('a2', 'two')\n"
+        "ON CONFLICT (id) DO NOTHING;"
+    )
+    out = parse_demo_inserts(sql)
+    assert out[0].pk_values == ["a1", "a2"]
+
+
+def test_non_id_primary_key():
+    sql = (
+        "INSERT INTO project_teams (project_id, team_id, assigned_by) VALUES\n"
+        "('p1', 't1', 'system@demo');"
+    )
+    out = parse_demo_inserts(sql)
+    assert out[0].pk_column == "project_id"
+    assert out[0].pk_values == ["p1"]
+
+
+def test_escaped_single_quote_in_value():
+    sql = "INSERT INTO teams (id, name) VALUES ('t1', 'O''Brien Team');"
+    out = parse_demo_inserts(sql)
+    assert out[0].pk_values == ["t1"]
+
+
+def test_on_conflict_paren_list_not_parsed_as_row():
+    # ON CONFLICT (id) has parens; must not be mistaken for a VALUES row.
+    sql = "INSERT INTO teams (id, name) VALUES ('t1','A') ON CONFLICT (id) DO NOTHING;"
+    out = parse_demo_inserts(sql)
+    assert out[0].pk_values == ["t1"]
+
+
+@pytest.mark.parametrize("preset", ["retail", "hls", "fsi", "mfg", "auto"])
+def test_real_packs_parse_cleanly(preset):
+    from pathlib import Path
+    import src.utils.demo_data_sql as mod
+
+    data_dir = Path(mod.__file__).parent.parent / "data"
+    pack = data_dir / f"demo_data_{preset}.sql"
+    if not pack.exists():
+        pytest.skip(f"{pack.name} not present")
+    out = parse_demo_inserts(pack.read_text(encoding="utf-8"))
+    assert out, "expected at least one INSERT parsed"
+    # Every parsed pk value in the real packs is a UUID.
+    for d in out:
+        for v in d.pk_values:
+            assert len(v) == 36 and v.count("-") == 4, (d.table, v)
+    # data_contracts (which carries ';'-laden descriptions) must be captured.
+    tables = {d.table for d in out}
+    assert "data_contracts" in tables
+    assert "entity_domain_associations" in tables  # post-fix association rows

--- a/src/backend/src/utils/demo_data_sql.py
+++ b/src/backend/src/utils/demo_data_sql.py
@@ -1,0 +1,187 @@
+"""Parsing helpers for the self-contained demo-data SQL packs.
+
+The demo packs (``src/data/demo_data_*.sql``) are plain ``INSERT`` scripts. Both
+loading and teardown need to know *what rows a pack inserts* — historically the
+teardown maintained a hand-written list of ``DELETE ... WHERE id LIKE '<prefix>%'``
+statements that silently drifted out of sync with the packs (columns and tables
+change under migrations, the prefix list does not), leaving orphaned rows behind.
+
+Instead we derive teardown from the packs themselves: parse each ``INSERT`` to
+recover ``(table, pk_column, [pk_values])`` in insertion order, then delete those
+exact primary keys in reverse order. Deleting by the precise keys the pack wrote
+is both drift-proof and safer than prefix matching (it can never touch a built-in
+row that merely shares an id prefix).
+
+The parser is a small SQL tokenizer aware of single-quoted strings (with ``''``
+escapes), ``--`` line comments, and ``()``/``[]`` nesting (so ``COALESCE((SELECT
+...))`` and JSON payloads containing commas parse correctly).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class DemoInsert:
+    table: str
+    pk_column: str
+    pk_values: List[str]
+
+
+def _strip_line_comments(s: str) -> str:
+    """Remove ``-- ...`` comments that fall outside single-quoted strings."""
+    out: List[str] = []
+    in_q = False
+    i, n = 0, len(s)
+    while i < n:
+        c = s[i]
+        if in_q:
+            out.append(c)
+            if c == "'":
+                if i + 1 < n and s[i + 1] == "'":
+                    out.append("'")
+                    i += 2
+                    continue
+                in_q = False
+        else:
+            if c == "'":
+                in_q = True
+                out.append(c)
+            elif c == "-" and i + 1 < n and s[i + 1] == "-":
+                j = s.find("\n", i)
+                if j == -1:
+                    break
+                i = j
+                continue
+            else:
+                out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def _first_field(row_inner: str) -> str:
+    """Return the first top-level comma-separated field of a ``(...)`` row body,
+    honoring quotes and nesting."""
+    depth = 0
+    in_q = False
+    i, n = 0, len(row_inner)
+    while i < n:
+        c = row_inner[i]
+        if in_q:
+            if c == "'":
+                if i + 1 < n and row_inner[i + 1] == "'":
+                    i += 2
+                    continue
+                in_q = False
+        else:
+            if c == "'":
+                in_q = True
+            elif c in "([":
+                depth += 1
+            elif c in ")]":
+                depth -= 1
+            elif c == "," and depth == 0:
+                return row_inner[:i].strip()
+        i += 1
+    return row_inner.strip()
+
+
+def _iter_rows(values_region: str):
+    """Yield the inner text of each top-level ``(...)`` group in a VALUES region."""
+    values_region = _strip_line_comments(values_region)
+    depth = 0
+    in_q = False
+    start = None
+    i, n = 0, len(values_region)
+    while i < n:
+        c = values_region[i]
+        if in_q:
+            if c == "'":
+                if i + 1 < n and values_region[i + 1] == "'":
+                    i += 2
+                    continue
+                in_q = False
+        else:
+            if c == "'":
+                in_q = True
+            elif c == "(":
+                if depth == 0:
+                    start = i + 1
+                depth += 1
+            elif c == ")":
+                depth -= 1
+                if depth == 0 and start is not None:
+                    yield values_region[start:i]
+                    start = None
+        i += 1
+
+
+def _unquote(tok: str) -> str:
+    t = tok.strip()
+    if len(t) >= 2 and t[0] == "'" and t[-1] == "'":
+        return t[1:-1].replace("''", "'")
+    return t
+
+
+# Locate each statement head; the VALUES body and terminating ';' are found with
+# a quote/paren-aware scan (NOT regex), because demo rows legitimately contain ';'
+# inside quoted strings (e.g. contract descriptions), which a regex tail would
+# mis-terminate on.
+_HEAD_RE = re.compile(
+    r"INSERT\s+INTO\s+(?P<table>[a-zA-Z_][\w]*)\s*"
+    r"\((?P<cols>[^)]*)\)\s*VALUES",
+    re.I,
+)
+
+
+def _find_statement_end(sql: str, start: int) -> int:
+    """Return the index just past the ';' terminating the statement that begins at
+    ``start``, scanning past ';' that appear inside single-quoted strings."""
+    in_q = False
+    i, n = start, len(sql)
+    while i < n:
+        c = sql[i]
+        if in_q:
+            if c == "'":
+                if i + 1 < n and sql[i + 1] == "'":
+                    i += 2
+                    continue
+                in_q = False
+        else:
+            if c == "'":
+                in_q = True
+            elif c == ";":
+                return i + 1
+        i += 1
+    return n
+
+
+def parse_demo_inserts(sql: str) -> List[DemoInsert]:
+    """Parse a demo-data SQL pack into an ordered list of ``DemoInsert``.
+
+    Order mirrors the physical INSERT order in the file, which the packs keep
+    FK-safe (parents before children); callers deleting for teardown should walk
+    the result in reverse. The primary-key column is taken as the first column of
+    each INSERT's column list (all packs lead with the row's own key, e.g. ``id``,
+    or ``project_id`` for the ``project_teams`` junction).
+    """
+    inserts: List[DemoInsert] = []
+    for m in _HEAD_RE.finditer(sql):
+        cols = [c.strip() for c in m.group("cols").split(",") if c.strip()]
+        if not cols:
+            continue
+        end = _find_statement_end(sql, m.end())
+        values_region = sql[m.end():end]
+        # Trim the trailing "ON CONFLICT (...) ..." clause so its parenthesised
+        # column list is not mistaken for a VALUES row.
+        oc = re.search(r"\bON\s+CONFLICT\b", values_region, re.I)
+        if oc:
+            values_region = values_region[:oc.start()]
+        pk_col = cols[0]
+        pk_values = [_unquote(_first_field(row)) for row in _iter_rows(values_region)]
+        pk_values = [v for v in pk_values if v]
+        if pk_values:
+            inserts.append(DemoInsert(table=m.group("table"), pk_column=pk_col, pk_values=pk_values))
+    return inserts


### PR DESCRIPTION
## Problem

Loading any demo preset reported `"status": "success"` but populated almost nothing in the UI. Root cause: the demo packs (`demo_data_*.sql`) were **stale against the current schema**.

Commit `1688c299` (multi-domain assignment, #520/#597) removed the single-value domain columns — `assets.domain_id`, `data_contracts.domain_id`, `data_products.domain`, `teams.domain_id` — replacing them with the `entity_domain_associations` junction table. The packs still inserted the old columns, so:

- every `assets`/`data_contracts`/`data_products` insert threw `UndefinedColumn`,
- which cascaded FK violations into every dependent child insert (`data_product_teams`, `mdm_*`, `data_contract_*`, `data_profiling_runs`, …).

For retail that was **33 of 66 statements failing silently**. The loader caught each as a warning, counted only successes, and still returned `"success"`. All five vertical presets were broken identically (`migrate` was clean).

## Fixes

**1. Repair the packs (all 5 presets)**
- Strip the removed domain column from the `teams`/`data_contracts`/`data_products`/`assets` inserts.
- Emit `entity_domain_associations` rows (new type code `031`, `is_primary=true`) to preserve each entity's domain link. Products carry a domain *name*, so it's mapped to the domain *id* via the pack's own `data_domains`.
- Refresh the retail type-code legend to reflect post-migration reality (`021`/`025` → `assets`, `022` → `entity_subscriptions`; `023`/`024` retired) and document `031`.

**2. Truthful loader**
- Track failed statements; return `"status": "partial"` with `statements_failed` + a `failures` sample; log at error level. A half-loaded pack no longer masquerades as success.

**3. Drift-proof teardown**
- `clear_demo_data` maintained a hand-written `DELETE ... LIKE '<prefix>%'` list that had itself drifted (never deleted `entity_domain_associations` or `data_contract_quality_checks`). Replaced with a data-driven approach: a new SQL-aware parser (`utils/demo_data_sql.py`) recovers `(table, pk_column, ids)` from each INSERT, and teardown deletes those exact keys in reverse insertion order — FK-safe, and unable to touch built-in rows that merely share an id prefix (so the old `created_by`/`is_system` guards are gone). Same-table deletes are coalesced into one statement so the self-referential `data_domains.parent_id` hierarchy clears under its NO ACTION FK.

The parser handles what a regex can't: `;` inside quoted strings (which had silently truncated the `data_contracts` insert), JSON commas, `COALESCE((SELECT ...))` values, interleaved comments, `ON CONFLICT` tails, and non-`id` PKs (`project_teams`).

## Verification

- Every pack loads under `psql ON_ERROR_STOP=1` with **zero errors** (was 33/66 for retail).
- Row integrity: retail asset rows 11 → 11; total tuples +68, exactly the association rows added.
- Full load + derived-teardown round-trip against Postgres returns the schema to baseline, no FK errors.
- New unit tests `test_demo_data_sql.py` (13 cases incl. all 5 real packs) pass.

Also cleaned up stale "datasets" references (the dropped `datasets`/`dataset_*` tables) in the retail type-code map; no live SQL or app code references the dropped tables.