### PR TITLE
ci(docs): bump pages actions to v5 (SHA-pinned deps)

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: website/ontos/build
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1


### PR DESCRIPTION
## What

Second follow-up to the Pages deploy. After pinning the top-level actions to SHAs, the build still failed:

> The action `actions/upload-artifact@v4` is not allowed in databrickslabs/ontos because all actions must be pinned to a full-length commit SHA.

That's a **transitive** ref: `upload-pages-artifact@v3.0.1` internally calls `actions/upload-artifact@v4` via an unpinned tag, which the policy rejects even though our top-level pin was a SHA.

Fix — bump both Pages actions to v5, which pin their internal deps to SHAs:

- `actions/upload-pages-artifact` → `fc324d3547104276b827a68afc52ff2a11cc49c9` (v5.0.0) — internal `upload-artifact` is SHA-pinned to v7.0.0
- `actions/deploy-pages` → `368f82528645a54fb793d4d04e342629a3f51346` (v5.0.1) — matching artifact backend, no internal `uses:`

## After merge

Push to `development` re-triggers the workflow (or run `workflow_dispatch`), which should now build and publish to https://databrickslabs.github.io/ontos/.

This pull request and its description were written by Isaac.