### PR TITLE
ci(docs): deploy Docusaurus site to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,64 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - development
+    paths:
+      - 'website/ontos/**'
+      - '.github/workflows/deploy-docs.yml'
+  # Allow manual runs from the Actions tab
+  workflow_dispatch:
+
+# Permissions required for the GitHub Pages deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress one
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+defaults:
+  run:
+    working-directory: website/ontos
+
+jobs:
+  build:
+    name: Build Docusaurus site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/ontos/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build website
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/ontos/build
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/ontos/docusaurus.config.ts
+++ b/website/ontos/docusaurus.config.ts
@@ -32,7 +32,10 @@ const config: Config = {
   onBrokenMarkdownLinks: 'throw',
   onDuplicateRoutes: 'throw',
   onBrokenAnchors: 'throw',
-  deploymentBranch: 'ontos-docs',
+  // Deployment is handled by the "Deploy Docs to GitHub Pages" GitHub Actions
+  // workflow (Actions -> Pages artifact), so no deploymentBranch is needed here.
+  // Only set this if you switch back to the classic `docusaurus deploy` command.
+  // deploymentBranch: 'gh-pages',
   trailingSlash: false,
 
   // Even if you don't use internationalization, you can use this field to set


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that builds the Docusaurus docs in `website/ontos` and publishes them to **GitHub Pages** at https://databrickslabs.github.io/ontos/.

- `.github/workflows/deploy-docs.yml` — builds with Node 20 and deploys via the Pages artifact (`upload-pages-artifact` → `deploy-pages`). No `gh-pages` branch.
- Triggers on push to `development` (paths under `website/ontos/**` or the workflow itself) plus manual `workflow_dispatch`.
- Removes the stale `deploymentBranch: 'ontos-docs'` from `docusaurus.config.ts` — that setting only applies to the classic `docusaurus deploy` command and is unused by this Actions-based flow (and pointed at a source branch, which would self-overwrite).

The site config (`url`, `baseUrl: /ontos/`, `organizationName`, `projectName`) was already Pages-ready.

## Required repo setting (one-time, manual)

GitHub Pages must be enabled with **Source = "GitHub Actions"** under Settings → Pages. Pages is currently disabled on the repo. Once set, merges to `development` publish automatically.

## Follow-up

Deploy currently triggers from `development` to bootstrap the freshly established docs site (frequent updates expected). **Once the docs reach a publishable steady state, switch the trigger from `development` to `main`** so published docs track `main`.

## Notes

- Local `npm run build` fails on Node 26 (rspack `importFaster` `ERR_MODULE_NOT_FOUND`); CI pins Node 20, so the deployed build is unaffected.

This pull request and its description were written by Isaac.