### PR TITLE
chore(security): allowlist doc-placeholder connection strings in .gitleaksignore

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,16 @@
+# gitleaks allowlist — false-positive fingerprints.
+#
+# Each entry below is a documentation/example placeholder connection string
+# (not a real credential) that the Databricks pre-push secret scanner
+# (gitleaks) re-flags on every new-branch push, forcing SKIP_SECRET_SCAN=1.
+# Fingerprint format: <commit>:<file>:<rule>:<line>
+#
+# Verified 2026-09-10:
+#   - test-engineer.md: sample CI workflow using postgres:postgres@localhost/test_db
+#   - SECRETS_*.md: user:password@host examples inside secrets-handling docs
+#     (incl. a self-labeled "Simulated API response")
+
+114cb4e9effe26fa7b98e8078007148151f8125d:.claude/agents/test-engineer.md:postgres-connection-string:822
+114cb4e9effe26fa7b98e8078007148151f8125d:.claude/agents/test-engineer.md:postgres-connection-string:827
+0b3920d740c434b747bb8a0c58a5d5d99c950ef6:docs/SECRETS_SECURITY_SUMMARY.md:postgres-connection-string:62
+0b3920d740c434b747bb8a0c58a5d5d99c950ef6:docs/SECRETS_MANAGEMENT_SECURITY_ANALYSIS.md:postgres-connection-string:167


### PR DESCRIPTION
## Problem

The Databricks pre-push secret scanner (gitleaks) re-flags four example connection strings on **every new-branch push**, forcing contributors to bypass the check with `SKIP_SECRET_SCAN=1`. That's dangerous as a habit — it trains people to disable secret scanning.

Root cause: on a new branch the scanner scans `merge-base(main, branch)..branch`; since branches fork off `development` (which diverged from `main` long ago), that range is huge, so it falls back to scanning all commits authored by the pusher — repeatedly re-hitting old commits that contain example strings.

## Verification

All four flagged strings were inspected and confirmed to be **documentation/example placeholders, not real credentials**:

| File:line | Value | Context |
|---|---|---|
| `.claude/agents/test-engineer.md:822,827` | `postgres:postgres@localhost:5432/test_db` | sample GitHub Actions workflow |
| `docs/SECRETS_SECURITY_SUMMARY.md:62` | `user:password@host:5432/db` | code-comment example |
| `docs/SECRETS_MANAGEMENT_SECURITY_ANALYSIS.md:167` | `user:password@host:5432/db` | self-labeled "Simulated API response" |

## Fix

gitleaks auto-loads `.gitleaksignore` from the repo root, so committing these fingerprints suppresses the false positives for the whole team. Confirmed: this branch pushed cleanly **without** `SKIP_SECRET_SCAN`.

Scoped narrowly to these four fingerprints — any *new* secret still blocks the push.