### PR TITLE
chore(features): clean up feature maturity classification

### DIFF
--- a/docs/decisions/feature-maturity-policy.md
+++ b/docs/decisions/feature-maturity-policy.md
@@ -1,0 +1,70 @@
+# Feature Maturity Policy (GA / Beta / Alpha)
+
+**Date**: 2026-08-31
+**Owner**: Frontend + platform
+**Source of truth**: `src/frontend/src/config/features.ts` (`FeatureMaturity`)
+
+## What maturity means
+
+Every **top-level, sidebar-visible feature** carries a `maturity` value in
+`features.ts`. It gates visibility, not permissions (permissions are a
+separate axis — see below).
+
+| Level | Meaning | Default visibility | Bar to qualify |
+|---|---|---|---|
+| `ga` | Generally available. Stable API + UI, supported, safe for all users. | Always shown | Feature-complete for its scope; has tests (frontend + backend); no known data-loss or auth gaps; docs exist. |
+| `beta` | Usable and maintained, but API/UI may still change; rough edges expected. | Shown by default (**Show Beta** on) | Implemented end-to-end and actively maintained; may lack full test coverage or polish. |
+| `alpha` | Experimental / not officially supported. May be incomplete or change without notice. | **Hidden by default** (**Show Alpha** off) | Behind the alpha toggle deliberately, regardless of code maturity — signals "not committed to yet". |
+
+Visibility is controlled per-user by two toggles in the user menu
+(`feature-visibility-store.ts`): **Show Beta** (default on) and **Show
+Alpha** (default off). GA is always visible. The `β` / `α` badges render in
+the sidebar (`navigation.tsx`) and on the About cards (`about.tsx`).
+
+## Current classification
+
+| Maturity | Features |
+|---|---|
+| **GA** | Marketplace, Search, Data Catalog, Assets, Concepts, Contracts, Products, My Products, My Requests |
+| **Beta** | Compliance, Master Data Management, Asset Reviews |
+| **Alpha** | Security Features, Entitlements, Entitlements Sync, Estate Manager, Catalog Commander |
+
+## Maturity is NOT the permission registry
+
+There are two independent registries — do not conflate them:
+
+- **`src/frontend/src/config/features.ts`** — maturity + sidebar registry.
+  ~17 entries. The sidebar and About page are built **entirely** from this
+  list, so by construction nothing sidebar-visible is missing a maturity.
+- **`src/backend/src/common/features.py`** (`APP_FEATURES`) — the RBAC
+  permission registry. ~50 entries. Many entries here are **not** top-level
+  features and intentionally have no maturity: Settings sub-pages
+  (`settings-*`, `data-domains`, `teams`, `projects`, …), Concepts
+  sub-routes (`term-mapping` → `/concepts/mapping`, ontology generator →
+  `/concepts/generator`), and `cross_cutting: True` capabilities surfaced
+  inline rather than in the sidebar (`schema-importer`, `process-workflows`,
+  `access-grants`, `comments`, `ontology`, `entity_relationships`).
+
+**Rule: a route not present in `features.ts` is a sub-route or cross-cutting
+capability by design — it is not an "unregistered feature" and should not be
+promoted to a top-level maturity-tagged feature just because it has a route.**
+
+Keep the display name for a given feature id aligned between the two
+registries (the role editor falls back to the backend name; the sidebar uses
+the i18n `features.<id>.name`).
+
+## Outstanding: test debt on newly-promoted GA features
+
+**Data Catalog** and **Assets** were promoted beta→GA on 2026-08-31 as
+central, mature, actively-maintained features. Caveat: both still have
+**zero frontend tests** and thin backend tests. They carry the GA label
+ahead of the GA test bar — track adding coverage as follow-up so the label
+and the reality converge. Apply the full test bar before promoting the
+remaining beta features (Compliance, MDM, Asset Reviews).
+
+## How to change a feature's maturity
+
+1. Edit the `maturity` field in `features.ts`.
+2. Confirm the `β`/`α` badge renders as expected (sidebar + About).
+3. If promoting to GA, verify the GA bar (tests, docs, no auth/data gaps).
+4. Keep the name/group consistent with `features.py` for the same id.

--- a/src/backend/src/common/features.py
+++ b/src/backend/src/common/features.py
@@ -76,7 +76,7 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
 
     # --- Build ---
     'data-products': {
-        'name': 'Data Products',
+        'name': 'Products',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS + [FeatureAccessLevel.FILTERED],  # Allow filtering
         'group': GROUP_BUILD,
     },
@@ -204,11 +204,6 @@ APP_FEATURES: Dict[str, Dict[str, str | List[FeatureAccessLevel]]] = {
     },
     'settings-maturity-levels': {
         'name': 'Maturity Levels',
-        'allowed_levels': READ_WRITE_ADMIN_LEVELS,
-        'group': GROUP_SETTINGS,
-    },
-    'settings-maturity-levels': {
-        'name': 'Settings — Maturity Levels',
         'allowed_levels': READ_WRITE_ADMIN_LEVELS,
         'group': GROUP_SETTINGS,
     },

--- a/src/frontend/src/config/features.ts
+++ b/src/frontend/src/config/features.ts
@@ -64,7 +64,7 @@ import {
       description: 'Browse Unity Catalog assets, search columns, and analyze lineage.',
       icon: BookOpen,
       group: 'Discover',
-      maturity: 'beta',
+      maturity: 'ga',
       showInLanding: true,
     },
     // Build - Create and manage data assets
@@ -75,7 +75,7 @@ import {
       description: 'Catalog and manage data and analytics assets with identity, metadata, and relationships.',
       icon: Box,
       group: 'Build',
-      maturity: 'beta',
+      maturity: 'ga',
       showInLanding: true,
     },
     {


### PR DESCRIPTION
## Summary

Takes stock of feature release/beta/alpha status and cleans it up.

- **Promote Data Catalog and Assets from beta → GA** in `features.ts` — both are central, mature, actively-maintained features.
- **Fix a duplicate `settings-maturity-levels` key** in the backend `APP_FEATURES` registry. Python kept the second definition, silently mislabeling the permission as "Settings — Maturity Levels"; removed the dead first entry so it resolves to "Maturity Levels".
- **Align the `data-products` permission name** to the user-facing "Products" (was "Data Products"), matching the sidebar / About / i18n. The role editor falls back to the backend name, so users saw the mismatch there.
- **Add `docs/decisions/feature-maturity-policy.md`** documenting GA/beta/alpha semantics, the two-registry model (frontend `features.ts` maturity vs backend `features.py` RBAC), the rule that unregistered routes are cross-cutting/sub-routes by design, and the outstanding GA test debt on the newly-promoted features.

## Updated classification

| Maturity | Features |
|---|---|
| **GA** | Marketplace, Search, Data Catalog, Assets, Concepts, Contracts, Products, My Products, My Requests |
| **Beta** | Compliance, Master Data Management, Asset Reviews |
| **Alpha** | Security Features, Entitlements, Entitlements Sync, Estate Manager, Catalog Commander |

## Notes

- No test asserted the old maturity of Data Catalog / Assets, so nothing breaks.
- Caveat documented in the policy doc: Data Catalog and Assets carry GA ahead of the GA test bar (zero frontend tests) — tracked as follow-up.

This pull request and its description were written by Isaac.