### PR TITLE
fix(access): cap approve/reject dialogs to viewport with internal scroll

### DIFF
--- a/src/frontend/src/components/access/handle-access-grant-dialog.tsx
+++ b/src/frontend/src/components/access/handle-access-grant-dialog.tsx
@@ -157,8 +157,8 @@ export default function HandleAccessGrantDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[560px]">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[560px] flex flex-col max-h-[85vh] overflow-hidden">
+        <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center gap-2">
             <Shield className="h-5 w-5 text-primary" />
             Handle Access Request
@@ -168,7 +168,7 @@ export default function HandleAccessGrantDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
+        <div className="space-y-4 flex-1 overflow-y-auto px-1 -mx-1">
           {/* Request Details */}
           <div className="p-4 bg-muted/50 rounded-lg border space-y-3">
             <div className="flex items-center gap-2">
@@ -287,7 +287,7 @@ export default function HandleAccessGrantDialog({
           </div>
         </div>
 
-        <DialogFooter className="gap-2 sm:gap-2 flex-col sm:flex-row">
+        <DialogFooter className="gap-2 sm:gap-2 flex-col sm:flex-row shrink-0">
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}

--- a/src/frontend/src/components/workflows/workflow-approval-response-dialog.tsx
+++ b/src/frontend/src/components/workflows/workflow-approval-response-dialog.tsx
@@ -319,17 +319,18 @@ export default function WorkflowApprovalResponseDialog({
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-md flex flex-col max-h-[85vh] overflow-hidden">
+        <DialogHeader className="shrink-0">
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         {loadingConfig ? (
-          <div className="flex items-center justify-center py-8">
+          <div className="flex flex-1 items-center justify-center py-8">
             <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
           </div>
         ) : (
           <>
+            <div className="flex-1 overflow-y-auto space-y-4 px-1 -mx-1">
             {detailRows.length > 0 && (
               <div className="rounded-md border bg-muted/30 p-3 space-y-1.5">
                 <div className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
@@ -397,7 +398,8 @@ export default function WorkflowApprovalResponseDialog({
                 disabled={submitting}
               />
             </div>
-            <DialogFooter className="gap-2 sm:gap-0">
+            </div>
+            <DialogFooter className="gap-2 sm:gap-0 shrink-0">
               <Button
                 variant="destructive"
                 disabled={submitting}


### PR DESCRIPTION
Fixes #687

## Summary

The notification-launched Approve/Reject access dialogs had no height cap and no internal scroll, so with tall content the dialog grew past the viewport and the Approve/Deny (Reject) buttons fell off-screen (only reachable by zooming the browser out). This caps each dialog to the viewport, scrolls the body internally, and pins the header + action footer so the buttons stay reachable at 100% zoom for any content height.

## Before / After (UI)

Same access-request dialog, same content, at a short viewport (~620px tall).

**Before (`development`)** — the dialog overflows the viewport: the header is clipped at the top and the **Deny / Approve buttons fall off-screen** with no way to scroll to them (workaround was zooming the browser out).

![Before: approve/deny buttons off-screen](https://raw.githubusercontent.com/surojitchowdhury/ontos/pr-assets/dialog-687/docs/pr-assets/687/before.png)

**After (this PR)** — the dialog caps to the viewport: the header + action footer are pinned and the body scrolls internally, so **Deny / Approve stay reachable** at 100% zoom.

![After: buttons pinned, body scrolls](https://raw.githubusercontent.com/surojitchowdhury/ontos/pr-assets/dialog-687/docs/pr-assets/687/after.png)

## Change (targeted per-dialog — shared `ui/dialog.tsx` untouched)

Both `handle-access-grant-dialog.tsx` and `workflow-approval-response-dialog.tsx`:
- `DialogContent`: add `flex flex-col max-h-[85vh] overflow-hidden` (flex column capped to 85% of viewport height; `flex` overrides the base `grid` via tailwind-merge, base `gap-4` still applies).
- Header: `shrink-0` (stays pinned).
- Body: `flex-1 overflow-y-auto` so only the middle scrolls; `px-1 -mx-1` for focus-ring breathing room. In the workflow dialog a scroll wrapper was added around the content so the footer remains a non-scrolling sibling.
- `DialogFooter`: `shrink-0` (pinned, always visible).

### Scope decision
Fixed per-dialog rather than in the shared `DialogContent`, whose base is used by every dialog in the app — a central max-h/overflow/flex change would have broad blast radius. The two affected dialogs already have header/body/footer structure, so a ~10-line scoped change fully resolves #687 without risking other dialogs.

## Gates
- `yarn type-check` (tsc --noEmit): pass.
- `yarn build`: success (pre-existing chunk-size warning only).
- eslint: no new problems (the two files' existing warnings are pre-existing, identical on untouched HEAD).




---

> Re-raised from a branch on this repository (previously #726, opened from a fork) so the required CI workflows can run — fork PRs do not receive the internal JFrog OIDC token, which failed every check at setup before any test ran. Same commits and diff; #726 is closed in favour of this PR.
