### PR TITLE
chore(deps): add Dependabot cooldown and cap TypeScript below 7 for docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,28 +4,48 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/src"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/src/backend"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"
     directory: "/src/e2e"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/src/frontend"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/website/ontos"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
+    # TypeScript 7.x is the native (Go) compiler rewrite; it breaks the JS
+    # compiler API that Docusaurus 3.x and its tooling rely on, and is not
+    # supported yet. Cap bumps below 7 so Dependabot still tracks the
+    # supported 6.x line but never proposes 7.x. Revisit when Docusaurus v4
+    # (which is expected to carry TS 7 support) lands.
+    ignore:
+      - dependency-name: "typescript"
+        versions: [">=7"]


### PR DESCRIPTION
## What

Two changes to `.github/dependabot.yml`:

1. **7-day `cooldown` on all six update entries.** Dependabot keeps proposing versions the Databricks JFrog registry can't serve yet — either the pip mirror hasn't synced the release, or npm curation blocks it under the 7-day immaturity window. This has red-CI'd several dependency PRs (#779 `google-cloud-bigquery`, #777 `mlflow`, #773 `lucide-react`). A 7-day cooldown makes Dependabot wait until the registry can install the version.

2. **Cap `typescript` below 7 for `/website/ontos` only.** TS 7 is the native (Go) compiler rewrite that breaks the JS compiler API Docusaurus 3.x and its tooling depend on; it isn't supported yet (see #747, which bumped to 7.0.2). The docs site has **no CI** to catch the break, so a bad bump merges green silently. The `>=7` cap still lets Dependabot track the supported 6.x line. The main app (`/src/frontend`) is deliberately left free — its required `TypeScript Type Check` job guards it.

## Notes

- The `ignore` is scoped to the `/website/ontos` npm entry, so it does not affect the main app.
- Mitigates but doesn't fully eliminate the registry-lag class of failure; mirror sync can occasionally exceed 7 days.

Closes #790