### PR TITLE
ci(docs): pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -31,10 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: website/ontos/build
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## What

The `Deploy Docs to GitHub Pages` workflow failed on its first run: `databrickslabs/ontos` enforces that all GitHub Actions be pinned to a full-length commit SHA, and the `@v4`/`@v3` tag refs were rejected ([failed run](https://github.com/databrickslabs/ontos/actions/runs/34582482690)).

This pins all four actions to their release commit SHAs, matching the convention already used in `test-coverage.yml` and `pr-title-lint.yml` (`<sha> # vX.Y.Z`):

- `actions/checkout` → `11d5960a326750d5838078e36cf38b85af677262` (v4.4.0)
- `actions/setup-node` → `49933ea5288caeca8642d1e84afbd3f7d6820020` (v4.4.0)
- `actions/upload-pages-artifact` → `56afc609e74202658d3ffba0e8f6dda462b719fa` (v3.0.1)
- `actions/deploy-pages` → `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` (v4.0.5)

## After merge

The push to `development` re-triggers the workflow (or run it manually via `workflow_dispatch`), which should now build and publish to https://databrickslabs.github.io/ontos/.

This pull request and its description were written by Isaac.